### PR TITLE
feat(cascade): widen `<` / `<=` upper bounds that exclude OF_VERSION

### DIFF
--- a/scripts/cascade/bump-strategy.sh
+++ b/scripts/cascade/bump-strategy.sh
@@ -14,18 +14,30 @@ set -euo pipefail
 BUMP_HELPER_DIR=$(mktemp -d)
 trap 'rm -rf "${BUMP_HELPER_DIR}"' EXIT
 cat > "${BUMP_HELPER_DIR}/_bump.py" <<'HELPER'
-"""rewrite_requirement: bump ==/>=/~= clauses in a PEP 508 requirement.
+"""rewrite_requirement: bump ==/>=/~= clauses in a PEP 508 requirement,
+and widen `<` / `<=` upper bounds that would otherwise exclude OF_VERSION.
 
-Lower-bound clauses go to OF_VERSION; upper-bound clauses (<, <=, !=),
-clause order, surrounding whitespace, and any environment marker are
-preserved verbatim.
+Lower-bound clauses (==, >=, ~=) go to OF_VERSION. Upper-bound clauses
+(<, <=) are widened to admit OF_VERSION when they currently exclude it;
+otherwise they stay verbatim. != exclusions, `>` lower bounds, clause
+order, surrounding whitespace, and any environment marker are preserved
+verbatim regardless.
+
+Widening rule for the new upper bound:
+    * target.major == 0 (pre-1.0 / unstable): `<target.major>.<target.minor + 1>.0`
+      (e.g. 0.2.0 -> 0.3.0). Matches the org's existing "track next minor"
+      pin pattern for 0.X filters.
+    * target.major >= 1: `<target.major + 1>.0.0` (e.g. 1.0.0 -> 2.0.0).
+      Standard SemVer "track next major" for post-1.0 filters.
 """
 from __future__ import annotations
 
 from packaging.requirements import Requirement
 from packaging.specifiers import Specifier
+from packaging.version import Version
 
 _BUMPABLE_OPS = ("==", ">=", "~=")
+_UPPER_BOUND_OPS = ("<", "<=")
 
 
 def _specifier_span(text: str, req: Requirement) -> tuple[int, int]:
@@ -54,10 +66,20 @@ def _specifier_span(text: str, req: Requirement) -> tuple[int, int]:
     return spec_start, spec_end
 
 
+def next_upper_bound(target: Version) -> str:
+    """Compute the widened upper bound to admit `target` and a reasonable
+    forward range. See module docstring for the rule.
+    """
+    if target.major == 0:
+        return f"0.{target.minor + 1}.0"
+    return f"{target.major + 1}.0.0"
+
+
 def rewrite_requirement(old: str, of_version: str) -> str:
     req = Requirement(old)
     if not req.specifier:
         return old
+    target = Version(of_version)
     spec_start, spec_end = _specifier_span(old, req)
     spec_text = old[spec_start:spec_end]
     new_clauses: list[str] = []
@@ -68,13 +90,25 @@ def rewrite_requirement(old: str, of_version: str) -> str:
             new_clauses.append(raw)
             continue
         s = Specifier(stripped)
+        leading = raw[: len(raw) - len(raw.lstrip())]
+        trailing = raw[len(raw.rstrip()) :]
         if s.operator in _BUMPABLE_OPS:
-            leading = raw[: len(raw) - len(raw.lstrip())]
-            trailing = raw[len(raw.rstrip()) :]
             new_clauses.append(f"{leading}{s.operator}{of_version}{trailing}")
             bumped = True
-        else:
-            new_clauses.append(raw)
+            continue
+        if s.operator in _UPPER_BOUND_OPS:
+            bound = Version(s.version)
+            needs_widen = (
+                (s.operator == "<" and target >= bound)
+                or (s.operator == "<=" and target > bound)
+            )
+            if needs_widen:
+                new_clauses.append(
+                    f"{leading}<{next_upper_bound(target)}{trailing}"
+                )
+                bumped = True
+                continue
+        new_clauses.append(raw)
     if not bumped:
         return old
     return old[:spec_start] + ",".join(new_clauses) + old[spec_end:]

--- a/scripts/cascade/check_constraint.py
+++ b/scripts/cascade/check_constraint.py
@@ -12,10 +12,14 @@ silent "no openfilter dep" line.
 
 `widen:<spec>` — OF_VERSION is outside the current constraint and every
 blocking clause is one bump-strategy.sh's rewriter can rewrite in place
-(`<`, `<=`, `==`, `~=`, `>=`). `skip:<spec>` is reserved for blocks the
-rewriter can't handle: `!=X` exclusions and `>X` strict lower bounds.
+without downgrading: `<`, `<=`, `==`, `~=`. `skip:<spec>` covers the rest:
+`!=X` and `>X` (rewriter has no rule), and `>=X` blocking (rewriter has
+`>=` in `_BUMPABLE_OPS`, but a `>=X` clause only blocks when target < X,
+so applying that rule would downgrade the consumer's floor — different
+semantic category from widening, kept as a skip-class guardrail).
 Cascade PRs are human-reviewed before merge, so the split exists to filter
-mechanically-unhandled clauses, not to gate operator-intent decisions.
+mechanically-unhandled-or-unsafe clauses, not to gate operator-intent
+decisions.
 
 When openfilter appears in MULTIPLE PEP 621 tables (e.g. [project.dependencies]
 AND [project.optional-dependencies.gpu]), all matching specifiers are
@@ -36,7 +40,7 @@ def _is_widenable_block(combined: SpecifierSet, target: Version) -> bool:
     for s in combined:
         if target in SpecifierSet(str(s)):
             continue
-        if s.operator in ("<", "<=", "==", "~=", ">="):
+        if s.operator in ("<", "<=", "==", "~="):
             continue
         return False
     return True

--- a/scripts/cascade/check_constraint.py
+++ b/scripts/cascade/check_constraint.py
@@ -1,7 +1,7 @@
 """Check openfilter version constraint compatibility.
 
 Reads OF_VERSION from env, scans pyproject.toml for openfilter dependency.
