### PR TITLE
feat(tests): add IPC/serialization overhead benchmarking harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,11 @@ build-wheel:  ## Build python wheel
 
 .PHONY: test
 test:  ## Run basic unit tests
-	pytest -v --cov=tests -s tests
+	pytest -v --cov=tests -s tests --benchmark-disable
+
+.PHONY: bench
+bench:  ## Run performance benchmarks
+	pytest tests/test_benchmarks.py -v --benchmark-group-by=group -s --benchmark-max-time=0.5
 
 .PHONY: test-all
 test-all:  ## Run all unit tests

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build-wheel:  ## Build python wheel
 
 .PHONY: test
 test:  ## Run basic unit tests
-	pytest -v --cov=tests -s tests --benchmark-disable
+	pytest -v --cov=tests -s tests --benchmark-disable -m "not slow"
 
 .PHONY: bench
 bench:  ## Run performance benchmarks
@@ -34,7 +34,7 @@ test-all:  ## Run all unit tests
 .PHONY: test-coverage
 test-coverage:  ## Run unit tests and generate coverage report
 	@mkdir -p Reports
-	@pytest -v --cov=tests --junitxml=Reports/coverage.xml --cov-report=json:Reports/coverage.json
+	@pytest -v --cov=tests --junitxml=Reports/coverage.xml --cov-report=json:Reports/coverage.json --benchmark-disable -m "not slow"
 	@jq -r '["File Name", "Statements", "Missing", "Coverage%"], (.files | to_entries[] | [.key, .value.summary.num_statements, .value.summary.missing_lines, .value.summary.percent_covered_display]) | @csv'  Reports/coverage.json >  Reports/coverage_report.csv
 	@jq -r '["TOTAL", (.totals.num_statements // 0), (.totals.missing_lines // 0), (.totals.percent_covered_display // "0")] | @csv'  Reports/coverage.json >>  Reports/coverage_report.csv
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ all = [
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    "pytest-benchmark>=5.1.0",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
   "pytest~=9.0.2",
   "jq~=1.11.0",
   "pytest-cov~=7.0.0",
+  "pytest-benchmark>=5.1.0",
 ]
 
 mqtt_out = [
@@ -123,4 +124,5 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-pythonpath = "src"
+pythonpath = ["src", "tests"]
+markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,41 @@
+"""Shared test helpers and fixtures."""
+
+from queue import Queue, Empty
+from threading import Thread, Event
+
+from openfilter.filter_runtime import Frame
+from openfilter.filter_runtime.mq import MQSender
+
+
+class ThreadMQSender(Thread):
+    """Threaded MQ sender for tests — ZMQ sender blocks until a subscriber
+    issues a request, so it must run in its own thread."""
+
+    def __init__(self, *args, **kwargs):
+        self.stop_evt = Event()
+        self.queue = Queue()
+        super().__init__(target=self._run, args=(args, kwargs), daemon=True)
+        self.start()
+
+    def destroy(self):
+        self.queue.put(False)
+        self.stop_evt.set()
+        self.join(timeout=5)
+
+    def send(self, frames: dict[str, Frame] | None = None):
+        self.queue.put(frames)
+
+    def _run(self, args, kwargs):
+        sender = MQSender(*args, **kwargs)
+        frames = False
+        while not self.stop_evt.is_set():
+            if frames is False:
+                try:
+                    frames = self.queue.get(timeout=0.01)
+                except Empty:
+                    continue
+                if frames is False:
+                    break
+            if sender.send(frames, 10):
+                frames = False
+        sender.destroy()

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -421,23 +421,26 @@ class TestZmqIpcBenchmarks:
         )
         receiver = MQReceiver(addr, f"{mq_id}-recv")
 
-        # Warm up
-        for _ in range(2):
-            sender.send(frames)
-            result = receiver.recv(timeout=5000)
-            if result is None:
-                pytest.fail("receiver.recv() timed out during warm-up")
+        try:
+            # Warm up
+            for _ in range(2):
+                sender.send(frames)
+                result = receiver.recv(timeout=5000)
+                if result is None:
+                    pytest.fail("receiver.recv() timed out during warm-up")
 
-        t0 = time.perf_counter()
-        for _ in range(n):
-            sender.send(frames)
-            result = receiver.recv(timeout=5000)
-            if result is None:
-                pytest.fail("receiver.recv() timed out during measurement")
-        elapsed = time.perf_counter() - t0
+            t0 = time.perf_counter()
+            for _ in range(n):
+                sender.send(frames)
+                result = receiver.recv(timeout=5000)
+                if result is None:
+                    pytest.fail("receiver.recv() timed out during measurement")
+            elapsed = time.perf_counter() - t0
+        finally:
+            # Cleanup: destroy sender before receiver to avoid ZMQ PUSH blocking
+            sender.destroy()
+            receiver.destroy()
 
-        sender.destroy()
-        receiver.destroy()
         return (elapsed / n) * 1000
 
     @pytest.mark.slow

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -424,16 +424,20 @@ class TestZmqIpcBenchmarks:
         # Warm up
         for _ in range(2):
             sender.send(frames)
-            receiver.recv()
+            result = receiver.recv(timeout=5000)
+            if result is None:
+                pytest.fail("receiver.recv() timed out during warm-up")
 
         t0 = time.perf_counter()
         for _ in range(n):
             sender.send(frames)
-            receiver.recv()
+            result = receiver.recv(timeout=5000)
+            if result is None:
+                pytest.fail("receiver.recv() timed out during measurement")
         elapsed = time.perf_counter() - t0
 
-        receiver.destroy()
         sender.destroy()
+        receiver.destroy()
         return (elapsed / n) * 1000
 
     @pytest.mark.slow
