### PR TITLE
fix: remove unused eager imports from filters __init__.py

### DIFF
--- a/openfilter/filter_runtime/filters/__init__.py
+++ b/openfilter/filter_runtime/filters/__init__.py
@@ -1,5 +1,1 @@
-from .image_in import ImageIn, ImageInConfig
-from .image_out import ImageOut, ImageOutConfig
-from .video_out import VideoOut, VideoOutConfig
 
-__all__ = ['ImageIn', 'ImageInConfig', 'ImageOut', 'ImageOutConfig', 'VideoOut', 'VideoOutConfig']

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,0 +1,49 @@
+"""Verify that importing the filters package does not eagerly load optional dependencies."""
+
+import importlib
+import sys
+import unittest
+
+
+class TestFiltersPackageImport(unittest.TestCase):
+    """The filters __init__.py must be empty — no eager imports of submodules."""
+
+    def test_import_does_not_load_video_out(self):
+        """Importing the filters package must NOT trigger video_out (which needs av)."""
+        # Clear cached modules
+        mods_to_remove = [k for k in sys.modules if k.startswith('openfilter.filter_runtime.filters')]
+        saved = {k: sys.modules.pop(k) for k in mods_to_remove}
+
+        # Block av to simulate video-in container (no av installed)
+        import builtins
+        _real_import = builtins.__import__
+
+        def _mock_import(name, *args, **kwargs):
+            if name == 'av':
+                raise ImportError("Mocked: av is not installed")
+            return _real_import(name, *args, **kwargs)
+
+        builtins.__import__ = _mock_import
+        try:
+            # This must NOT crash — __init__.py should be empty
+            mod = importlib.import_module('openfilter.filter_runtime.filters')
+            # No re-exports expected
+            self.assertFalse(hasattr(mod, 'VideoOut'), "VideoOut should not be eagerly imported")
+            self.assertFalse(hasattr(mod, 'ImageOut'), "ImageOut should not be eagerly imported")
+            self.assertFalse(hasattr(mod, 'ImageIn'), "ImageIn should not be eagerly imported")
+        finally:
+            builtins.__import__ = _real_import
+            # Restore
+            for k in list(sys.modules):
+                if k.startswith('openfilter.filter_runtime.filters'):
+                    sys.modules.pop(k, None)
+            sys.modules.update(saved)
+
+    def test_submodule_direct_import_still_works(self):
+        """Direct submodule imports must still work."""
+        from openfilter.filter_runtime.filters.image_in import ImageIn
+        self.assertIsNotNone(ImageIn)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Empties `filters/__init__.py` — removes all eager imports of filter classes. No code imports from the package level; every consumer imports directly from submodules.

## Problem

PR #66 replaced vidgear with PyAV in VideoOut (`import av` at module level). Since `__init__.py` eagerly imported all filters, every container that doesn't have `av` installed crashed on startup:

```
File "openfilter/filter_runtime/filters/__init__.py", line 3
    from .video_out import VideoOut, VideoOutConfig
File "openfilter/filter_runtime/filters/video_out.py", line 8
    import av
ModuleNotFoundError: No module named 'av'
```

Affected: video-in, image-in, image-out, and all other non-video-out containers running openfilter >= 0.1.25.

## Why the eager imports existed

Added in the initial release (commit `5618b29`) as a convenience so consumers could write:
```python
from openfilter.filter_runtime.filters import VideoOut
```

But no code anywhere uses this pattern. Every consumer imports directly from submodules:
```python
from openfilter.filter_runtime.filters.video_out import VideoOut
```

Verified by searching all repos (openfilter, filter-*, CLI). Zero matches for package-level imports.

## Fix

Empty `__init__.py`. This:
1. Fixes the crash — nothing to eagerly import
2. Doesn't break any existing code — no consumers use package-level imports
3. Avoids silent `try/except ImportError` that could mask real bugs
4. Follows the principle: each Docker image installs only the extras it needs via `pyproject.toml` (`[video_in]`, `[video_out]`, etc.)

Per review feedback from @lucasmundim — simpler than the original `try/except` approach.

## Tests

- `test_import_does_not_load_video_out` — importing `filters` with `av` mocked as missing does NOT crash
- `test_submodule_direct_import_still_works` — direct `from filters.image_in import ImageIn` works

## Test plan

- [x] New tests pass (2/2)
- [x] Existing filter tests pass
- [ ] Docker images start without crashing

Co-authored-by: Lucas Mundim <lmundim@plainsight.ai>