### PR TITLE
feat(cli): openfilter emit-schema (FILTER-442)

### DIFF
--- a/openfilter/cli/__main__.py
+++ b/openfilter/cli/__main__.py
@@ -1,6 +1,7 @@
 import sys
 
 from .common import SCRIPT
+from .cmd_emit_schema import cmd_emit_schema
 from .cmd_info import cmd_info
 from .cmd_run import cmd_run
 
@@ -9,7 +10,8 @@ def main():
     args = sys.argv[2:]
     cmd  = sys.argv[1] if len(sys.argv) > 1 else ''
 
-    if cmd_func := getattr(sys.modules[__name__], f'cmd_{cmd}', None):
+    cmd_attr = f'cmd_{cmd.replace("-", "_")}'
+    if cmd_func := getattr(sys.modules[__name__], cmd_attr, None):
         cmd_func(args)
 
     else:
@@ -17,9 +19,10 @@ def main():
 usage: {SCRIPT} COMMAND ...
 
 Commands:
-  run       Directly run one or more filter(s)
-  logs      Show filter(s) logs
-  info      Get help on a specific filter
+  run           Directly run one or more filter(s)
+  logs          Show filter(s) logs
+  info          Get help on a specific filter
+  emit-schema   Emit a filter's JSON Schema (declarative config, FC-1)
 
 Run '{SCRIPT} COMMAND --help' for more information on a command.
 """.strip())

--- a/openfilter/cli/cmd_emit_schema.py
+++ b/openfilter/cli/cmd_emit_schema.py
@@ -1,0 +1,121 @@
+"""``openfilter emit-schema`` — Goldenrod.2 FC-1 / FC-3.
+
+Imports a filter module, locates its ``FilterConfigBase`` subclass, and writes
+the emitted JSON Schema to stdout (or ``-o <path>``). This is the build-time
+half of the schema-emission contract; FC-3's transport (manifest attestation /
+sigstore / ORAS) is layered on top — the CLI's only job is to produce the
+artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import inspect
+import json
+import logging
+import os
+import sys
+from typing import Iterable
+
+from openfilter.filter_runtime.config import FilterConfigBase
+
+from .common import SCRIPT
+
+logger = logging.getLogger(__name__)
+logger.setLevel(int(getattr(logging, (os.getenv("LOG_LEVEL") or "INFO").upper())))
+
+
+def _candidate_classes(module: object) -> Iterable[type[FilterConfigBase]]:
+    for _, attr in inspect.getmembers(module, inspect.isclass):
+        if attr is FilterConfigBase:
+            continue
+        if not issubclass(attr, FilterConfigBase):
+            continue
+        if attr.__module__ != getattr(module, "__name__", None):
+            continue
+        yield attr
+
+
+def _resolve_config_class(spec: str) -> type[FilterConfigBase]:
+    """Resolve a module path or ``module:Class`` into a ``FilterConfigBase`` subclass."""
+    module_name, _, class_name = spec.partition(":")
+    module = importlib.import_module(module_name)
+
+    if class_name:
+        cls = getattr(module, class_name, None)
+        if cls is None:
+            raise SystemExit(f"{spec!r}: {class_name} not found in {module_name}")
+        if not (inspect.isclass(cls) and issubclass(cls, FilterConfigBase)):
+            raise SystemExit(
+                f"{spec!r}: {class_name} is not a FilterConfigBase subclass"
+            )
+        return cls
+
+    candidates = list(_candidate_classes(module))
+    if not candidates:
+        raise SystemExit(
+            f"{spec!r}: no FilterConfigBase subclass declared in {module_name}. "
+            f"Pass module:ClassName to disambiguate or check that the filter is migrated."
+        )
+    if len(candidates) > 1:
+        names = ", ".join(c.__name__ for c in candidates)
+        raise SystemExit(
+            f"{spec!r}: multiple FilterConfigBase subclasses found ({names}). "
+            f"Pass module:ClassName to disambiguate."
+        )
+    return candidates[0]
+
+
+def cmd_emit_schema(args: list[str]) -> None:
+    parser = argparse.ArgumentParser(
+        prog=f"{SCRIPT} emit-schema",
+        description=(
+            "Emit a filter's JSON Schema (draft 2020-12). "
+            "MODULE is an importable dotted path; optionally suffix with ':ClassName' "
+            "to disambiguate when a module declares more than one config class."
+        ),
+    )
+    parser.add_argument(
+        "MODULE",
+        help="Importable filter module (e.g. filter_template.filter) "
+        "or module:ConfigClass.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="-",
+        help="Output path; '-' (default) writes to stdout.",
+    )
+    parser.add_argument(
+        "--include-managed",
+        action="store_true",
+        help="Include platform-managed fields in the emitted schema "
+        "(default: operator-facing surface only).",
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent (default 2; pass 0 for compact).",
+    )
+
+    opts = parser.parse_args(args)
+    cls = _resolve_config_class(opts.MODULE)
+
+    schema = cls.emit_schema(include_managed=opts.include_managed)
+    schema.setdefault("title", cls.__name__)
+    schema.setdefault("$schema", "https://json-schema.org/draft/2020-12/schema")
+
+    text = json.dumps(schema, indent=opts.indent or None, sort_keys=False)
+
+    if opts.output == "-":
+        sys.stdout.write(text)
+        if not text.endswith("\n"):
+            sys.stdout.write("\n")
+    else:
+        with open(opts.output, "w", encoding="utf-8") as f:
+            f.write(text)
+            if not text.endswith("\n"):
+                f.write("\n")
+        logger.info("wrote schema for %s to %s", cls.__qualname__, opts.output)