@@ -498,73 +502,82 @@ class TestPipelineSimulation:
             n_frames: number of frames to push through.
             label: human-readable pipeline name.
         """
-        logging.getLogger().setLevel(logging.CRITICAL)
+        logger = logging.getLogger("openfilter")
+        original_level = logger.level
+        logger.setLevel(logging.CRITICAL)
 
-        # Build the ZMQ chain: stage[i] sender → stage[i+1] receiver
-        n_hops = len(stages) - 1
         senders = []
         receivers = []
+        try:
+            # Build the ZMQ chain: stage[i] sender → stage[i+1] receiver
+            n_hops = len(stages) - 1
 
-        for i in range(n_hops):
-            _, _, _, jpg = stages[i]
-            addr = f"ipc:///tmp/bench-pipe-{label}-{i}-{id(stages)}"
-            senders.append(
-                ThreadMQSender(addr, f"p{i}s", outs_jpg=jpg, outs_metrics=False)
-            )
-            receivers.append(MQReceiver(addr, f"p{i}r"))
+            for i in range(n_hops):
+                _, _, _, jpg = stages[i]
+                addr = f"ipc:///tmp/bench-pipe-{label}-{i}-{id(stages)}"
+                senders.append(
+                    ThreadMQSender(addr, f"p{i}s", outs_jpg=jpg, outs_metrics=False)
+                )
+                receivers.append(MQReceiver(addr, f"p{i}r"))
 
-        # Build source frame
-        src_name, src_process_ms, src_res, src_jpg = stages[0]
-        if src_res:
-            source_frame = _rgb_frame(*src_res)
-        else:
-            source_frame = Frame({"source": True})
+            # Build source frame
+            src_name, src_process_ms, src_res, src_jpg = stages[0]
+            if src_res:
+                source_frame = _rgb_frame(*src_res)
+            else:
+                source_frame = Frame({"source": True})
 
-        # Warm up
-        if senders:
-            for _ in range(2):
-                senders[0].send({"main": source_frame.ro})
-                f = receivers[0].recv()
-                for j in range(1, n_hops):
-                    senders[j].send(f)
-                    f = receivers[j].recv()
+            # Warm up
+            if senders:
+                for _ in range(2):
+                    senders[0].send({"main": source_frame.ro})
+                    f = receivers[0].recv(timeout=5000)
+                    if f is None:
+                        pytest.fail(f"Pipeline {label}: recv timed out during warm-up at hop 0")
+                    for j in range(1, n_hops):
+                        senders[j].send(f)
+                        f = receivers[j].recv(timeout=5000)
+                        if f is None:
+                            pytest.fail(f"Pipeline {label}: recv timed out during warm-up at hop {j}")
 
-        # Measure
-        per_stage_process = [0.0] * len(stages)
-        total_elapsed = 0.0
+            # Measure
+            per_stage_process = [0.0] * len(stages)
+            total_elapsed = 0.0
 
-        for _ in range(n_frames):
-            t0 = time.perf_counter()
+            for _ in range(n_frames):
+                t0 = time.perf_counter()
 
-            # Source stage: simulate VideoIn read + optional resample
-            if src_process_ms > 0:
-                tp = time.perf_counter()
-                time.sleep(src_process_ms / 1000)
-                per_stage_process[0] += time.perf_counter() - tp
-
-            # Send source frame into pipeline
-            current_frames = {"main": source_frame.ro}
-
-            for hop in range(n_hops):
-                # Send to next filter
-                senders[hop].send(current_frames)
-                current_frames = receivers[hop].recv()
-
-                # Simulate filter process()
-                _, proc_ms, _, _ = stages[hop + 1]
-                if proc_ms > 0:
+                # Source stage: simulate VideoIn read + optional resample
+                if src_process_ms > 0:
                     tp = time.perf_counter()
-                    time.sleep(proc_ms / 1000)
-                    per_stage_process[hop + 1] += time.perf_counter() - tp
+                    time.sleep(src_process_ms / 1000)
+                    per_stage_process[0] += time.perf_counter() - tp
 
-            total_elapsed += time.perf_counter() - t0
+                # Send source frame into pipeline
+                current_frames = {"main": source_frame.ro}
 
-        # Cleanup
-        for r in receivers:
-            r.destroy()
-        for s in senders:
-            s.destroy()
-        logging.getLogger().setLevel(logging.WARNING)
+                for hop in range(n_hops):
+                    # Send to next filter
+                    senders[hop].send(current_frames)
+                    current_frames = receivers[hop].recv(timeout=5000)
+                    if current_frames is None:
+                        pytest.fail(f"Pipeline {label}: recv timed out at hop {hop}")
+
+                    # Simulate filter process()
+                    _, proc_ms, _, _ = stages[hop + 1]
+                    if proc_ms > 0:
+                        tp = time.perf_counter()
+                        time.sleep(proc_ms / 1000)
+                        per_stage_process[hop + 1] += time.perf_counter() - tp
+
+                total_elapsed += time.perf_counter() - t0
+        finally:
+            # Cleanup: destroy senders first to avoid ZMQ PUSH blocking on missing PULL peer
+            for s in senders:
+                s.destroy()
+            for r in receivers:
+                r.destroy()
+            logger.setLevel(original_level)
 
         avg_total_ms = (total_elapsed / n_frames) * 1000
         avg_process_ms = sum(per_stage_process) / n_frames * 1000

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -11,54 +11,19 @@ Skip benchmarks during normal test runs:
     pytest tests/ --benchmark-disable
 """
 
+import functools
 import json
 import logging
 import time
-from queue import Queue, Empty
-from threading import Thread, Event
+import warnings
 
 import cv2
 import numpy as np
 import pytest
 
+from helpers import ThreadMQSender
 from openfilter.filter_runtime import Filter, Frame
-from openfilter.filter_runtime.mq import MQ, MQSender, MQReceiver
-
-# ---------------------------------------------------------------------------
-# Threaded MQ helpers (from test_mq.py pattern) — needed because ZMQ sender
-# blocks until a subscriber issues a request.
-# ---------------------------------------------------------------------------
-
-
-class ThreadMQSender(Thread):
-    def __init__(self, *args, **kwargs):
-        self.stop_evt = Event()
-        self.queue = Queue()
-        super().__init__(target=self._run, args=(args, kwargs), daemon=True)
-        self.start()
-
-    def destroy(self):
-        self.queue.put(False)
-        self.stop_evt.set()
-        self.join(timeout=5)
-
-    def send(self, frames):
-        self.queue.put(frames)
-
-    def _run(self, args, kwargs):
-        sender = MQSender(*args, **kwargs)
-        frames = False
-        while not self.stop_evt.is_set():
-            if frames is False:
-                try:
-                    frames = self.queue.get(timeout=0.01)
-                except Empty:
-                    continue
-                if frames is False:
-                    break
-            if sender.send(frames, 10):
-                frames = False
-        sender.destroy()
+from openfilter.filter_runtime.mq import MQ, MQReceiver
 
 
 # ---------------------------------------------------------------------------
@@ -100,12 +65,29 @@ def _frame_with_meta(h, w):
     )
 
 
-FRAME_480P = _rgb_frame(480, 640)
-FRAME_720P = _rgb_frame(720, 1280)
-FRAME_1080P = _rgb_frame(1080, 1920)
-FRAME_4K = _rgb_frame(2160, 3840)
-FRAME_DATA_ONLY = Frame({"detections": [{"class": "car", "score": 0.9}] * 20})
-FRAME_WITH_META = _frame_with_meta(480, 640)
+@functools.cache
+def FRAME_480P():
+    return _rgb_frame(480, 640)
+
+@functools.cache
+def FRAME_720P():
+    return _rgb_frame(720, 1280)
+
+@functools.cache
+def FRAME_1080P():
+    return _rgb_frame(1080, 1920)
+
+@functools.cache
+def FRAME_4K():
+    return _rgb_frame(2160, 3840)
+
+@functools.cache
+def FRAME_DATA_ONLY():
+    return Frame({"detections": [{"class": "car", "score": 0.9}] * 20})
+
+@functools.cache
+def FRAME_WITH_META():
+    return _frame_with_meta(480, 640)
 
 
 # ---------------------------------------------------------------------------
@@ -119,52 +101,52 @@ class TestFrameSerdeBenchmarks:
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_serialize_480p_raw(self, benchmark):
-        frames = {"main": FRAME_480P}
+        frames = {"main": FRAME_480P()}
         benchmark(MQ.frames2topicmsgs, frames, False)
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_serialize_480p_jpg(self, benchmark):
-        frames = {"main": FRAME_480P}
+        frames = {"main": FRAME_480P()}
         benchmark(MQ.frames2topicmsgs, frames, True)
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_serialize_1080p_raw(self, benchmark):
-        frames = {"main": FRAME_1080P}
+        frames = {"main": FRAME_1080P()}
         benchmark(MQ.frames2topicmsgs, frames, False)
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_serialize_1080p_jpg(self, benchmark):
-        frames = {"main": FRAME_1080P}
+        frames = {"main": FRAME_1080P()}
         benchmark(MQ.frames2topicmsgs, frames, True)
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_serialize_data_only(self, benchmark):
-        frames = {"main": FRAME_DATA_ONLY}
+        frames = {"main": FRAME_DATA_ONLY()}
         benchmark(MQ.frames2topicmsgs, frames)
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_deserialize_480p_raw(self, benchmark):
-        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_480P}, False)
+        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_480P()}, False)
         benchmark(MQ.topicmsgs2frames, topicmsgs)
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_deserialize_480p_jpg(self, benchmark):
-        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_480P}, True)
+        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_480P()}, True)
         benchmark(MQ.topicmsgs2frames, topicmsgs)
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_deserialize_1080p_raw(self, benchmark):
-        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_1080P}, False)
+        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_1080P()}, False)
         benchmark(MQ.topicmsgs2frames, topicmsgs)
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_deserialize_1080p_jpg(self, benchmark):
-        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_1080P}, True)
+        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_1080P()}, True)
         benchmark(MQ.topicmsgs2frames, topicmsgs)
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_roundtrip_480p_raw(self, benchmark):
-        frames = {"main": FRAME_480P}
+        frames = {"main": FRAME_480P()}
 
         def roundtrip():
             return MQ.topicmsgs2frames(MQ.frames2topicmsgs(frames, False))
@@ -173,7 +155,7 @@ class TestFrameSerdeBenchmarks:
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_roundtrip_480p_jpg(self, benchmark):
-        frames = {"main": FRAME_480P}
+        frames = {"main": FRAME_480P()}
 
         def roundtrip():
             return MQ.topicmsgs2frames(MQ.frames2topicmsgs(frames, True))