-Outputs: none | none:poetry-format | ok:<spec> | skip:<spec> | error:<msg>
+Outputs: none | none:poetry-format | ok:<spec> | widen:<spec> | skip:<spec> | error:<msg>
 
 `none:poetry-format` is emitted when no openfilter dep was found in PEP 621
 [project.dependencies] / [project.optional-dependencies] but one IS present
@@ -9,6 +9,14 @@ under Poetry's [tool.poetry.dependencies] (or dev-dependencies). The cascade
 only knows how to rewrite PEP 621 pins, so Poetry consumers are still
 skipped — but the operator gets a distinguishable diagnostic instead of a
 silent "no openfilter dep" line.
+
+`widen:<spec>` means OF_VERSION is outside the current constraint, BUT the
+only blocking clauses are upper bounds (`<` / `<=`) that bump-strategy.sh
+can safely widen. `skip:<spec>` is reserved for blocks the cascade refuses
+to rewrite automatically: lower-bound exclusions (would be a downgrade) and
+explicit `!=` exclusions (deliberate gating). Splitting `widen` from `skip`
+lets the cascade discover this filter as eligible while keeping a hard
+boundary against silent semantic regressions.
 
 When openfilter appears in MULTIPLE PEP 621 tables (e.g. [project.dependencies]
 AND [project.optional-dependencies.gpu]), all matching specifiers are
@@ -20,8 +28,30 @@ the optional specifier rejects.
 import sys, os, tomllib
 
 from packaging.requirements import Requirement
-from packaging.specifiers import SpecifierSet
+from packaging.specifiers import Specifier, SpecifierSet
 from packaging.version import Version
+
+
+def _is_widenable_block(combined: SpecifierSet, target: Version) -> bool:
+    """True when every clause that excludes `target` is a widenable upper bound.
+
+    Widenable: `<X` or `<=X` — bump-strategy.sh's rewriter handles these
+    in place.
+
+    Not widenable: `>=X` / `>X` lower bounds (widening would be a downgrade),
+    `!=X` exclusions (deliberate gating), and `==X` / `~=X` pins (the
+    rewriter can bump these in place, but if they're still excluding
+    target after intersection it means another clause makes the situation
+    unsalvageable; operator should inspect).
+    """
+    for s in combined:
+        if target in SpecifierSet(str(s)):
+            continue
+        if s.operator in ("<", "<="):
+            continue
+        return False
+    return True
+
 
 try:
     if not os.path.exists("pyproject.toml"):
@@ -65,6 +95,11 @@ try:
         sys.exit(0)
     v = Version(v_str)
     spec_str = str(combined)
-    print(("ok:" if v in combined else "skip:") + spec_str)
+    if v in combined:
+        print("ok:" + spec_str)
+    elif _is_widenable_block(combined, v):
+        print("widen:" + spec_str)
+    else:
+        print("skip:" + spec_str)
 except Exception as e:
     print("error:" + str(e))

--- a/scripts/cascade/check_constraint.py
+++ b/scripts/cascade/check_constraint.py
@@ -10,13 +10,12 @@ only knows how to rewrite PEP 621 pins, so Poetry consumers are still
 skipped — but the operator gets a distinguishable diagnostic instead of a
 silent "no openfilter dep" line.
 