--- a/tests/test_emit_schema_cli.py
+++ b/tests/test_emit_schema_cli.py
@@ -1,0 +1,116 @@
+"""Tests for the `openfilter emit-schema` CLI (Goldenrod.2 FC-3)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from openfilter.filter_runtime.config import MANAGED_KEY
+
+
+_SYNTH_FILTER = textwrap.dedent(
+    """
+    from typing import Literal
+    from pydantic import Field
+    from openfilter.filter_runtime.config import FilterConfigBase, Managed
+    from openfilter.filter_runtime.formats import VideoSource
+
+    class SynthFilterConfig(FilterConfigBase):
+        sources: list[VideoSource] = Managed([], resolve="orchestrator-generated")
+        confidence_threshold: float = Field(default=0.5, ge=0, le=1)
+        mode: Literal["fast", "accurate"] = "fast"
+    """
+)
+
+
+@pytest.fixture
+def synth_filter_module(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    mod_path = tmp_path / "_synth_emit_schema_filter.py"
+    mod_path.write_text(_SYNTH_FILTER)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    # Subprocess invocations also need the path
+    monkeypatch.setenv(
+        "PYTHONPATH",
+        str(tmp_path) + os.pathsep + os.environ.get("PYTHONPATH", ""),
+    )
+    return mod_path.stem
+
+
+def _run_cli(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "openfilter.cli", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_emit_schema_cli_stdout(synth_filter_module: str) -> None:
+    result = _run_cli(["emit-schema", f"{synth_filter_module}:SynthFilterConfig"])
+    assert result.returncode == 0, result.stderr
+    schema = json.loads(result.stdout)
+    assert schema["title"] == "SynthFilterConfig"
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    props = schema["properties"]
+    assert "sources" not in props  # managed by default
+    assert "confidence_threshold" in props
+    assert props["mode"]["enum"] == ["fast", "accurate"]
+
+
+def test_emit_schema_cli_writes_file(
+    synth_filter_module: str, tmp_path: Path
+) -> None:
+    out = tmp_path / "schema.json"
+    result = _run_cli(
+        [
+            "emit-schema",
+            f"{synth_filter_module}:SynthFilterConfig",
+            "-o",
+            str(out),
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    schema = json.loads(out.read_text())
+    assert "confidence_threshold" in schema["properties"]
+
+
+def test_emit_schema_cli_include_managed_surfaces_overrides(
+    synth_filter_module: str,
+) -> None:
+    result = _run_cli(
+        [
+            "emit-schema",
+            f"{synth_filter_module}:SynthFilterConfig",
+            "--include-managed",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    schema = json.loads(result.stdout)
+    sources = schema["properties"]["sources"]
+    assert sources[MANAGED_KEY] is True
+    assert sources["items"]["format"] == "video-source"
+
+
+def test_emit_schema_cli_auto_picks_single_class(
+    synth_filter_module: str,
+) -> None:
+    result = _run_cli(["emit-schema", synth_filter_module])
+    assert result.returncode == 0, result.stderr
+    schema = json.loads(result.stdout)
+    assert schema["title"] == "SynthFilterConfig"
+
+
+def test_emit_schema_cli_fails_on_unknown_class(
+    synth_filter_module: str,
+) -> None:
+    result = _run_cli(
+        ["emit-schema", f"{synth_filter_module}:NotARealClass"]
+    )
+    assert result.returncode != 0
+    assert "NotARealClass" in result.stderr or "NotARealClass" in result.stdout


### PR DESCRIPTION
# 📦 Pull Request

## 📋 What does this PR do?

Adds the `openfilter emit-schema <module>[:Class]` CLI subcommand — the build-time producer half of the FC-3 schema-transport contract. The command imports a filter module, locates its `FilterConfigBase` subclass, and writes the emitted JSON Schema (draft 2020-12) to stdout (default) or `-o <path>`. Filter Dockerfiles invoke this at build time; the resulting JSON is pushed as a sibling OCI artifact (`application/vnd.openfilter.schema+json`) and the image manifest is stamped with a `com.plainsight.openfilter.schema` label carrying the artifact's sha256 digest.

Specifically:

- New `openfilter/cli/cmd_emit_schema.py` — argparse-driven subcommand with `module` / `module:Class` resolution, automatic candidate detection (errors out cleanly when a module declares 0 or 2+ `FilterConfigBase` subclasses), `--include-managed` opt-in to surface platform-managed fields, and `-o <path>` output redirection.
- Tweak the `openfilter` CLI dispatcher (`openfilter/cli/__main__.py`) to translate `cmd-with-hyphens` to `cmd_with_hyphens` so subcommands can use their canonical hyphenated spellings without breaking the underscore-named Python handler convention.
- 5 unit tests in `tests/test_emit_schema_cli.py` covering stdout output, `-o <path>`, `--include-managed`, single-class auto-pick, and unknown-class failure.

The wiring of the sibling-artifact upload + label-stamping into `cloudbuild-cascade.yaml` is tracked as a sub-step of [FILTER-442](https://plainsight-ai.atlassian.net/browse/FILTER-442); it depends on PLAT-side FC-5 ingest and lands separately.

---

## 🔍 Why is this needed?

[FILTER-441](https://plainsight-ai.atlassian.net/browse/FILTER-441) landed `FilterConfigBase.emit_schema()` — the in-process serializer that produces each filter's JSON Schema. This PR is the CLI wrapper Dockerfiles invoke at build time so the artifact can ride alongside the image without a Python-runtime hop in the platform's ingest path.

Once both are in place, the transport contract closes: filter CI emits the schema, pushes it as a sibling OCI artifact, and stamps the image manifest's `com.plainsight.openfilter.schema` label with the sha256 digest. The platform fetches the artifact by digest from the same registry without pulling the filter image's layers. Integrity is transitively protected by whatever trust we already place in the registry serving the image bytes — no separate key infrastructure needed.

(Cosign-signed attestations were considered for the transport but deferred to a future-driver-only ticket — see
[FILTER-448](https://plainsight-ai.atlassian.net/browse/FILTER-448), closed Won't Do — the marginal threat surface didn't justify standing up KMS for the first internal use.)

---

## 🧪 How was it tested?

5 unit tests in `tests/test_emit_schema_cli.py`:

- `test_emit_schema_cli_stdout` — `module:Class` spec, stdout output, `$schema` keyword + managed-field stripping
- `test_emit_schema_cli_writes_file` — `-o <path>` redirection
- `test_emit_schema_cli_include_managed_surfaces_overrides` — `--include-managed` round-trips FC-2 markers
- `test_emit_schema_cli_auto_picks_single_class` — module-only spec finds the lone `FilterConfigBase` subclass
- `test_emit_schema_cli_fails_on_unknown_class` — typo'd class name errors out cleanly

```
$ uv run --with pytest pytest tests/test_emit_schema_cli.py -q
.....                                                                    [100%]
5 passed in 1.79s
```

Combined with [FILTER-441](https://plainsight-ai.atlassian.net/browse/FILTER-441)'s config-side suite (already merged in #86, 46 tests), the full FC-1 / FC-1.5 / FC-2 / FC-3-emission contract has 51 tests exercising it end-to-end.

---

## 🔗 Related Issues

- [FILTER-442](https://plainsight-ai.atlassian.net/browse/FILTER-442) — this ticket
- [FILTER-441](https://plainsight-ai.atlassian.net/browse/FILTER-441) — `FilterConfigBase.emit_schema()` (merged in #86)
- [FILTER-440](https://plainsight-ai.atlassian.net/browse/FILTER-440) — Declarative Configuration Contract (parent epic)
- [FILTER-448](https://plainsight-ai.atlassian.net/browse/FILTER-448) — cosign / KMS signing (closed Won't Do; revisit on concrete compliance/multi-tenancy driver)

---

## 🖼️ Screenshots or Logs (if applicable)

```
$ openfilter emit-schema my_filter.filter --include-managed
{
  "title": "MyFilterConfig",
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "properties": {
    "sources": {
      "items": {"format": "video-source", "type": "string"},
      "type": "array",
      "x-openfilter-managed": true,
      "x-openfilter-resolve": "orchestrator-generated"
    },
    "confidence_threshold": {
      "type": "number", "minimum": 0, "maximum": 1, "default": 0.5
    },
    ...
  }
}
```

---

## ✅ Checklist

- [x] I have read and agreed to the terms of the [LICENSE](../LICENSE)
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have followed the [coding style](../CONTRIBUTING.md#coding-style)
- [x] I have signed all commits in compliance with the DCO (`git commit -s`)
- [x] I have added or updated **tests** as needed
- [x] I have added or updated **documentation** as needed (`docs/declarative-config.md`'s "Schema emission" section, landed with FILTER-441 in #86, already describes this CLI's surface)

[FILTER-442]: https://plainsight-ai.atlassian.net/browse/FILTER-442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