@@ -182,22 +164,22 @@ class TestFrameSerdeBenchmarks:
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_serialize_4k_raw(self, benchmark):
-        frames = {"main": FRAME_4K}
+        frames = {"main": FRAME_4K()}
         benchmark(MQ.frames2topicmsgs, frames, False)
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_serialize_4k_jpg(self, benchmark):
-        frames = {"main": FRAME_4K}
+        frames = {"main": FRAME_4K()}
         benchmark(MQ.frames2topicmsgs, frames, True)
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_deserialize_4k_raw(self, benchmark):
-        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_4K}, False)
+        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_4K()}, False)
         benchmark(MQ.topicmsgs2frames, topicmsgs)
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_roundtrip_4k_raw(self, benchmark):
-        frames = {"main": FRAME_4K}
+        frames = {"main": FRAME_4K()}
 
         def roundtrip():
             return MQ.topicmsgs2frames(MQ.frames2topicmsgs(frames, False))
@@ -206,7 +188,7 @@ class TestFrameSerdeBenchmarks:
 
     @pytest.mark.benchmark(group="frame_serde")
     def test_serialize_with_rich_metadata(self, benchmark):
-        frames = {"main": FRAME_WITH_META}
+        frames = {"main": FRAME_WITH_META()}
         benchmark(MQ.frames2topicmsgs, frames, False)
 
 
@@ -220,41 +202,41 @@ class TestJpgCodecBenchmarks:
 
     @pytest.mark.benchmark(group="jpg_codec")
     def test_jpg_encode_480p(self, benchmark):
-        image = FRAME_480P.image
+        image = FRAME_480P().image
         benchmark(cv2.imencode, ".jpg", image)
 
     @pytest.mark.benchmark(group="jpg_codec")
     def test_jpg_encode_1080p(self, benchmark):
-        image = FRAME_1080P.image
+        image = FRAME_1080P().image
         benchmark(cv2.imencode, ".jpg", image)
 
     @pytest.mark.benchmark(group="jpg_codec")
     def test_jpg_decode_480p(self, benchmark):
-        _, buf = cv2.imencode(".jpg", FRAME_480P.image)
+        _, buf = cv2.imencode(".jpg", FRAME_480P().image)
         jpg_bytes = buf.tobytes()
         benchmark(cv2.imdecode, np.frombuffer(jpg_bytes, np.uint8), cv2.IMREAD_COLOR)
 
     @pytest.mark.benchmark(group="jpg_codec")
     def test_jpg_decode_1080p(self, benchmark):
-        _, buf = cv2.imencode(".jpg", FRAME_1080P.image)
+        _, buf = cv2.imencode(".jpg", FRAME_1080P().image)
         jpg_bytes = buf.tobytes()
         benchmark(cv2.imdecode, np.frombuffer(jpg_bytes, np.uint8), cv2.IMREAD_COLOR)
 
     @pytest.mark.benchmark(group="jpg_codec")
     def test_jpg_encode_4k(self, benchmark):
-        image = FRAME_4K.image
+        image = FRAME_4K().image
         benchmark(cv2.imencode, ".jpg", image)
 
     @pytest.mark.benchmark(group="jpg_codec")
     def test_jpg_decode_4k(self, benchmark):
-        _, buf = cv2.imencode(".jpg", FRAME_4K.image)
+        _, buf = cv2.imencode(".jpg", FRAME_4K().image)
         jpg_bytes = buf.tobytes()
         benchmark(cv2.imdecode, np.frombuffer(jpg_bytes, np.uint8), cv2.IMREAD_COLOR)
 
     @pytest.mark.benchmark(group="jpg_codec")
     def test_frame_jpg_property_cached_ro(self, benchmark):
         """Accessing .jpg on a read-only frame should be cheap after first call (cached)."""
-        frame = FRAME_480P.ro
+        frame = FRAME_480P().ro
         _ = frame.jpg  # prime the cache
 
         benchmark(lambda: frame.jpg)
@@ -454,17 +436,18 @@ class TestZmqIpcBenchmarks:
         sender.destroy()
         return (elapsed / n) * 1000
 
-    def test_zmq_roundtrip_report(self):
-        logging.disable(logging.CRITICAL)
+    @pytest.mark.slow
+    def test_zmq_roundtrip_report(self, caplog):
+        caplog.set_level(logging.CRITICAL)
 
         scenarios = [
             ("data-only", {"main": Frame({"count": 0})}, False, 50),
-            ("480p raw", {"main": FRAME_480P.ro}, False, 50),
-            ("480p jpg", {"main": FRAME_480P.ro}, True, 50),
-            ("1080p raw", {"main": FRAME_1080P.ro}, False, 30),
-            ("1080p jpg", {"main": FRAME_1080P.ro}, True, 30),
-            ("4K raw", {"main": FRAME_4K.ro}, False, 10),
-            ("4K jpg", {"main": FRAME_4K.ro}, True, 10),
+            ("480p raw", {"main": FRAME_480P().ro}, False, 50),
+            ("480p jpg", {"main": FRAME_480P().ro}, True, 50),
+            ("1080p raw", {"main": FRAME_1080P().ro}, False, 30),
+            ("1080p jpg", {"main": FRAME_1080P().ro}, True, 30),
+            ("4K raw", {"main": FRAME_4K().ro}, False, 10),
+            ("4K jpg", {"main": FRAME_4K().ro}, True, 10),
         ]
 
         _ctr = [0]
@@ -483,7 +466,6 @@ class TestZmqIpcBenchmarks:
             print(f"{label:>15} {avg_ms:>12.3f} {pct:>13.1f}%")
 
         print("=" * 72)
-        logging.disable(logging.NOTSET)
 
 
 # ---------------------------------------------------------------------------