-`widen:<spec>` means OF_VERSION is outside the current constraint, BUT the
-only blocking clauses are upper bounds (`<` / `<=`) that bump-strategy.sh
-can safely widen. `skip:<spec>` is reserved for blocks the cascade refuses
-to rewrite automatically: lower-bound exclusions (would be a downgrade) and
-explicit `!=` exclusions (deliberate gating). Splitting `widen` from `skip`
-lets the cascade discover this filter as eligible while keeping a hard
-boundary against silent semantic regressions.
+`widen:<spec>` — OF_VERSION is outside the current constraint and every
+blocking clause is one bump-strategy.sh's rewriter can rewrite in place
+(`<`, `<=`, `==`, `~=`, `>=`). `skip:<spec>` is reserved for blocks the
+rewriter can't handle: `!=X` exclusions and `>X` strict lower bounds.
+Cascade PRs are human-reviewed before merge, so the split exists to filter
+mechanically-unhandled clauses, not to gate operator-intent decisions.
 
 When openfilter appears in MULTIPLE PEP 621 tables (e.g. [project.dependencies]
 AND [project.optional-dependencies.gpu]), all matching specifiers are
@@ -33,21 +32,11 @@ from packaging.version import Version
 
 
 def _is_widenable_block(combined: SpecifierSet, target: Version) -> bool:
-    """True when every clause that excludes `target` is a widenable upper bound.
-
-    Widenable: `<X` or `<=X` — bump-strategy.sh's rewriter handles these
-    in place.
-
-    Not widenable: `>=X` / `>X` lower bounds (widening would be a downgrade),
-    `!=X` exclusions (deliberate gating), and `==X` / `~=X` pins (the
-    rewriter can bump these in place, but if they're still excluding
-    target after intersection it means another clause makes the situation
-    unsalvageable; operator should inspect).
-    """
+    """True when every clause excluding `target` is one bump-strategy.sh rewrites."""
     for s in combined:
         if target in SpecifierSet(str(s)):
             continue
-        if s.operator in ("<", "<="):
+        if s.operator in ("<", "<=", "==", "~=", ">="):
             continue
         return False
     return True

--- a/scripts/cascade/discover.sh
+++ b/scripts/cascade/discover.sh
@@ -8,10 +8,11 @@
 #   3. Has a VERSION file at the default branch tip
 #   4. Declares an `openfilter` PEP 621 dependency whose constraint either
 #      already permits ${OF_VERSION} (check_constraint.py emits `ok:`) or
-#      is only blocked by a widenable upper bound (`<` / `<=`) that
-#      bump-strategy.sh's rewriter will rewrite in place (emits `widen:`).
-#      Lower-bound exclusions (downgrades) and `!=` exclusions still
-#      `skip:`.
+#      is blocked only by clauses bump-strategy.sh's rewriter can adjust
+#      without downgrading (`<` / `<=` upper bounds, `==` / `~=` pins —
+#      emits `widen:`). `>=X` blocking floors stay `skip:` (rewriting them
+#      would downgrade the consumer); `!=X` exclusions and `>X` strict
+#      lower bounds stay `skip:` (rewriter has no rule).
 # Required env: OF_VERSION (bare semver), GH_TOKEN (plainsight-bot PAT).
 # Optional env: SINGLE_FILTER (precedes), FILTER_SUBSET (comma-separated).
 # Note: SINGLE_FILTER not-found hard-exits — behavior change vs build-filters.sh,
@@ -177,12 +178,13 @@ while IFS= read -r REPO; do
       # Eligible — target already permitted by the current pin range.
       ;;
     widen:*)
-      # Eligible — target outside the current pin range but only by an
-      # upper bound (< / <=). bump-strategy.sh's rewriter will widen it
-      # using next_upper_bound() (next-minor-after-target for 0.X,
-      # next-major-after-target for 1.0+). Surfaced separately in
-      # diagnostics so the operator knows this PR is more than a
-      # lower-bound bump.
+      # Eligible — target outside the current pin range, but every
+      # blocking clause is one bump-strategy.sh's rewriter can adjust
+      # without downgrading: `<` / `<=` upper bounds (widened to a fresh
+      # upper bound via next_upper_bound() — next-minor-after-target for
+      # 0.X, next-major-after-target for 1.0+) and `==` / `~=` pins
+      # (re-pointed to OF_VERSION). Surfaced separately in diagnostics so
+      # the operator knows this PR is more than a lower-bound bump.
       CONSTRAINT="${COMPAT#widen:}"
       echo "  ${REPO}: eligible — pin ${CONSTRAINT} will be widened for ${OF_VERSION}" >&2
       ;;

