### PR TITLE
ci: dismiss stale approvals via external-review-freshness for untrusted PRs

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -16,7 +16,7 @@
       "type": "pull_request",
       "parameters": {
         "required_approving_review_count": 1,
-        "dismiss_stale_reviews_on_push": true,
+        "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": true,
         "require_last_push_approval": false,
         "required_review_thread_resolution": false,

--- a/.github/workflows/external-review-freshness.yaml
+++ b/.github/workflows/external-review-freshness.yaml
@@ -20,6 +20,15 @@ permissions:
   pull-requests: write
   contents: read
 
+# Per-PR concurrency: a force-push or rapid fixup-push fires `synchronize`
+# twice in quick succession, queuing two dismissal runs against the same
+# review set. Cancel the older run so only the latest push's freshness check
+# survives — avoids racy double-dismiss attempts and a transient PR state
+# where stale runs flap the approval.
+concurrency:
+  group: external-review-freshness-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   dismiss:
     runs-on: ubuntu-latest

--- a/.github/workflows/external-review-freshness.yaml
+++ b/.github/workflows/external-review-freshness.yaml
@@ -1,0 +1,30 @@
+name: External review freshness
+
+# Dismiss APPROVED reviews when an untrusted contributor (typically a fork
+# drive-by) pushes new commits. Replaces the GitHub-native
+# `dismiss_stale_reviews_on_push` rule (now off in .github/rulesets/main.json),
+# which dismissed approvals on *every* push including trusted-maintainer
+# self-pushes. This action keys trust on the PR author's repo collaborator
+# permission (admin/maintain/write → trusted) and only dismisses for
+# everyone else, so a maintainer's own fixup commit no longer invalidates a
+# fresh approval.
+#
+# Must run on pull_request_target (not pull_request) so the job has
+# base-repo permissions to dismiss reviews on fork PRs.
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  dismiss:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: PlainsightAI/gh-actions-public/external-review-freshness@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: "false"


### PR DESCRIPTION
## 📋 What does this PR do?

Replaces GitHub's built-in `dismiss_stale_reviews_on_push` rule with the `PlainsightAI/gh-actions-public/external-review-freshness` composite action. The native rule fires on every push, including trusted-maintainer fixups. The action only dismisses APPROVED reviews when the PR author lacks admin/maintain/write collaborator permission — i.e. fork drive-bys.

- `.github/rulesets/main.json`: flip `dismiss_stale_reviews_on_push` true → false on the `pull_request` rule. The existing `apply-rulesets` workflow reconciles the live ruleset (`id=5556771`) on push to main.
- `.github/workflows/external-review-freshness.yaml`: new workflow on `pull_request_target` / `synchronize`. Permissions `pull-requests: write` + `contents: read`. Calls the action with the intrinsic `GITHUB_TOKEN` and `dry-run: "false"`.

## 🔍 Why is this needed?

The native stale-review dismissal is a blunt instrument: a maintainer pushing a one-line fixup invalidates a fresh approval. The freshness action keys trust on the PR author's collaborator role, so trusted contributors retain approvals across their own pushes while fork drive-bys still force re-review — which is the actual security need.

## 🧪 How was it tested?

- [ ] After merge: `apply-rulesets` reconciles live ruleset 5556771 (`dismiss_stale_reviews_on_push: false`).
- [ ] Fork PR with APPROVED review + new fork push → approval dismissed, dismissal message posted.
- [ ] Maintainer fixup push to own-branch PR with approval → approval kept.
- [ ] Workflow runs only on `synchronize` (not on `opened`/`reopened`).

## 🔗 Related Issues

N/A — CI plumbing

## 🖼️ Screenshots or Logs (if applicable)

N/A.

## ✅ Checklist

- [x] I have read and agreed to the terms of the [LICENSE](../LICENSE)
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have followed the [coding style](../CONTRIBUTING.md#coding-style)
- [x] I have signed all commits in compliance with the DCO (`git commit -s`)
- [ ] I have added or updated **tests** as needed _(N/A — workflow change)_
- [ ] I have added or updated **documentation** as needed _(N/A)_