### PR TITLE
fix(tests): use relative import for assert_empty helper

### DIFF
--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -17,7 +17,7 @@ from openfilter.filter_runtime import Filter, FilterConfig, Frame, FilterContext
 from openfilter.filter_runtime.test import RunnerContext, FiltersToQueue, QueueToFilters
 from openfilter.filter_runtime.utils import setLogLevelGlobal
 from openfilter.filter_runtime.filters.util import Util
-from tests.helpers import assert_empty
+from helpers import assert_empty
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

- Fixes `ModuleNotFoundError` when running `tests/test_filter.py` directly as a script
- Changes `from tests.helpers import assert_empty` to `from helpers import assert_empty`
- Matches the import pattern used by `test_mq.py` and `test_benchmarks.py`

## Context

Regression from PR #80. When Python runs `tests/test_filter.py` as a script, `sys.path[0]` is `tests/`, not the repo root, so `tests.helpers` cannot be imported. Pytest works fine because it adds the repo root to `sys.path`.

## Test plan

- [x] `python tests/test_filter.py --help` no longer raises `ModuleNotFoundError`
- [x] `pytest tests/test_filter.py` still passes