--- a/scripts/cascade/discover.sh
+++ b/scripts/cascade/discover.sh
@@ -6,8 +6,12 @@
 #   1. `filter-*` name and not on the static exclude list
 #   2. No `.github/no-cascade-openfilter` opt-out marker
 #   3. Has a VERSION file at the default branch tip
-#   4. Declares an `openfilter` PEP 621 dependency whose constraint allows
-#      ${OF_VERSION} (delegated to scripts/cascade/check_constraint.py)
+#   4. Declares an `openfilter` PEP 621 dependency whose constraint either
+#      already permits ${OF_VERSION} (check_constraint.py emits `ok:`) or
+#      is only blocked by a widenable upper bound (`<` / `<=`) that
+#      bump-strategy.sh's rewriter will rewrite in place (emits `widen:`).
+#      Lower-bound exclusions (downgrades) and `!=` exclusions still
+#      `skip:`.
 # Required env: OF_VERSION (bare semver), GH_TOKEN (plainsight-bot PAT).
 # Optional env: SINGLE_FILTER (precedes), FILTER_SUBSET (comma-separated).
 # Note: SINGLE_FILTER not-found hard-exits — behavior change vs build-filters.sh,
@@ -170,7 +174,17 @@ while IFS= read -r REPO; do
       SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
       continue ;;
     ok:*)
-      # Eligible.
+      # Eligible — target already permitted by the current pin range.
+      ;;
+    widen:*)
+      # Eligible — target outside the current pin range but only by an
+      # upper bound (< / <=). bump-strategy.sh's rewriter will widen it
+      # using next_upper_bound() (next-minor-after-target for 0.X,
+      # next-major-after-target for 1.0+). Surfaced separately in
+      # diagnostics so the operator knows this PR is more than a
+      # lower-bound bump.
+      CONSTRAINT="${COMPAT#widen:}"
+      echo "  ${REPO}: eligible — pin ${CONSTRAINT} will be widened for ${OF_VERSION}" >&2
       ;;
     skip:*)
       CONSTRAINT="${COMPAT#skip:}"

--- a/tests/test_cascade_bump_strategy.py
+++ b/tests/test_cascade_bump_strategy.py
@@ -319,6 +319,37 @@ def test_requirements_widens_upper_bound(tmp_path: Path) -> None:
     assert req.read_text() == "openfilter>=0.2.0,<0.3.0\n"
 
 
+def test_pyproject_tilde_pin_bumps_in_place(tmp_path: Path) -> None:
+    """`~=0.1.30` cascading to 0.3.0 — rewriter emits `~=0.3.0`.
+
+    Companion to the `widen:` classification in check_constraint.py: the
+    classifier dispatches `~=` pins, and the rewriter handles them via
+    _BUMPABLE_OPS.
+    """
+    py = tmp_path / "pyproject.toml"
+    py.write_text(
+        '[project]\n'
+        'name = "filter-x"\n'
+        'version = "0.0.1"\n'
+        'dependencies = ["openfilter[all]~=0.1.30"]\n'
+    )
+    _run(tmp_path, of_version="0.3.0")
+    assert '"openfilter[all]~=0.3.0"' in py.read_text()
+
+
+def test_pyproject_exact_pin_bumps_in_place(tmp_path: Path) -> None:
+    """`==0.1.18` cascading to 0.3.0 — rewriter emits `==0.3.0`."""
+    py = tmp_path / "pyproject.toml"
+    py.write_text(
+        '[project]\n'
+        'name = "filter-x"\n'
+        'version = "0.0.1"\n'
+        'dependencies = ["openfilter==0.1.18"]\n'
+    )
+    _run(tmp_path, of_version="0.3.0")
+    assert '"openfilter==0.3.0"' in py.read_text()
+
+
 def test_pyproject_widening_is_idempotent(tmp_path: Path) -> None:
     """Re-running bump-strategy on an already-widened pin is a no-op."""
     py = tmp_path / "pyproject.toml"

--- a/tests/test_cascade_bump_strategy.py
+++ b/tests/test_cascade_bump_strategy.py
@@ -223,3 +223,114 @@ def test_pyproject_idempotent_rerun_is_noop(tmp_path: Path) -> None:
     _run(tmp_path)
     second = py.read_text()
     assert first == second
