### PR TITLE
fix(tests): poll for runner exit instead of single-step assert (FILTER-461)

### DIFF
--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -33,6 +33,38 @@ def _strip_meta(d):
 getdatas = lambda q, t=5: {t: _strip_meta(f.data) for t, f in q.get(True, t).items()}
 
 
+def wait_for_runner_exit(runner, timeout=5.0, interval=0.1):
+    """Poll ``runner.step()`` until it returns something other than ``False``, or timeout.
+
+    Used after sending the shutdown sentinel (``qout.put(None)``) to give all
+    filters time to drain + report exit codes. Returns whatever ``step()``
+    yields at that point — typically the exit-codes list, or ``False`` on
+    timeout (in which case the caller's ``assertEqual`` will fail loudly
+    with that ``False``, surfacing the actual problem rather than a
+    timing-flaky pass on some Python versions and not others).
+
+    Why a test-local helper instead of ``Runner.wait(timeout)``:
+    ``Runner.wait`` already implements a timeout-bounded step loop, but it
+    relies on the runner's ``step_wait`` parameter (a ZMQ-poll timeout
+    threaded into ``step()``) for its waiting discipline. Tests elsewhere
+    in this file drive the runner via bare ``step()`` calls; reaching for
+    ``wait()`` only at the shutdown step would break that pattern. The
+    explicit ``sleep(interval)`` here also gives the kernel a deterministic
+    scheduling gap between attempts, which mattered on Python 3.10 under
+    #82's zero-copy IPC where a single ``step()`` immediately after
+    ``qout.put(None)`` was racing the filters' drain-and-report path. See
+    FILTER-461.
+    """
+    deadline = time() + timeout
+    while True:
+        result = runner.step()
+        if result is not False:
+            return result
+        if time() >= deadline:
+            return result
+        sleep(interval)
+
+
 class FilterFromQueue(Filter):
     def setup(self, config):
         if (start_sleep := config.start_sleep):
@@ -285,7 +317,7 @@ class TestFilterOld(unittest.TestCase):
 
             qout1.put(None)  # tell them nicely to stop
             qout2.put(None)
-            self.assertEqual(runner.step(), [0, 0, 0])
+            self.assertEqual(wait_for_runner_exit(runner), [0, 0, 0])
 
         finally:
             runner.stop()
@@ -318,12 +350,12 @@ class TestFilterOld(unittest.TestCase):
                 self.assertEqual(getdatas(qin1), d)
 
                 qout.put(None)  # tell it nicely to stop
-                self.assertEqual(runner2.step(), [0])
+                self.assertEqual(wait_for_runner_exit(runner2), [0])
 
             finally:
                 runner2.stop()
 
-            self.assertEqual(runner1.step(), [0, 0])
+            self.assertEqual(wait_for_runner_exit(runner1), [0, 0])
 
         finally:
             runner1.stop()
@@ -355,7 +387,7 @@ class TestFilterOld(unittest.TestCase):
             self.assertEqual(set(r), set(('main', '_metrics', '_filter')))
 
             qout.put(None)  # tell it nicely to stop
-            self.assertEqual(runner.step(), [0, 0])
+            self.assertEqual(wait_for_runner_exit(runner), [0, 0])
 
         finally:
             runner.stop()
@@ -495,7 +527,7 @@ class TestFilterOld(unittest.TestCase):
             # self.assertTrue(qworker2.empty())
 
             qout.put(None)  # tell it nicely to stop
-            self.assertEqual(runner.step(), [0, 0, 0, 0, 0])
+            self.assertEqual(wait_for_runner_exit(runner), [0, 0, 0, 0, 0])
 
         finally:
             runner.stop()


### PR DESCRIPTION
## 📋 What does this PR do?

Adds a `wait_for_runner_exit(runner, timeout=5.0)` helper in `tests/test_filter.py` that polls `runner.step()` until it returns something other than `False` (or times out), and replaces five fragile single-step shutdown assertions across four `TestFilterOld` tests:

- `test_topo_balance_step`
- `test_topo_ephemeral_join_step`
- `test_topo_doubly_ephemeral_tee_step` (two callsites)
- `test_topo_subscribe_wildcard_all_step`

Each callsite previously asserted that a single `runner.step()` immediately after `qout.put(None)` would return the exit-codes list (`[0] * N` for N filters). With the helper, the assertion now waits up to 5 s for the runner to actually report termination — preserving the original assertion semantics, but with the same `step → settle → assert` discipline the data-frame iterations already use.

## 🔍 Why is this needed?

`test_topo_balance_step` started failing on Python 3.10 only as of [Create Release dry-run run #25936326919](https://github.com/PlainsightAI/openfilter/actions/runs/25936326919), while passing on 3.11 / 3.12 / 3.13. The same test passed on 3.10 for the v0.1.30 release ([run #24800470941](https://github.com/PlainsightAI/openfilter/actions/runs/24800470941), 2026-04-22). Between those, #82 introduced the zero-copy IPC transport with SHM — a perf rewrite of the layer this test exercises. The faster IPC shifted timing margins such that on 3.10's GIL/scheduling, at least one of N filters routinely hasn't yet drained the `None` shutdown sentinel + reported its exit code by the time the next `step()` runs. Result: `step()` returns `False` ("not done") instead of `[0, 0, …]`.

This is **test fragility, not a runtime regression** — the 9 data-frame iterations in the same test exercise the full pipeline correctly across 3.10 too. But it was also a **release blocker**: the Create Release workflow gates on every matrix Python version passing run-tests, so any release dispatch was rolling dice on the 3.10 job.

See [FILTER-461](https://plainsight-ai.atlassian.net/browse/FILTER-461) for the full root-cause analysis.

## 🧪 How was it tested?

Set up a fresh Python 3.10 venv with the project in editable mode (`uv venv .venv-310 --python 3.10`, `uv pip install -e ".[all]"`, install pytest), and ran the failing test:

```
$ .venv-310/bin/pytest tests/test_filter.py::TestFilterOld::test_topo_balance_step -v
…
tests/test_filter.py::TestFilterOld::test_topo_balance_step PASSED  [100%]
1 passed in 3.66s
```

Repeated 3× consecutively — all green. Also ran all four patched tests together — all pass:

```
tests/test_filter.py::TestFilterOld::test_topo_balance_step PASSED  [ 25%]
tests/test_filter.py::TestFilterOld::test_topo_ephemeral_join_step PASSED  [ 50%]
tests/test_filter.py::TestFilterOld::test_topo_doubly_ephemeral_tee_step PASSED  [ 75%]
tests/test_filter.py::TestFilterOld::test_topo_subscribe_wildcard_all_step PASSED  [100%]
4 passed in 8.72s
```

Final CI confirmation will come from the Create Release re-dispatch after this merges — all four Python matrix versions should pass run-tests consistently.

## 🔗 Related Issues

- [FILTER-461](https://plainsight-ai.atlassian.net/browse/FILTER-461) — root-cause analysis and fix proposal (this PR implements the proposed fix).
- Unblocks the v0.2.1 release ceremony (validation of the `PLAINSIGHT_PYPI_TOKEN` publish path was caught by this flake before reaching the PyPI upload step).

## ✅ Checklist

- [x] I have read and agreed to the terms of the [LICENSE](../LICENSE)
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have followed the [coding style](../CONTRIBUTING.md#coding-style)
- [x] I have signed all commits in compliance with the DCO (`git commit -s`)
- [x] I have added or updated **tests** as needed (the fix IS the test change; helper is documented in-line)
- [x] I have added or updated **documentation** as needed (helper has a docstring explaining the FILTER-461 context)


[FILTER-461]: https://plainsight-ai.atlassian.net/browse/FILTER-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