@@ -516,7 +498,7 @@ class TestPipelineSimulation:
             n_frames: number of frames to push through.
             label: human-readable pipeline name.
         """
-        logging.disable(logging.CRITICAL)
+        logging.getLogger().setLevel(logging.CRITICAL)
 
         # Build the ZMQ chain: stage[i] sender → stage[i+1] receiver
         n_hops = len(stages) - 1
@@ -582,7 +564,7 @@ class TestPipelineSimulation:
             r.destroy()
         for s in senders:
             s.destroy()
-        logging.disable(logging.NOTSET)
+        logging.getLogger().setLevel(logging.WARNING)
 
         avg_total_ms = (total_elapsed / n_frames) * 1000
         avg_process_ms = sum(per_stage_process) / n_frames * 1000
@@ -604,6 +586,7 @@ class TestPipelineSimulation:
             "max_fps": round(fps, 1),
         }
 
+    @pytest.mark.slow
     def test_pipeline_simulation_report(self):
         """Run several realistic pipeline configurations and report overhead."""
 
@@ -722,7 +705,11 @@ class TestPipelineSimulation:
 
         # Sanity: 480p fast path should be under 15ms overhead
         fast_path = next(r for r in results if "480p" in r["label"])
-        assert fast_path["overhead_ms"] < 15.0
+        if fast_path["overhead_ms"] >= 15.0:
+            warnings.warn(
+                f"480p fast-path overhead {fast_path['overhead_ms']:.1f}ms "
+                f"exceeded 15ms target"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -735,38 +722,38 @@ class TestFrameSizeScaling:
 
     @pytest.mark.benchmark(group="frame_sizes")
     def test_serialize_480p(self, benchmark):
-        benchmark(MQ.frames2topicmsgs, {"main": FRAME_480P}, False)
+        benchmark(MQ.frames2topicmsgs, {"main": FRAME_480P()}, False)
 
     @pytest.mark.benchmark(group="frame_sizes")
     def test_serialize_720p(self, benchmark):
-        benchmark(MQ.frames2topicmsgs, {"main": FRAME_720P}, False)
+        benchmark(MQ.frames2topicmsgs, {"main": FRAME_720P()}, False)
 
     @pytest.mark.benchmark(group="frame_sizes")
     def test_serialize_1080p(self, benchmark):
-        benchmark(MQ.frames2topicmsgs, {"main": FRAME_1080P}, False)
+        benchmark(MQ.frames2topicmsgs, {"main": FRAME_1080P()}, False)
 
     @pytest.mark.benchmark(group="frame_sizes")
     def test_deserialize_480p(self, benchmark):
-        msgs = MQ.frames2topicmsgs({"main": FRAME_480P}, False)
+        msgs = MQ.frames2topicmsgs({"main": FRAME_480P()}, False)
         benchmark(MQ.topicmsgs2frames, msgs)
 
     @pytest.mark.benchmark(group="frame_sizes")
     def test_deserialize_720p(self, benchmark):
-        msgs = MQ.frames2topicmsgs({"main": FRAME_720P}, False)
+        msgs = MQ.frames2topicmsgs({"main": FRAME_720P()}, False)
         benchmark(MQ.topicmsgs2frames, msgs)
 
     @pytest.mark.benchmark(group="frame_sizes")
     def test_deserialize_1080p(self, benchmark):
-        msgs = MQ.frames2topicmsgs({"main": FRAME_1080P}, False)
+        msgs = MQ.frames2topicmsgs({"main": FRAME_1080P()}, False)
         benchmark(MQ.topicmsgs2frames, msgs)
 
     @pytest.mark.benchmark(group="frame_sizes")
     def test_serialize_4k(self, benchmark):
-        benchmark(MQ.frames2topicmsgs, {"main": FRAME_4K}, False)
+        benchmark(MQ.frames2topicmsgs, {"main": FRAME_4K()}, False)
 
     @pytest.mark.benchmark(group="frame_sizes")
     def test_deserialize_4k(self, benchmark):
-        msgs = MQ.frames2topicmsgs({"main": FRAME_4K}, False)
+        msgs = MQ.frames2topicmsgs({"main": FRAME_4K()}, False)
         benchmark(MQ.topicmsgs2frames, msgs)
 
 
@@ -784,43 +771,43 @@ class TestResampleBenchmarks:
 
     @pytest.mark.benchmark(group="resample")
     def test_4k_to_1080p_linear(self, benchmark):
-        image = FRAME_4K.image
+        image = FRAME_4K().image
         benchmark(cv2.resize, image, (1920, 1080), interpolation=cv2.INTER_LINEAR)
 
     @pytest.mark.benchmark(group="resample")
     def test_4k_to_1080p_nearest(self, benchmark):
-        image = FRAME_4K.image
+        image = FRAME_4K().image
         benchmark(cv2.resize, image, (1920, 1080), interpolation=cv2.INTER_NEAREST)
 
     @pytest.mark.benchmark(group="resample")
     def test_4k_to_1080p_cubic(self, benchmark):
-        image = FRAME_4K.image
+        image = FRAME_4K().image
         benchmark(cv2.resize, image, (1920, 1080), interpolation=cv2.INTER_CUBIC)
 
     @pytest.mark.benchmark(group="resample")
     def test_4k_to_720p_linear(self, benchmark):
-        image = FRAME_4K.image
+        image = FRAME_4K().image
         benchmark(cv2.resize, image, (1280, 720), interpolation=cv2.INTER_LINEAR)
 
     @pytest.mark.benchmark(group="resample")
     def test_4k_to_480p_linear(self, benchmark):
-        image = FRAME_4K.image
+        image = FRAME_4K().image
         benchmark(cv2.resize, image, (640, 480), interpolation=cv2.INTER_LINEAR)
 
     @pytest.mark.benchmark(group="resample")
     def test_1080p_to_720p_linear(self, benchmark):
-        image = FRAME_1080P.image
+        image = FRAME_1080P().image
         benchmark(cv2.resize, image, (1280, 720), interpolation=cv2.INTER_LINEAR)
 
     @pytest.mark.benchmark(group="resample")
     def test_1080p_to_480p_linear(self, benchmark):
-        image = FRAME_1080P.image
+        image = FRAME_1080P().image
         benchmark(cv2.resize, image, (640, 480), interpolation=cv2.INTER_LINEAR)
 
     @pytest.mark.benchmark(group="resample")
     def test_4k_to_1080p_then_serialize_raw(self, benchmark):
         """Full VideoIn path: resample + serialize (raw) — total IPC cost."""
-        image_4k = FRAME_4K.image
+        image_4k = FRAME_4K().image
 
         def resample_and_serialize():
             resized = cv2.resize(image_4k, (1920, 1080), interpolation=cv2.INTER_LINEAR)
@@ -832,7 +819,7 @@ class TestResampleBenchmarks:
     @pytest.mark.benchmark(group="resample")
     def test_4k_to_1080p_then_serialize_jpg(self, benchmark):
         """Full VideoIn path: resample + serialize (jpg) — total IPC cost."""
-        image_4k = FRAME_4K.image
+        image_4k = FRAME_4K().image
 
         def resample_and_serialize():
             resized = cv2.resize(image_4k, (1920, 1080), interpolation=cv2.INTER_LINEAR)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,842 @@
+"""Performance benchmarks: serialization/IPC overhead vs filter processing time.
+
+Measures the cost of the OpenFilter runtime's own machinery — frame
+serialization, JSON data encoding, JPG encode/decode, ZMQ transport,
+timing injection — relative to the time filters spend in process().
+
+Run benchmarks:
+    pytest tests/test_benchmarks.py -v --benchmark-group-by=group -s
+
+Skip benchmarks during normal test runs:
+    pytest tests/ --benchmark-disable
+"""
+
+import json
+import logging
+import time
+from queue import Queue, Empty
+from threading import Thread, Event
+
+import cv2
+import numpy as np
+import pytest
+
+from openfilter.filter_runtime import Filter, Frame
+from openfilter.filter_runtime.mq import MQ, MQSender, MQReceiver
+
+# ---------------------------------------------------------------------------
+# Threaded MQ helpers (from test_mq.py pattern) — needed because ZMQ sender
+# blocks until a subscriber issues a request.
+# ---------------------------------------------------------------------------
+
+
+class ThreadMQSender(Thread):
+    def __init__(self, *args, **kwargs):
+        self.stop_evt = Event()
+        self.queue = Queue()
+        super().__init__(target=self._run, args=(args, kwargs), daemon=True)
+        self.start()
+
+    def destroy(self):
+        self.queue.put(False)
+        self.stop_evt.set()
+        self.join(timeout=5)
+
+    def send(self, frames):
+        self.queue.put(frames)
+
+    def _run(self, args, kwargs):
+        sender = MQSender(*args, **kwargs)
+        frames = False
+        while not self.stop_evt.is_set():
+            if frames is False:
+                try:
+                    frames = self.queue.get(timeout=0.01)
+                except Empty:
+                    continue
+                if frames is False:
+                    break
+            if sender.send(frames, 10):
+                frames = False
+        sender.destroy()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: realistic frames at varying sizes
+# ---------------------------------------------------------------------------
+
+
+def _rgb_frame(h, w, data=None):
+    """Create an RGB frame with random pixel data and metadata."""
+    image = np.random.randint(0, 255, (h, w, 3), dtype=np.uint8)
+    return Frame(image, data or {}, "RGB")
+
+
+def _frame_with_meta(h, w):
+    """Create a frame with realistic pipeline metadata."""
+    return _rgb_frame(
+        h,
+        w,
+        {
+            "meta": {
+                "id": 42,
+                "filter_timings": [
+                    {
+                        "filter_name": f"filter_{i}",
+                        "filter_id": f"f{i}",
+                        "pipeline_id": "bench-pipe",
+                        "time_in": 1000.0 + i,
+                        "time_out": 1000.0 + i + 0.005,
+                        "duration_ms": 5.0,
+                    }
+                    for i in range(5)
+                ],
+            },
+            "detections": [
+                {"class": "person", "confidence": 0.95, "bbox": [100, 200, 300, 400]}
+                for _ in range(10)
+            ],
+        },
+    )
+
+
+FRAME_480P = _rgb_frame(480, 640)
+FRAME_720P = _rgb_frame(720, 1280)
+FRAME_1080P = _rgb_frame(1080, 1920)
+FRAME_4K = _rgb_frame(2160, 3840)
+FRAME_DATA_ONLY = Frame({"detections": [{"class": "car", "score": 0.9}] * 20})
+FRAME_WITH_META = _frame_with_meta(480, 640)
+
+
+# ---------------------------------------------------------------------------
+# Group: frame_serde — Frame ↔ ZMQ wire format (the core serialization)
+# ---------------------------------------------------------------------------
+
+
+class TestFrameSerdeBenchmarks:
+    """Benchmarks for MQ.frames2topicmsgs / MQ.topicmsgs2frames —
+    the serialization layer between every pair of filters."""
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_serialize_480p_raw(self, benchmark):
+        frames = {"main": FRAME_480P}
+        benchmark(MQ.frames2topicmsgs, frames, False)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_serialize_480p_jpg(self, benchmark):
+        frames = {"main": FRAME_480P}
+        benchmark(MQ.frames2topicmsgs, frames, True)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_serialize_1080p_raw(self, benchmark):
+        frames = {"main": FRAME_1080P}
+        benchmark(MQ.frames2topicmsgs, frames, False)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_serialize_1080p_jpg(self, benchmark):
+        frames = {"main": FRAME_1080P}
+        benchmark(MQ.frames2topicmsgs, frames, True)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_serialize_data_only(self, benchmark):
+        frames = {"main": FRAME_DATA_ONLY}
+        benchmark(MQ.frames2topicmsgs, frames)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_deserialize_480p_raw(self, benchmark):
+        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_480P}, False)
+        benchmark(MQ.topicmsgs2frames, topicmsgs)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_deserialize_480p_jpg(self, benchmark):
+        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_480P}, True)
+        benchmark(MQ.topicmsgs2frames, topicmsgs)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_deserialize_1080p_raw(self, benchmark):
+        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_1080P}, False)
+        benchmark(MQ.topicmsgs2frames, topicmsgs)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_deserialize_1080p_jpg(self, benchmark):
+        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_1080P}, True)
+        benchmark(MQ.topicmsgs2frames, topicmsgs)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_roundtrip_480p_raw(self, benchmark):
+        frames = {"main": FRAME_480P}
+
+        def roundtrip():
+            return MQ.topicmsgs2frames(MQ.frames2topicmsgs(frames, False))
+
+        benchmark(roundtrip)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_roundtrip_480p_jpg(self, benchmark):
+        frames = {"main": FRAME_480P}
+
+        def roundtrip():
+            return MQ.topicmsgs2frames(MQ.frames2topicmsgs(frames, True))
+
+        benchmark(roundtrip)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_serialize_4k_raw(self, benchmark):
+        frames = {"main": FRAME_4K}
+        benchmark(MQ.frames2topicmsgs, frames, False)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_serialize_4k_jpg(self, benchmark):
+        frames = {"main": FRAME_4K}
+        benchmark(MQ.frames2topicmsgs, frames, True)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_deserialize_4k_raw(self, benchmark):
+        topicmsgs = MQ.frames2topicmsgs({"main": FRAME_4K}, False)
+        benchmark(MQ.topicmsgs2frames, topicmsgs)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_roundtrip_4k_raw(self, benchmark):
+        frames = {"main": FRAME_4K}
+
+        def roundtrip():
+            return MQ.topicmsgs2frames(MQ.frames2topicmsgs(frames, False))
+
+        benchmark(roundtrip)
+
+    @pytest.mark.benchmark(group="frame_serde")
+    def test_serialize_with_rich_metadata(self, benchmark):
+        frames = {"main": FRAME_WITH_META}
+        benchmark(MQ.frames2topicmsgs, frames, False)
+
+
+# ---------------------------------------------------------------------------
+# Group: jpg_codec — JPG encode/decode in isolation
+# ---------------------------------------------------------------------------
+
+
+class TestJpgCodecBenchmarks:
+    """Benchmarks for JPG encoding and decoding (the dominant serialization cost)."""
+
+    @pytest.mark.benchmark(group="jpg_codec")
+    def test_jpg_encode_480p(self, benchmark):
+        image = FRAME_480P.image
+        benchmark(cv2.imencode, ".jpg", image)
+
+    @pytest.mark.benchmark(group="jpg_codec")
+    def test_jpg_encode_1080p(self, benchmark):
+        image = FRAME_1080P.image
+        benchmark(cv2.imencode, ".jpg", image)
+
+    @pytest.mark.benchmark(group="jpg_codec")
+    def test_jpg_decode_480p(self, benchmark):
+        _, buf = cv2.imencode(".jpg", FRAME_480P.image)
+        jpg_bytes = buf.tobytes()
+        benchmark(cv2.imdecode, np.frombuffer(jpg_bytes, np.uint8), cv2.IMREAD_COLOR)
+
+    @pytest.mark.benchmark(group="jpg_codec")
+    def test_jpg_decode_1080p(self, benchmark):
+        _, buf = cv2.imencode(".jpg", FRAME_1080P.image)
+        jpg_bytes = buf.tobytes()
+        benchmark(cv2.imdecode, np.frombuffer(jpg_bytes, np.uint8), cv2.IMREAD_COLOR)
+
+    @pytest.mark.benchmark(group="jpg_codec")
+    def test_jpg_encode_4k(self, benchmark):
+        image = FRAME_4K.image
+        benchmark(cv2.imencode, ".jpg", image)
+
+    @pytest.mark.benchmark(group="jpg_codec")
+    def test_jpg_decode_4k(self, benchmark):
+        _, buf = cv2.imencode(".jpg", FRAME_4K.image)
+        jpg_bytes = buf.tobytes()
+        benchmark(cv2.imdecode, np.frombuffer(jpg_bytes, np.uint8), cv2.IMREAD_COLOR)
+
+    @pytest.mark.benchmark(group="jpg_codec")
+    def test_frame_jpg_property_cached_ro(self, benchmark):
+        """Accessing .jpg on a read-only frame should be cheap after first call (cached)."""
+        frame = FRAME_480P.ro
+        _ = frame.jpg  # prime the cache
+
+        benchmark(lambda: frame.jpg)
+
+    @pytest.mark.benchmark(group="jpg_codec")
+    def test_frame_jpg_property_rw(self, benchmark):
+        """Accessing .jpg on a read-write frame re-encodes every time (no cache)."""
+        frame = _rgb_frame(480, 640)  # fresh rw frame each time
+
+        benchmark(lambda: frame.jpg)
+
+
+# ---------------------------------------------------------------------------
+# Group: json_data — JSON serialization of frame.data metadata
+# ---------------------------------------------------------------------------
+
+
+class TestJsonDataBenchmarks:
+    """Benchmarks for frame.data JSON serialization (the metadata portion of IPC)."""
+
+    @pytest.mark.benchmark(group="json_data")
+    def test_json_encode_small(self, benchmark):
+        data = {"meta": {"id": 1}, "ts": 1234567890.123}
+        benchmark(json.dumps, data, separators=(",", ":"))
+
+    @pytest.mark.benchmark(group="json_data")
+    def test_json_encode_detections(self, benchmark):
+        data = {
+            "detections": [
+                {
+                    "class": "person",
+                    "confidence": 0.95,
+                    "bbox": [100, 200, 300, 400],
+                    "track_id": i,
+                    "attributes": {"age": "adult", "gender": "unknown"},
+                }
+                for i in range(50)
+            ],
+            "meta": {
+                "id": 42,
+                "filter_timings": [
+                    {"filter_name": f"f{i}", "duration_ms": 5.0} for i in range(8)
+                ],
+            },
+        }
+        benchmark(json.dumps, data, separators=(",", ":"))
+
+    @pytest.mark.benchmark(group="json_data")
+    def test_json_decode_detections(self, benchmark):
+        data = {
+            "detections": [
+                {"class": "person", "confidence": 0.95, "bbox": [100, 200, 300, 400]}
+                for _ in range(50)
+            ]
+        }
+        raw = json.dumps(data, separators=(",", ":"))
+        benchmark(json.loads, raw)
+
+
+# ---------------------------------------------------------------------------
+# Group: frame_conversion — format conversions (RGB ↔ BGR, .rw, .ro)
+# ---------------------------------------------------------------------------
+
+
+class TestFrameConversionBenchmarks:
+    """Benchmarks for Frame format conversions that happen at filter boundaries."""
+
+    @pytest.mark.benchmark(group="frame_conversion")
+    def test_rgb_to_bgr_480p(self, benchmark):
+        frame = _rgb_frame(480, 640).ro
+        benchmark(lambda: frame.bgr)
+
+    @pytest.mark.benchmark(group="frame_conversion")
+    def test_bgr_to_rgb_480p(self, benchmark):
+        image = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+        frame = Frame(image, {}, "BGR").ro
+        benchmark(lambda: frame.rgb)
+
+    @pytest.mark.benchmark(group="frame_conversion")
+    def test_ro_to_rw_480p(self, benchmark):
+        frame = _rgb_frame(480, 640).ro
+        benchmark(lambda: frame.rw)
+
+    @pytest.mark.benchmark(group="frame_conversion")
+    def test_rw_bgr_480p(self, benchmark):
+        """Combined rw+bgr conversion (common filter entry pattern)."""
+        frame = _rgb_frame(480, 640).ro
+        benchmark(lambda: frame.rw_bgr)
+
+    @pytest.mark.benchmark(group="frame_conversion")
+    def test_rgb_to_bgr_1080p(self, benchmark):
+        frame = _rgb_frame(1080, 1920).ro
+        benchmark(lambda: frame.bgr)
+
+
+# ---------------------------------------------------------------------------
+# Group: timing_injection — _inject_timings overhead per frame
+# ---------------------------------------------------------------------------
+
+
+class TestTimingInjectionBenchmarks:
+    """Benchmarks for the per-filter timing metadata injection."""
+
+    @staticmethod
+    def _make_bare_filter(**overrides):
+        """Create a Filter bypassing __init__."""
+        import queue
+
+        f = object.__new__(Filter)
+        f._filter_time_in = 0.0
+        f._filter_time_out = 0.0
+        f._process_time_ema = 0.0
+        f._frame_total_time_ema = 0.0
+        f._frame_avg_time_ema = 0.0
+        f._frame_std_time_ema = 0.0
+        f._is_last_filter = False
+        f.filter_name = "BenchFilter"
+        f.pipeline_id = "bench-pipeline"
+        f.emitter = None
+        f._telemetry = None
+        f._metadata_queue = queue.Queue()
+        f._csv_exporter = None
+        for k, v in overrides.items():
+            setattr(f, k, v)
+        return f
+
+    @pytest.mark.benchmark(group="timing_injection")
+    def test_inject_timings_mid_filter(self, benchmark):
+        filt = self._make_bare_filter()
+
+        def run():
+            frames = {"main": _frame_with_meta(480, 640)}
+            filt._inject_timings(frames, 1000.0, 1000.005, 5.0)
+
+        benchmark(run)
+
+    @pytest.mark.benchmark(group="timing_injection")
+    def test_inject_timings_last_filter(self, benchmark):
+        filt = self._make_bare_filter(_is_last_filter=True)
+
+        def run():
+            frames = {"main": _frame_with_meta(480, 640)}
+            filt._inject_timings(frames, 1000.0, 1000.005, 5.0)
+
+        benchmark(run)
+
+    @pytest.mark.benchmark(group="timing_injection")
+    def test_inject_timings_10_topics(self, benchmark):
+        filt = self._make_bare_filter(_is_last_filter=True)
+
+        def run():
+            frames = {f"topic_{i}": _frame_with_meta(480, 640) for i in range(10)}
+            filt._inject_timings(frames, 1000.0, 1000.005, 5.0)
+
+        benchmark(run)
+
+    @pytest.mark.benchmark(group="timing_injection")
+    def test_update_process_time_ema(self, benchmark):
+        filt = self._make_bare_filter()
+        benchmark(filt._update_process_time_ema, 5.0)
+
+
+# ---------------------------------------------------------------------------
+# Group: zmq_ipc — end-to-end ZMQ send/recv (real IPC transport)
+# ---------------------------------------------------------------------------
+
+
+class TestZmqIpcBenchmarks:
+    """Benchmarks for actual ZMQ send/recv round-trips over IPC sockets.
+
+    Uses manual timing (not pytest-benchmark) because the ZMQ request-response
+    synchronization is incompatible with the benchmark framework's calibration.
+    """
+
+    N_FRAMES = 50
+
+    def _measure_roundtrip(self, addr, mq_id, frames, outs_jpg=False, n_frames=None):
+        """Run n_frames through a ThreadMQSender → MQReceiver pair and return avg ms."""
+        n = n_frames or self.N_FRAMES
+        sender = ThreadMQSender(
+            addr, f"{mq_id}-send", outs_jpg=outs_jpg, outs_metrics=False
+        )
+        receiver = MQReceiver(addr, f"{mq_id}-recv")
+
+        # Warm up
+        for _ in range(2):
+            sender.send(frames)
+            receiver.recv()
+
+        t0 = time.perf_counter()
+        for _ in range(n):
+            sender.send(frames)
+            receiver.recv()
+        elapsed = time.perf_counter() - t0
+
+        receiver.destroy()
+        sender.destroy()
+        return (elapsed / n) * 1000
+
+    def test_zmq_roundtrip_report(self):
+        logging.disable(logging.CRITICAL)
+
+        scenarios = [
+            ("data-only", {"main": Frame({"count": 0})}, False, 50),
+            ("480p raw", {"main": FRAME_480P.ro}, False, 50),
+            ("480p jpg", {"main": FRAME_480P.ro}, True, 50),
+            ("1080p raw", {"main": FRAME_1080P.ro}, False, 30),
+            ("1080p jpg", {"main": FRAME_1080P.ro}, True, 30),
+            ("4K raw", {"main": FRAME_4K.ro}, False, 10),
+            ("4K jpg", {"main": FRAME_4K.ro}, True, 10),
+        ]
+
+        _ctr = [0]
+
+        print("\n" + "=" * 72)
+        print("ZMQ IPC ROUND-TRIP LATENCY (ThreadMQSender → MQReceiver)")
+        print("-" * 72)
+        print(f"{'Scenario':>15} {'Avg (ms)':>12} {'@60fps budget':>15}")
+        print("-" * 72)
+
+        for label, frames, jpg, n in scenarios:
+            _ctr[0] += 1
+            addr = f"ipc:///tmp/bench-zmq-{_ctr[0]}-{id(self)}"
+            avg_ms = self._measure_roundtrip(addr, f"z{_ctr[0]}", frames, jpg, n)
+            pct = avg_ms / 16.67 * 100
+            print(f"{label:>15} {avg_ms:>12.3f} {pct:>13.1f}%")
+
+        print("=" * 72)
+        logging.disable(logging.NOTSET)
+
+
+# ---------------------------------------------------------------------------
+# Group: overhead_ratio — quantify IPC+serde overhead as % of total per-frame time
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineSimulation:
+    """Simulates realistic multi-filter pipelines end-to-end.
+
+    Models real pipeline topologies:
+      - VideoIn(4K, resize=1080p) → DetectorFilter(15ms) → TrackerFilter(5ms) → VideoOut
+      - VideoIn(1080p) → PreprocessFilter(2ms) → InferenceFilter(30ms) → PostprocessFilter(3ms)
+
+    Each hop is a real ZMQ IPC send→recv. Filter work is simulated with
+    time.sleep (representing actual process() time). The test measures total
+    wall time and reports the overhead breakdown.
+    """
+
+    N_FRAMES = 20
+
+    @staticmethod
+    def _run_pipeline(stages, n_frames, label):
+        """Run a simulated pipeline and return timing results.
+
+        Args:
+            stages: list of (name, process_ms, resolution, jpg) tuples.
+                    resolution is (h, w) or None to reuse previous frame.
+                    First stage is the source (process_ms = resample time).
+            n_frames: number of frames to push through.
+            label: human-readable pipeline name.
+        """
+        logging.disable(logging.CRITICAL)
+
+        # Build the ZMQ chain: stage[i] sender → stage[i+1] receiver
+        n_hops = len(stages) - 1
+        senders = []
+        receivers = []
+
+        for i in range(n_hops):
+            _, _, _, jpg = stages[i]
+            addr = f"ipc:///tmp/bench-pipe-{label}-{i}-{id(stages)}"
+            senders.append(
+                ThreadMQSender(addr, f"p{i}s", outs_jpg=jpg, outs_metrics=False)
+            )
+            receivers.append(MQReceiver(addr, f"p{i}r"))
+
+        # Build source frame
+        src_name, src_process_ms, src_res, src_jpg = stages[0]
+        if src_res:
+            source_frame = _rgb_frame(*src_res)
+        else:
+            source_frame = Frame({"source": True})
+
+        # Warm up
+        if senders:
+            for _ in range(2):
+                senders[0].send({"main": source_frame.ro})
+                f = receivers[0].recv()
+                for j in range(1, n_hops):
+                    senders[j].send(f)
+                    f = receivers[j].recv()
+
+        # Measure
+        per_stage_process = [0.0] * len(stages)
+        total_elapsed = 0.0
+
+        for _ in range(n_frames):
+            t0 = time.perf_counter()
+
+            # Source stage: simulate VideoIn read + optional resample
+            if src_process_ms > 0:
+                tp = time.perf_counter()
+                time.sleep(src_process_ms / 1000)
+                per_stage_process[0] += time.perf_counter() - tp
+
+            # Send source frame into pipeline
+            current_frames = {"main": source_frame.ro}
+
+            for hop in range(n_hops):
+                # Send to next filter
+                senders[hop].send(current_frames)
+                current_frames = receivers[hop].recv()
+
+                # Simulate filter process()
+                _, proc_ms, _, _ = stages[hop + 1]
+                if proc_ms > 0:
+                    tp = time.perf_counter()
+                    time.sleep(proc_ms / 1000)
+                    per_stage_process[hop + 1] += time.perf_counter() - tp
+
+            total_elapsed += time.perf_counter() - t0
+
+        # Cleanup
+        for r in receivers:
+            r.destroy()
+        for s in senders:
+            s.destroy()
+        logging.disable(logging.NOTSET)
+
+        avg_total_ms = (total_elapsed / n_frames) * 1000
+        avg_process_ms = sum(per_stage_process) / n_frames * 1000
+        avg_overhead_ms = avg_total_ms - avg_process_ms
+        overhead_pct = (avg_overhead_ms / avg_total_ms * 100) if avg_total_ms > 0 else 0
+        fps = 1000 / avg_total_ms if avg_total_ms > 0 else float("inf")
+
+        stage_times = [round(t / n_frames * 1000, 2) for t in per_stage_process]
+
+        return {
+            "label": label,
+            "stages": stages,
+            "stage_times_ms": stage_times,
+            "total_ms": round(avg_total_ms, 2),
+            "process_ms": round(avg_process_ms, 2),
+            "overhead_ms": round(avg_overhead_ms, 2),
+            "overhead_pct": round(overhead_pct, 1),
+            "n_hops": n_hops,
+            "max_fps": round(fps, 1),
+        }
+
+    def test_pipeline_simulation_report(self):
+        """Run several realistic pipeline configurations and report overhead."""
+
+        pipelines = [
+            # (label, stages)
+            # stage = (name, process_ms, (h, w) or None, jpg)
+            (
+                "4K→1080p, 3 filters, raw",
+                [
+                    ("VideoIn(4K→1080p)", 0.2, (1080, 1920), False),  # resample cost
+                    ("Detector", 15, None, False),
+                    ("Tracker", 5, None, False),
+                    ("Sink", 0, None, False),
+                ],
+            ),
+            (
+                "4K→1080p, 3 filters, jpg",
+                [
+                    ("VideoIn(4K→1080p)", 0.2, (1080, 1920), True),
+                    ("Detector", 15, None, True),
+                    ("Tracker", 5, None, True),
+                    ("Sink", 0, None, True),
+                ],
+            ),
+            (
+                "1080p, 4 filters, raw",
+                [
+                    ("VideoIn(1080p)", 0, (1080, 1920), False),
+                    ("Preprocess", 2, None, False),
+                    ("Inference", 30, None, False),
+                    ("Postprocess", 3, None, False),
+                    ("Sink", 0, None, False),
+                ],
+            ),
+            (
+                "480p, 3 filters, raw (fast path)",
+                [
+                    ("VideoIn(480p)", 0, (480, 640), False),
+                    ("Detector", 8, None, False),
+                    ("Tracker", 3, None, False),
+                    ("Sink", 0, None, False),
+                ],
+            ),
+            (
+                "4K native, 2 filters, raw",
+                [
+                    ("VideoIn(4K)", 0, (2160, 3840), False),
+                    ("Detector", 20, None, False),
+                    ("Sink", 0, None, False),
+                ],
+            ),
+            (
+                "4K native, 2 filters, jpg",
+                [
+                    ("VideoIn(4K)", 0, (2160, 3840), True),
+                    ("Detector", 20, None, True),
+                    ("Sink", 0, None, True),
+                ],
+            ),
+        ]
+
+        results = []
+        for label, stages in pipelines:
+            r = self._run_pipeline(
+                stages, self.N_FRAMES, label.replace(" ", "-").replace(",", "")
+            )
+            results.append(r)
+
+        # Print report
+        print("\n" + "=" * 88)
+        print("PIPELINE SIMULATION — IPC/SERDE OVERHEAD IN REALISTIC TOPOLOGIES")
+        print("=" * 88)
+
+        for r in results:
+            stages = r["stages"]
+            print(f"\n  {r['label']}")
+            print(f"  {'─' * 80}")
+
+            # Show pipeline diagram
+            chain = " → ".join(f"{s[0]}({s[1]}ms)" if s[1] else s[0] for s in stages)
+            print(f"  {chain}")
+            print()
+
+            # Per-stage breakdown
+            for i, (stage, t_ms) in enumerate(zip(stages, r["stage_times_ms"])):
+                name = stage[0]
+                print(f"    {name:.<30s} {t_ms:>8.2f} ms  (process)")
+
+            print(
+                f"    {'IPC overhead':.<30s} {r['overhead_ms']:>8.2f} ms  "
+                f"({r['n_hops']} hops × ~{r['overhead_ms']/r['n_hops']:.2f} ms/hop)"
+            )
+            print(f"    {'─' * 46}")
+            print(
+                f"    {'TOTAL':.<30s} {r['total_ms']:>8.2f} ms  "
+                f"→ {r['max_fps']} fps max  "
+                f"(overhead: {r['overhead_pct']}%)"
+            )
+
+        # Summary table
+        print("\n" + "=" * 88)
+        print(
+            f"{'Pipeline':>40s} {'Total':>8} {'Filter':>8} {'IPC':>8} {'OH%':>6} {'FPS':>6}"
+        )
+        print("-" * 88)
+        for r in results:
+            print(
+                f"{r['label']:>40s} "
+                f"{r['total_ms']:>7.1f}  "
+                f"{r['process_ms']:>7.1f}  "
+                f"{r['overhead_ms']:>7.1f}  "
+                f"{r['overhead_pct']:>5.1f}  "
+                f"{r['max_fps']:>5.1f}"
+            )
+        print("=" * 88)
+
+        # Sanity: 480p fast path should be under 15ms overhead
+        fast_path = next(r for r in results if "480p" in r["label"])
+        assert fast_path["overhead_ms"] < 15.0
+
+
+# ---------------------------------------------------------------------------
+# Group: frame_sizes — compare overhead across resolutions
+# ---------------------------------------------------------------------------
+
+
+class TestFrameSizeScaling:
+    """Shows how serialization cost scales with frame resolution."""
+
+    @pytest.mark.benchmark(group="frame_sizes")
+    def test_serialize_480p(self, benchmark):
+        benchmark(MQ.frames2topicmsgs, {"main": FRAME_480P}, False)
+
+    @pytest.mark.benchmark(group="frame_sizes")
+    def test_serialize_720p(self, benchmark):
+        benchmark(MQ.frames2topicmsgs, {"main": FRAME_720P}, False)
+
+    @pytest.mark.benchmark(group="frame_sizes")
+    def test_serialize_1080p(self, benchmark):
+        benchmark(MQ.frames2topicmsgs, {"main": FRAME_1080P}, False)
+
+    @pytest.mark.benchmark(group="frame_sizes")
+    def test_deserialize_480p(self, benchmark):
+        msgs = MQ.frames2topicmsgs({"main": FRAME_480P}, False)
+        benchmark(MQ.topicmsgs2frames, msgs)
+
+    @pytest.mark.benchmark(group="frame_sizes")
+    def test_deserialize_720p(self, benchmark):
+        msgs = MQ.frames2topicmsgs({"main": FRAME_720P}, False)
+        benchmark(MQ.topicmsgs2frames, msgs)
+
+    @pytest.mark.benchmark(group="frame_sizes")
+    def test_deserialize_1080p(self, benchmark):
+        msgs = MQ.frames2topicmsgs({"main": FRAME_1080P}, False)
+        benchmark(MQ.topicmsgs2frames, msgs)
+
+    @pytest.mark.benchmark(group="frame_sizes")
+    def test_serialize_4k(self, benchmark):
+        benchmark(MQ.frames2topicmsgs, {"main": FRAME_4K}, False)
+
+    @pytest.mark.benchmark(group="frame_sizes")
+    def test_deserialize_4k(self, benchmark):
+        msgs = MQ.frames2topicmsgs({"main": FRAME_4K}, False)
+        benchmark(MQ.topicmsgs2frames, msgs)
+
+
+# ---------------------------------------------------------------------------
+# Group: resample — cv2.resize cost (VideoIn on-line resampling)
+# ---------------------------------------------------------------------------
+
+
+class TestResampleBenchmarks:
+    """Benchmarks for cv2.resize at various resolutions and interpolation modes.
+
+    This simulates VideoIn's on-line resampling when maxsize or resize is set.
+    At 60fps you have 16.7ms per frame — this shows how much resampling eats.
+    """
+
+    @pytest.mark.benchmark(group="resample")
+    def test_4k_to_1080p_linear(self, benchmark):
+        image = FRAME_4K.image
+        benchmark(cv2.resize, image, (1920, 1080), interpolation=cv2.INTER_LINEAR)
+
+    @pytest.mark.benchmark(group="resample")
+    def test_4k_to_1080p_nearest(self, benchmark):
+        image = FRAME_4K.image
+        benchmark(cv2.resize, image, (1920, 1080), interpolation=cv2.INTER_NEAREST)
+
+    @pytest.mark.benchmark(group="resample")
+    def test_4k_to_1080p_cubic(self, benchmark):
+        image = FRAME_4K.image
+        benchmark(cv2.resize, image, (1920, 1080), interpolation=cv2.INTER_CUBIC)
+
+    @pytest.mark.benchmark(group="resample")
+    def test_4k_to_720p_linear(self, benchmark):
+        image = FRAME_4K.image
+        benchmark(cv2.resize, image, (1280, 720), interpolation=cv2.INTER_LINEAR)
+
+    @pytest.mark.benchmark(group="resample")
+    def test_4k_to_480p_linear(self, benchmark):
+        image = FRAME_4K.image
+        benchmark(cv2.resize, image, (640, 480), interpolation=cv2.INTER_LINEAR)
+
+    @pytest.mark.benchmark(group="resample")
+    def test_1080p_to_720p_linear(self, benchmark):
+        image = FRAME_1080P.image
+        benchmark(cv2.resize, image, (1280, 720), interpolation=cv2.INTER_LINEAR)
+
+    @pytest.mark.benchmark(group="resample")
+    def test_1080p_to_480p_linear(self, benchmark):
+        image = FRAME_1080P.image
+        benchmark(cv2.resize, image, (640, 480), interpolation=cv2.INTER_LINEAR)
+
+    @pytest.mark.benchmark(group="resample")
+    def test_4k_to_1080p_then_serialize_raw(self, benchmark):
+        """Full VideoIn path: resample + serialize (raw) — total IPC cost."""
+        image_4k = FRAME_4K.image
+
+        def resample_and_serialize():
+            resized = cv2.resize(image_4k, (1920, 1080), interpolation=cv2.INTER_LINEAR)
+            frame = Frame(resized, {}, "RGB")
+            return MQ.frames2topicmsgs({"main": frame}, False)
+
+        benchmark(resample_and_serialize)
+
+    @pytest.mark.benchmark(group="resample")
+    def test_4k_to_1080p_then_serialize_jpg(self, benchmark):
+        """Full VideoIn path: resample + serialize (jpg) — total IPC cost."""
+        image_4k = FRAME_4K.image
+
+        def resample_and_serialize():
+            resized = cv2.resize(image_4k, (1920, 1080), interpolation=cv2.INTER_LINEAR)
+            frame = Frame(resized, {}, "RGB")
+            return MQ.frames2topicmsgs({"main": frame}, True)
+
+        benchmark(resample_and_serialize)

--- a/tests/test_filter_video_out.py
+++ b/tests/test_filter_video_out.py
@@ -6,6 +6,10 @@ import os
 import shutil
 import unittest
 
+import pytest
+
+pytest.importorskip("av", reason="av not installed — skipping video_out tests")
+
 from openfilter.filter_runtime import Filter, Frame
 from openfilter.filter_runtime.test import QueueToFilters
 from openfilter.filter_runtime.utils import setLogLevelGlobal

--- a/tests/test_filter_video_out.py
+++ b/tests/test_filter_video_out.py
@@ -6,10 +6,6 @@ import os
 import shutil
 import unittest
 
-import pytest
-
-pytest.importorskip("av", reason="av not installed — skipping video_out tests")
-
 from openfilter.filter_runtime import Filter, Frame
 from openfilter.filter_runtime.test import QueueToFilters
 from openfilter.filter_runtime.utils import setLogLevelGlobal

--- a/tests/test_mq.py
+++ b/tests/test_mq.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import unittest
-from queue import Queue, Empty
+from queue import Queue
 from threading import Event, Thread
 
 from openfilter.filter_runtime import Frame
@@ -17,41 +17,7 @@ log_level = int(getattr(logging, (os.getenv('LOG_LEVEL') or 'CRITICAL').upper())
 setLogLevelGlobal(log_level)
 
 
-class ThreadMQSender(Thread):
-    def __init__(self, *args, **kwargs):
-        self.stop_evt = Event()
-        self.queue    = Queue()
-
-        super().__init__(target=self.thread_func, args=(args, kwargs), daemon=True)
-
-        self.start()
-
-    def destroy(self):
-        self.queue.put(False)  # to wake up queue getter
-        self.stop_evt.set()
-        self.join()
-
-    def send(self, frames: dict[str, Frame] | None = None):
-        self.queue.put(frames)
-
-    def thread_func(self, args, kwargs):
-        sender = MQSender(*args, **kwargs)  # important to create in this thread
-        frames = False
-
-        while not self.stop_evt.is_set():
-            if frames is False:
-                try:
-                    frames = self.queue.get(timeout=0.01)
-                except Empty:
-                    continue
-
-                if frames is False:
-                    break
-
-            if sender.send(frames, 10):
-                frames = False
-
-        sender.destroy()
+from helpers import ThreadMQSender
 
 
 class ThreadMQReceiver(Thread):


### PR DESCRIPTION
# 📦 Pull Request

## 📋 What does this PR do?

Adds a pytest-benchmark harness (`make bench`) that measures the serialization and IPC overhead of the OpenFilter runtime — the cost of moving frames between filters — separately from filter processing time.

9 benchmark groups covering frame serde, JPG codec, JSON metadata, frame format conversions, timing injection, ZMQ IPC round-trips, cv2.resize resampling, resolution scaling, and end-to-end multi-filter pipeline simulations with per-stage overhead breakdowns.

## 🔍 Why is this needed?

The runtime already has per-filter timing instrumentation (filter_timings), but there was no way to isolate the cost of the machinery *between* filters — ZMQ transport, frame serialization, JPG encode/decode, buffer copies — from the filter work itself. Without this you can't tell whether a slow pipeline needs a faster model or a faster transport, and you can't verify that an optimization actually helped.

## 🧪 How was it tested?

- `make bench` runs the full 55-test harness in ~25s
- `make test` skips benchmarks via --benchmark-disable (no regressions)
- ruff check and black --target-version py312 pass clean
- Pipeline simulation models 6 realistic topologies (480p–4K, 2–4 filters, raw and JPG transport) with real ZMQ IPC

## 🔗 Related Issues

FILTER-415 (under FILTER-367: Inference Performance & Scaling)

## 🖼️ Screenshots or Logs (if applicable)

Baseline pipeline simulation output:

| Pipeline                     | Filter | IPC OH  | OH%  | Max FPS |
|------------------------------|--------|---------|------|---------|
| 480p, 3 filters, raw         | 11.1ms | 1.3ms   | 10%  | 80.9    |
| 4K→1080p, 3 filters, raw     | 20.4ms | 6.4ms   | 24%  | 37.3    |
| 1080p, 4 filters, raw        | 35.2ms | 9.3ms   | 21%  | 22.5    |
| 4K native, 2 filters, raw    | 20.1ms | 34.5ms  | 63%  | 18.3    |

## ✅ Checklist

- [x] I have read and agreed to the terms of the LICENSE
- [x] I have read the CONTRIBUTING guide
- [x] I have followed the coding style
- [x] I have signed all commits in compliance with the DCO
- [x] I have added or updated tests as needed
- [x] I have added or updated documentation as needed