+
+
+# ───────────────────────── upper-bound widening ──────────────────────────
+# DT-145 augmentation: bump-strategy.sh now widens `<` / `<=` upper bounds
+# that would exclude OF_VERSION. Widening rule: for 0.X targets, next minor
+# after target; for 1.0+ targets, next major after target. Lower bounds
+# (`>=`), exclusions (`!=`), and `>` clauses are still preserved verbatim.
+
+
+def test_pyproject_widens_upper_bound_for_0_x_target(tmp_path: Path) -> None:
+    """Org-canonical case: filter pinning `>=0.1.30,<0.2.0` cascades to 0.2.0."""
+    py = tmp_path / "pyproject.toml"
+    py.write_text(
+        '[project]\n'
+        'name = "filter-x"\n'
+        'version = "0.0.1"\n'
+        'dependencies = ["openfilter[all]>=0.1.30,<0.2.0"]\n'
+    )
+    _run(tmp_path, of_version="0.2.0")
+    rewritten = py.read_text()
+    # Lower bound bumped to target; upper bound widened to next minor.
+    assert '"openfilter[all]>=0.2.0,<0.3.0"' in rewritten
+
+
+def test_pyproject_widens_upper_bound_for_1_0_target(tmp_path: Path) -> None:
+    """1.0+ targets widen to next-major rather than next-minor."""
+    py = tmp_path / "pyproject.toml"
+    py.write_text(
+        '[project]\n'
+        'name = "filter-x"\n'
+        'version = "0.0.1"\n'
+        'dependencies = ["openfilter>=0.2.0,<1.0.0"]\n'
+    )
+    _run(tmp_path, of_version="1.0.0")
+    rewritten = py.read_text()
+    assert '"openfilter>=1.0.0,<2.0.0"' in rewritten
+
+
+def test_pyproject_widens_le_upper_bound(tmp_path: Path) -> None:
+    """`<=X` upper bound widens when target > X."""
+    py = tmp_path / "pyproject.toml"
+    py.write_text(
+        '[project]\n'
+        'name = "filter-x"\n'
+        'version = "0.0.1"\n'
+        'dependencies = ["openfilter>=0.1.30,<=0.1.99"]\n'
+    )
+    _run(tmp_path, of_version="0.2.0")
+    rewritten = py.read_text()
+    # Both `<=` and `<` widen to the `<<next>` form.
+    assert '"openfilter>=0.2.0,<0.3.0"' in rewritten
+
+
+def test_pyproject_does_not_widen_when_upper_bound_already_admits_target(
+    tmp_path: Path,
+) -> None:
+    """No widening when `<X` already permits target — bound preserved verbatim."""
+    py = tmp_path / "pyproject.toml"
+    py.write_text(
+        '[project]\n'
+        'name = "filter-x"\n'
+        'version = "0.0.1"\n'
+        'dependencies = ["openfilter>=0.1.10,<2"]\n'
+    )
+    _run(tmp_path, of_version="1.2.3")
+    rewritten = py.read_text()
+    # Lower bound bumped; upper bound `<2` preserved verbatim (1.2.3 < 2).
+    assert '"openfilter>=1.2.3,<2"' in rewritten
+
+
+def test_pyproject_preserves_inline_comment_when_widening(tmp_path: Path) -> None:
+    """tomlkit + the rewriter together preserve the trailing inline comment
+    even though both the lower and upper bound are rewritten."""
+    py = tmp_path / "pyproject.toml"
+    py.write_text(
+        '[project]\n'
+        'name = "filter-x"\n'
+        'version = "0.0.1"\n'
+        'dependencies = [\n'
+        '    "openfilter>=0.1.30,<0.2.0",  # widened by cascade on 0.2.0 release\n'
+        ']\n'
+    )
+    _run(tmp_path, of_version="0.2.0")
+    rewritten = py.read_text()
+    assert '"openfilter>=0.2.0,<0.3.0"' in rewritten
+    assert "# widened by cascade on 0.2.0 release" in rewritten
+
+
+def test_requirements_widens_upper_bound(tmp_path: Path) -> None:
+    """requirements.txt path goes through the same _bump.py helper."""
+    req = tmp_path / "requirements.txt"
+    req.write_text("openfilter>=0.1.30,<0.2.0\n")
+    _run(tmp_path, of_version="0.2.0")
+    assert req.read_text() == "openfilter>=0.2.0,<0.3.0\n"
+
+
+def test_pyproject_widening_is_idempotent(tmp_path: Path) -> None:
+    """Re-running bump-strategy on an already-widened pin is a no-op."""
+    py = tmp_path / "pyproject.toml"
+    py.write_text(
+        '[project]\n'
+        'name = "filter-x"\n'
+        'version = "0.0.1"\n'
+        'dependencies = ["openfilter>=0.1.30,<0.2.0"]\n'
+    )
+    _run(tmp_path, of_version="0.2.0")
+    first = py.read_text()
+    _run(tmp_path, of_version="0.2.0")
+    second = py.read_text()
+    assert first == second
+    assert '"openfilter>=0.2.0,<0.3.0"' in second

