### PR TITLE
test: replace sleep-based timing with polling in ephemeral topology tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,7 +7,7 @@ from openfilter.filter_runtime import Frame
 from openfilter.filter_runtime.mq import MQSender
 
 
-def assert_empty(q, settle=0.5):
+def assert_empty(q, settle=0.2):
     """Assert that *q* receives no data within *settle* seconds.
 
     Blocks for *settle* seconds waiting on the queue. Returns

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,6 +7,19 @@ from openfilter.filter_runtime import Frame
 from openfilter.filter_runtime.mq import MQSender
 
 
+def assert_empty(q, settle=0.5):
+    """Assert that *q* receives no data within *settle* seconds.
+
+    Blocks for *settle* seconds waiting on the queue. Returns
+    if the queue stays empty, raises AssertionError otherwise.
+    """
+    try:
+        data = q.get(True, settle)
+    except Empty:
+        return
+    raise AssertionError(f'expected queue to be empty, but got: {data}')
+
+
 class ThreadMQSender(Thread):
     """Threaded MQ sender for tests — ZMQ sender blocks until a subscriber
     issues a request, so it must run in its own thread."""

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -17,6 +17,7 @@ from openfilter.filter_runtime import Filter, FilterConfig, Frame, FilterContext
 from openfilter.filter_runtime.test import RunnerContext, FiltersToQueue, QueueToFilters
 from openfilter.filter_runtime.utils import setLogLevelGlobal
 from openfilter.filter_runtime.filters.util import Util
+from tests.helpers import assert_empty
 
 logger = logging.getLogger(__name__)
 
@@ -250,58 +251,34 @@ class TestFilterOld(unittest.TestCase):
 
         try:
             qout1.put(d := {'main': {'val': 0}})
-
-            sleep(0.05)
-
             self.assertIs(runner.step(), False)
             self.assertEqual(getdatas(qin), d)
 
             qout2.put(e := {'other': {'val': 1}})
-
-            sleep(0.05)
-
             self.assertIs(runner.step(), False)
-            self.assertRaises(Empty, lambda: getdatas(qin, 0.05))
+            assert_empty(qin)
 
             qout1.put(d := {'main': {'val': 1}})
-
-            sleep(0.05)
-
             self.assertIs(runner.step(), False)
             self.assertEqual(getdatas(qin), {**d, **e})
 
             qout1.put(d := {'main': {'val': 2}})
-
-            sleep(0.05)
-
             self.assertIs(runner.step(), False)
             self.assertEqual(getdatas(qin), d)
 
             qout2.put(e := {'other': {'val': 3}})
-
-            sleep(0.05)
-
             self.assertIs(runner.step(), False)
-            self.assertRaises(Empty, lambda: getdatas(qin, 0.05))
+            assert_empty(qin)
 
             qout1.put(d := {'main': {'val': 3}})
-
-            sleep(0.05)
-
             self.assertIs(runner.step(), False)
             self.assertEqual(getdatas(qin), {**d, **e})
 
             qout2.put(e := {'other': {'val': 4}})
-
-            sleep(0.05)
-
             self.assertIs(runner.step(), False)
-            self.assertRaises(Empty, lambda: getdatas(qin, 0.05))
+            assert_empty(qin)
 
             qout1.put(d := {'main': {'val': 4}})
-
-            sleep(0.05)
-
             self.assertIs(runner.step(), False)
             self.assertEqual(getdatas(qin), {**d, **e})
 
@@ -320,14 +297,9 @@ class TestFilterOld(unittest.TestCase):
         ], exit_time=10)
 
         try:
-            sleep(0.2)
-
             qout.put(d := {'main': {'val': 0}})
             self.assertIs(runner1.step(), False)
-
-            sleep(0.1)
-
-            self.assertRaises(Empty, lambda: getdatas(qin1, 0.1))
+            assert_empty(qin1)
 
             runner2 = Filter.Runner([
                 (FilterToQueue, dict(sources='tcp://127.0.0.1?', queue=(qin2 := Queue()))),
@@ -335,18 +307,12 @@ class TestFilterOld(unittest.TestCase):
 
             try:
                 self.assertIs(runner2.step(), False)
-
-                sleep(0.1)
-
                 self.assertEqual(getdatas(qin2), d)
                 self.assertEqual(getdatas(qin1), d)
 
                 qout.put(d := {'main': {'val': 1}})
                 self.assertIs(runner1.step(), False)
                 self.assertIs(runner2.step(), False)
-
-                sleep(0.1)
-
                 self.assertEqual(getdatas(qin2), d)
                 self.assertEqual(getdatas(qin1), d)
 


### PR DESCRIPTION
## Summary

Replaces fragile `sleep()` + `assertRaises(Empty, ...)` patterns in ephemeral join/tee topology tests with a polling-based `assert_empty()` helper.

## Changes

- New `assert_empty(q, settle=0.2)` helper in `tests/helpers.py` - blocks for `settle` seconds and fails if unexpected data appears
- Refactored `test_topo_ephemeral_join_step` - removed 8 sleep calls, uses polling
- Refactored `test_topo_doubly_ephemeral_tee_step` - removed 4 sleep calls, uses polling
- Data-expected assertions rely on `getdatas()` built-in 5s blocking timeout

## Why

The `sleep(0.05)` timing was too tight for GitHub Actions runners on Python 3.13, causing flaky test failures that blocked the v0.1.28 release. Polling is deterministic regardless of runner speed.