--- a/tests/test_cascade_check_constraint.py
+++ b/tests/test_cascade_check_constraint.py
@@ -43,6 +43,10 @@ pytestmark = [
         not _module_available("packaging"),
         reason="`packaging` required for check_constraint.py",
     ),
+    pytest.mark.skipif(
+        sys.version_info < (3, 11),
+        reason="check_constraint.py uses stdlib `tomllib` (3.11+); cascade runs on GHA Python 3.11+",
+    ),
 ]
 
 

--- a/tests/test_cascade_check_constraint.py
+++ b/tests/test_cascade_check_constraint.py
@@ -9,9 +9,11 @@ policy: which pin shapes get auto-cascaded vs. left to operators.
 Coverage:
 - `<X` / `<=X` upper bounds — widenable (historical behavior).
 - `~=X` / `==X` pins — widenable. Almost half the filter fleet uses `~=` per
-  org convention (Mundim's stylistic preference, no semantic intent claim);
-  classifying them as skip strands them out of the cascade.
-- `!=X` exclusions and `>X` strict lower bounds — skip (rewriter can't handle).
+  org convention; classifying them as skip strands them out of the cascade.
+- `!=X` exclusions, `>X` strict lower bounds, and `>=X` blocking floors —
+  skip. The first two have no rewriter rule; `>=X` does have one in
+  `_BUMPABLE_OPS`, but only blocks when target < X, so applying it would
+  downgrade the consumer's stated floor — kept as a skip-class guardrail.
 """
 
 from __future__ import annotations
@@ -110,6 +112,18 @@ def test_not_equal_blocking_is_skip(tmp_path: Path) -> None:
 def test_gt_strict_lower_bound_blocking_is_skip(tmp_path: Path) -> None:
     """`>X` strict lower bound — not in the rewriter's handled op set."""
     _write_pyproject(tmp_path, "openfilter>0.3.0")
+    assert _run(tmp_path, of_version="0.3.0").startswith("skip:")
+
+
+def test_ge_lower_bound_blocking_is_skip(tmp_path: Path) -> None:
+    """`>=X` floor above target — skip, even though the rewriter could rewrite it.
+
+    `>=0.5.0` with target 0.3.0 is a blocking floor: target < floor. The
+    rewriter has `>=` in `_BUMPABLE_OPS` and would emit `>=0.3.0`, but that
+    is a downgrade of the consumer's stated minimum, not a widening. Kept
+    as a skip-class guardrail so the cascade never silently downgrades.
+    """
+    _write_pyproject(tmp_path, "openfilter>=0.5.0")
     assert _run(tmp_path, of_version="0.3.0").startswith("skip:")
 
 

--- a/tests/test_cascade_check_constraint.py
+++ b/tests/test_cascade_check_constraint.py
@@ -1,0 +1,147 @@
+"""Classifier output tests for scripts/cascade/check_constraint.py.
+
+The classifier emits `ok:` / `widen:` / `skip:` / `none*` / `error:` against a
+consumer pyproject.toml in CWD. discover.sh reads this and decides whether to
+dispatch a bump PR. Anything classified `skip:` is stranded — the cascade
+ignores it — so the boundary between `widen:` and `skip:` is the load-bearing
+policy: which pin shapes get auto-cascaded vs. left to operators.
+
+Coverage:
+- `<X` / `<=X` upper bounds — widenable (historical behavior).
+- `~=X` / `==X` pins — widenable. Almost half the filter fleet uses `~=` per
+  org convention (Mundim's stylistic preference, no semantic intent claim);
+  classifying them as skip strands them out of the cascade.
+- `!=X` exclusions and `>X` strict lower bounds — skip (rewriter can't handle).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "cascade" / "check_constraint.py"
+
+
+def _module_available(name: str) -> bool:
+    try:
+        __import__(name)
+    except ImportError:
+        return False
+    return True
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not SCRIPT.exists(), reason="check_constraint.py not present in this checkout"
+    ),
+    pytest.mark.skipif(
+        not _module_available("packaging"),
+        reason="`packaging` required for check_constraint.py",
+    ),
+]
+
+
+def _run(workdir: Path, of_version: str = "0.3.0") -> str:
+    env = {**os.environ, "OF_VERSION": of_version}
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=str(workdir),
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _write_pyproject(workdir: Path, openfilter_pin: str) -> None:
+    (workdir / "pyproject.toml").write_text(
+        '[project]\n'
+        'name = "filter-x"\n'
+        'version = "0.0.1"\n'
+        f'dependencies = ["{openfilter_pin}"]\n'
+    )
+
+
+def test_lt_upper_bound_excludes_target_is_widen(tmp_path: Path) -> None:
+    """`>=0.1.30,<0.2.0` upgrading to 0.3.0 — historical widen path."""
+    _write_pyproject(tmp_path, "openfilter>=0.1.30,<0.2.0")
+    assert _run(tmp_path, of_version="0.3.0").startswith("widen:")
+
+
+def test_le_upper_bound_excludes_target_is_widen(tmp_path: Path) -> None:
+    """`<=` upper bound that excludes target is also widen."""
+    _write_pyproject(tmp_path, "openfilter>=0.1.30,<=0.1.99")
+    assert _run(tmp_path, of_version="0.3.0").startswith("widen:")
+
+
+def test_tilde_pin_excluding_target_is_widen(tmp_path: Path) -> None:
+    """`~=0.1.30` upgrading to 0.3.0 — must dispatch, not strand.
+
+    `~=0.1.30` desugars to `>=0.1.30,<0.2.0`, so 0.3.0 is excluded. The rewriter
+    has `~=` in _BUMPABLE_OPS and emits `~=0.3.0`. Cascade PRs are reviewed
+    before merge; there's no auto-rewrite risk to design against.
+    """
+    _write_pyproject(tmp_path, "openfilter~=0.1.30")
+    assert _run(tmp_path, of_version="0.3.0").startswith("widen:")
+
+
+def test_exact_pin_excluding_target_is_widen(tmp_path: Path) -> None:
+    """`==0.1.18` upgrading to 0.3.0 — must dispatch, not strand."""
+    _write_pyproject(tmp_path, "openfilter==0.1.18")
+    assert _run(tmp_path, of_version="0.3.0").startswith("widen:")
+
+
+def test_not_equal_blocking_is_skip(tmp_path: Path) -> None:
+    """`!=X` blocking target — rewriter doesn't reason about exclusions."""
+    _write_pyproject(tmp_path, "openfilter!=0.3.0,>=0.1.30")
+    assert _run(tmp_path, of_version="0.3.0").startswith("skip:")
+
+
+def test_gt_strict_lower_bound_blocking_is_skip(tmp_path: Path) -> None:
+    """`>X` strict lower bound — not in the rewriter's handled op set."""
+    _write_pyproject(tmp_path, "openfilter>0.3.0")
+    assert _run(tmp_path, of_version="0.3.0").startswith("skip:")
+
+
+def test_target_already_admitted_is_ok(tmp_path: Path) -> None:
+    """`>=X` admitting target — no cascade needed."""
+    _write_pyproject(tmp_path, "openfilter>=0.1.21")
+    assert _run(tmp_path, of_version="0.3.0").startswith("ok:")
+
+
+def test_tilde_pin_already_admitting_target_is_ok(tmp_path: Path) -> None:
+    """`~=0.3.0` for target 0.3.5 — admitted, no action."""
+    _write_pyproject(tmp_path, "openfilter~=0.3.0")
+    assert _run(tmp_path, of_version="0.3.5").startswith("ok:")
+
+
+def test_combined_widenable_and_passing_clauses(tmp_path: Path) -> None:
+    """`~=0.1.30,!=0.1.35` for target 0.3.0 — `~=` excludes, `!=` doesn't.
+
+    The `!=0.1.35` clause passes (target isn't 0.1.35). The `~=0.1.30` clause
+    is the blocker, and it's rewritable. Should be `widen:`.
+    """
+    _write_pyproject(tmp_path, "openfilter~=0.1.30,!=0.1.35")
+    assert _run(tmp_path, of_version="0.3.0").startswith("widen:")
+
+
+def test_no_openfilter_dependency(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "filter-x"\nversion = "0.0.1"\ndependencies = ["numpy>=1.20"]\n'
+    )
+    assert _run(tmp_path).startswith("none")
+
+
+def test_poetry_format_detected(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.poetry]\nname = "filter-x"\n\n'
+        '[tool.poetry.dependencies]\n'
+        'openfilter = "^0.1.30"\n'
+    )
+    assert _run(tmp_path).startswith("none:poetry-format")


### PR DESCRIPTION
## 📋 What does this PR do?

Augments the openfilter → filter-* cascade so it can rewrite a consumer's pyproject upper bound when the new `OF_VERSION` exceeds it, instead of silently skipping the filter as a no-op.

Three coordinated changes in `scripts/cascade/`:

- **`bump-strategy.sh`** (the embedded `_bump.py` helper): adds upper-bound widening to `rewrite_requirement()`. Rule: `target.major == 0` → `<target.major>.<target.minor + 1>.0` (next minor, mirrors the org's existing "track minor" 0.X pin pattern); `target.major >= 1` → `<target.major + 1>.0.0` (standard SemVer next-major). `!=` exclusions, `>` lower bounds, clause order, surrounding whitespace, and environment markers are still preserved verbatim.
- **`check_constraint.py`**: emits a new `widen:<spec>` state for constraints whose only blocking clauses are widenable upper bounds (`<` / `<=`). `skip:<spec>` is now reserved for non-widenable blocks: lower-bound exclusions (downgrades) and explicit `!=` exclusions. Splitting `widen:` from `skip:` is what lets discover.sh consider the filter eligible while keeping a hard boundary against silent semantic regressions.
- **`discover.sh`**: treats `widen:` as eligible with a separate diagnostic line ("eligible — pin `<spec>` will be widened for `OF_VERSION`") so operators can tell at a glance that this cascade PR is more than a routine lower-bound bump.

## 🔍 Why is this needed?

Every `filter-*` repo in the org currently pins `openfilter[all]>=0.1.30,<0.2.0`. Under the pre-existing cascade behavior, a v0.2.0 (or v1.0.0) release would cascade to **zero** of 55 filters — the cascade refused to rewrite upper bounds, so it could only handle 0.1.x → 0.1.y bumps within the existing range. Without this augmentation, every non-patch openfilter release requires manually fanning out a constraint-widening PR across ~55 repos before the cascade can do anything useful.

Smoke test against the org-canonical case (`<0.2.0,>=0.1.30` → `OF_VERSION=0.2.0`) before this change:

```
filter-sam3-detector: skip (constraint <0.2.0,>=0.1.30 excludes 0.2.0)
Discovery complete: 0 eligible, 1 skipped
```

After this change:

```
filter-sam3-detector: eligible — pin <0.2.0,>=0.1.30 will be widened for 0.2.0
Discovery complete: 1 eligible, 0 skipped
[…]
pyproject.toml: rewrote 1 openfilter pin(s) → 0.2.0
```

Humans still review every cascade PR; widening is automation-floor behavior. The bot proposes the new bound; the reviewer can adjust it before merge if a non-default widening rule is wanted for that filter.

## 🧪 How was it tested?

**Unit tests** (`tests/test_cascade_bump_strategy.py`): 7 new tests covering the org-canonical 0.X → 0.Y widening, 1.0+ widening (next-major rule), `<=` widening, no-op-when-upper-bound-already-admits-target, inline-comment preservation through tomlkit, the `requirements.txt` rewrite path, and idempotency on re-run. All 16 tests in the file pass (9 pre-existing + 7 new).

```
$ pytest tests/test_cascade_bump_strategy.py -v
…
============================== 16 passed in 0.95s ==============================
```

**`check_constraint.py` manual validation** against the five representative cases (`>=0.1.30,<0.2.0` pin):

| `OF_VERSION` | Expected | Got |
|---|---|---|
| `0.1.30`           | `ok:`    | `ok:<0.2.0,>=0.1.30` |
| `0.2.0`            | `widen:` | `widen:<0.2.0,>=0.1.30` |
| `0.1.0`            | `skip:`  | `skip:<0.2.0,>=0.1.30` (downgrade) |
| `0.2.0` + `!=0.2.0` | `skip:` | `skip:!=0.2.0,<1.0,>=0.1.0` |
| no openfilter dep  | `none`   | `none` |

**End-to-end smoke test** via `gh workflow run cascade-on-tag.yaml --ref feat/dt-145-cascade-widen-constraint -f dry_run=true -f single_filter=filter-sam3-detector` (run
[25894063159](https://github.com/PlainsightAI/openfilter/actions/runs/25894063159)): discover correctly classified sam3-detector as `widen:`, bump-strategy cloned the consumer, ran the rewriter, and reported `pyproject.toml: rewrote 1 openfilter pin(s) → 0.2.0`. `open-mechanical-pr` was correctly skipped per `dry_run=true`.

## 🔗 Related Issues

[DT-145](https://plainsight-ai.atlassian.net/browse/DT-145) — cascade infrastructure.

## ✅ Checklist

- [x] I have read and agreed to the terms of the [LICENSE](../LICENSE)
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have followed the [coding style](../CONTRIBUTING.md#coding-style)
- [x] I have signed all commits in compliance with the DCO (`git commit -s`)
- [x] I have added or updated **tests** as needed
- [x] I have added or updated **documentation** as needed (in-tree docstrings on `discover.sh`, `check_constraint.py`, and `_bump.py`)

[DT-145]: https://plainsight-ai.atlassian.net/browse/DT-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