### PR TITLE
feat(filter_runtime): windowed async batch dispatch (FILTER-457/458/459/460)

### DIFF
--- a/openfilter/filter_runtime/filter.py
+++ b/openfilter/filter_runtime/filter.py
@@ -575,6 +575,10 @@ class Filter:
             flush-trigger order even when workers complete out of order. Submission BLOCKS when all workers are
             busy (natural upstream backpressure rather than silent drops). Useful for network-bound batches
             (remote VLM/retrieval calls) where call latency > flush interval.
+            A process_batch() exception in pool mode (batch_workers > 1) is logged and the batch is dropped —
+            the filter keeps running. This is intentionally non-fatal, and DIVERGES from the synchronous
+            batch_workers == 1 path, which re-raises and exits the run loop. Call self.exit() inside
+            process_batch() if a batch failure must stop the filter regardless of mode.
 
         batch_shutdown_timeout_s:
             Maximum seconds to wait for in-flight batch workers to drain during fini(). Default 60. Batches still
@@ -1676,8 +1680,16 @@ class Filter:
         with self._batch_inflight_lock:
             self._batch_inflight.add(future)
 
+        # Bind the semaphore by value. fini() nulls self._batch_submit_sem
+        # right after shutdown(wait=False), so a not_done future completing in
+        # the background afterwards would hit None.release() via self. The
+        # semaphore object itself stays valid; releasing it post-shutdown is
+        # harmless (nothing acquires it again). _batch_inflight_lock is never
+        # nulled, so referencing it through self stays safe.
+        submit_sem = self._batch_submit_sem
+
         def _on_done(f: concurrent.futures.Future) -> None:
-            self._batch_submit_sem.release()
+            submit_sem.release()
             with self._batch_inflight_lock:
                 self._batch_inflight.discard(f)
 
@@ -1694,9 +1706,28 @@ class Filter:
         """Pool-thread entry point. Runs process_batch() and returns the raw
         result list bracketed by start/end timestamps. Per-slot normalization
         + EMA + metadata enqueue all happen on resolution, not here, so
-        results emerge with timing tied to when downstream actually pulls."""
+        results emerge with timing tied to when downstream actually pulls.
+
+        A process_batch() exception is caught here and treated as a dropped
+        batch (every slot resolves to None), logged once. This is deliberately
+        NON-fatal and DIVERGES from the synchronous path (batch_workers == 1),
+        where _execute_batch re-raises and the run loop exits: pool mode exists
+        for network-bound batches (remote VLM / retrieval calls) where a
+        transient failure should not kill a long-running filter. A filter that
+        needs a batch failure to be fatal should detect it inside
+        process_batch() and call self.exit() — exit() sets stop_evt, which ends
+        the run loop regardless of this catch.
+        """
         t_in = time.time()
-        results = self.process_batch(batch)
+        try:
+            results = self.process_batch(batch)
+        except Exception:
+            logger.exception(
+                "process_batch() raised in pool worker on a batch of %d "
+                "frame(s); dropping the batch and continuing",
+                len(batch),
+            )
+            results = None
         t_out = time.time()
         if results is None:
             results = [None] * len(batch)
@@ -1720,12 +1751,18 @@ class Filter:
             try:
                 t_in, t_out, results = future.result()
             except Exception:
+                # Defensive: _batch_pool_worker catches process_batch()
+                # failures itself (logging once, dropping the batch), so this
+                # only fires on an unexpected pool-infrastructure failure
+                # (e.g. a cancelled future). Drop the slot rather than crash
+                # the loop — consistent with the pool path's non-fatal
+                # contract documented on _batch_pool_worker.
                 logger.exception(
-                    "Pool batch worker raised; slot %d/%d will not emit",
+                    "Pool future failed unexpectedly; slot %d/%d dropped",
                     slot_idx,
                     batch_len,
                 )
-                raise
+                return None
             if slot_idx >= len(results):
                 return None
             slot = results[slot_idx]
@@ -1739,9 +1776,16 @@ class Filter:
                     return None
             frames = self._normalize_frame_result(slot)
             process_time_ms = (t_out - t_in) * 1000
-            self._filter_time_in = t_in
-            self._filter_time_out = t_out
-            self._update_process_time_ema(process_time_ms)
+            # All slots of a pool batch share one process_batch() wall-clock
+            # (the future's t_in/t_out). Fold it into the EMA exactly once —
+            # on slot 0 — so a batch of N slots does not inflate the EMA
+            # N-fold. Mirrors the once-per-batch update in the synchronous
+            # _execute_batch path. _inject_timings still runs per slot: every
+            # frame needs its own timing metadata stamped.
+            if slot_idx == 0:
+                self._filter_time_in = t_in
+                self._filter_time_out = t_out
+                self._update_process_time_ema(process_time_ms)
             self._inject_timings(frames, t_in, t_out, process_time_ms)
             try:
                 self._metadata_queue.put_nowait((frames, self.emitter))
@@ -1797,21 +1841,29 @@ class Filter:
         # Timeout in batch mode — flush any partial batch and return early.
         # Only runs when frames is empty (timeout case), not when real frames are received.
         if batch_mode and not frames:
-            with self._batch_lock:
-                if self._frame_buffer:
-                    window_snapshot = list(self._frame_buffer)
-                    self._frames_since_last_dispatch = 0
-                    if not self._sliding_window:
-                        self._frame_buffer.clear()
-                    self._batch_flush_event.clear()
-                    self._cancel_batch_timer()
-                else:
-                    window_snapshot = None
-            if window_snapshot is not None:
-                batch = self.select_batch(window_snapshot)
-                flushed_results = self._execute_batch(batch)
-                for r in flushed_results:
-                    self._send_frames(r, outputs_timeout)
+            # Skip the timeout-driven drain in manual mode: batch_trigger="manual"
+            # contracts that ONLY flush_batch() drains the buffer, so a slow or
+            # idle source must not dispatch a partial batch here. A pending
+            # flush_batch() request is still honored — the recv-loop above picks
+            # up _batch_flush_event via _process_batch_flush before reaching this
+            # point — so manual flushes are not lost, only timeout flushes are
+            # suppressed.
+            if self._batch_trigger != "manual":
+                with self._batch_lock:
+                    if self._frame_buffer:
+                        window_snapshot = list(self._frame_buffer)
+                        self._frames_since_last_dispatch = 0
+                        if not self._sliding_window:
+                            self._frame_buffer.clear()
+                        self._batch_flush_event.clear()
+                        self._cancel_batch_timer()
+                    else:
+                        window_snapshot = None
+                if window_snapshot is not None:
+                    batch = self.select_batch(window_snapshot)
+                    flushed_results = self._execute_batch(batch)
+                    for r in flushed_results:
+                        self._send_frames(r, outputs_timeout)
             # In batch mode, timeout means "flush partial" — already done above.
             # No need to call process_frames({}) which would just return None.
             if (
@@ -2376,6 +2428,11 @@ class Filter:
             The default implementation calls process() per frame and evaluates any
             Callable returns eagerly to preserve pre-existing behavior; override
             process_batch() to opt into deferred-callable semantics.
+
+            Exception handling depends on batch_workers. With batch_workers == 1 (synchronous) a
+            process_batch() exception re-raises and exits the run loop. With batch_workers > 1 (pool) it
+            is logged once and the batch is dropped (every slot resolves to None) so the filter keeps
+            running. Call self.exit() from within process_batch() to stop the filter regardless of mode.
         """
         results = []
         for frames in batch:
@@ -2448,6 +2505,15 @@ class Filter:
     def _stop_batch_watcher(self) -> None:
         self._batch_stop.set()
         self._batch_wakeup.set()  # unblock the wait
+        # Join so shutdown sequencing is explicit: fini() proceeds straight to
+        # pool drain + mq.destroy() after this, and joining here closes the
+        # window where a late _batch_flush_event.set() from the watcher could
+        # race MQ teardown. daemon=True already rules out a leak; the join just
+        # makes the ordering deterministic. Bounded so a wedged watcher cannot
+        # block shutdown indefinitely.
+        watcher = self._batch_watcher
+        if watcher is not None:
+            watcher.join(timeout=1.0)
 
     def _reset_batch_timer(self) -> None:
         """Reset the accumulation timeout by waking the watcher."""

--- a/openfilter/filter_runtime/filter.py
+++ b/openfilter/filter_runtime/filter.py
@@ -9,6 +9,8 @@ import sys
 import threading
 import time
 import warnings
+from collections import deque
+from collections.abc import Sequence
 from datetime import datetime
 from multiprocessing import synchronize
 from typing import Any, Callable, Literal, List
@@ -293,6 +295,9 @@ class FilterConfig(
     accumulate_timeout_ms: (
         float | None
     )  # Max ms to wait for a full batch before flushing partial (default 100.0)
+    accumulate_window: (
+        int | None
+    )  # Ring buffer size in sliding-window mode; must be >= batch_size. Unset = one-shot buffer (current behavior).
 
     def clean(self):  # -> Self:
         """Return a clean instance of this config without any hidden items starting with '_'."""
@@ -534,6 +539,14 @@ class Filter:
             Maximum time in milliseconds to wait for a full batch before flushing a partial batch. Only used when
             batch_size > 1. Default 100.0. If frames arrive slower than this window the partial batch is flushed
             rather than waiting indefinitely.
+
+        accumulate_window:
+            Sliding-window ring buffer size; must be >= batch_size. When set, the runtime keeps the most recent
+            accumulate_window frames in a bounded ring rather than draining the buffer on each dispatch. The full
+            ring is passed to Filter.select_batch() which picks which frames go to process_batch(). Lets filters
+            with temporal sampling needs (caption/VLM, re-ID, audio-visual sync) reach across a wider window than
+            what fits in a single batch. Unset (the default) preserves the original one-shot drain-on-dispatch
+            behavior — equivalent to accumulate_window=batch_size.
 
     Environment variables:
         LOG_LEVEL:
@@ -785,7 +798,22 @@ class Filter:
         self._accumulate_timeout_ms = float(
             config.get("accumulate_timeout_ms") or 100.0
         )
-        self._frame_buffer: list[dict[str, Frame]] = []
+        # When accumulate_window is set, the buffer is a bounded sliding ring of that
+        # size and frames are NOT removed on dispatch — select_batch() picks the
+        # subset to send to process_batch(). When unset, the buffer behaves exactly
+        # as before: a one-shot list cleared on every dispatch.
+        raw_window = config.get("accumulate_window")
+        self._sliding_window: bool = raw_window is not None
+        self._accumulate_window: int = (
+            int(raw_window) if raw_window is not None else self._batch_size
+        )
+        self._frame_buffer: deque[dict[str, Frame]] | list[dict[str, Frame]] = (
+            deque(maxlen=self._accumulate_window) if self._sliding_window else []
+        )
+        # Counter of frames received since the last dispatch trigger. In sliding
+        # mode the buffer itself doesn't reset on dispatch, so we need an
+        # independent count to know when to fire again.
+        self._frames_since_last_dispatch: int = 0
         self._batch_lock = threading.Lock()
         self._batch_flush_event = threading.Event()
         self._batch_wakeup = threading.Event()
@@ -1377,14 +1405,23 @@ class Filter:
             # fired as a new frame arrives, we don't want a premature flush.
             self._batch_flush_event.clear()
             self._frame_buffer.append(frames)
+            self._frames_since_last_dispatch += 1
 
-            if len(self._frame_buffer) < self._batch_size:
+            if self._frames_since_last_dispatch < self._batch_size:
                 self._reset_batch_timer()
                 return None
 
-            batch = list(self._frame_buffer)
-            self._frame_buffer.clear()
+            # Snapshot the ring under the lock; selection happens outside so an
+            # overridden select_batch() can run arbitrary user code without
+            # blocking new appends.
+            window_snapshot: list[dict[str, Frame]] = list(self._frame_buffer)
+            self._frames_since_last_dispatch = 0
+            if not self._sliding_window:
+                # Original semantics: dispatch consumes the buffer.
+                self._frame_buffer.clear()
             self._batch_flush_event.clear()
+
+        batch = self.select_batch(window_snapshot)
 
         results = self._execute_batch(batch)
         # Stash intermediate results for loop_once to drain.
@@ -1548,13 +1585,16 @@ class Filter:
         if batch_mode and not frames:
             with self._batch_lock:
                 if self._frame_buffer:
-                    batch = list(self._frame_buffer)
-                    self._frame_buffer.clear()
+                    window_snapshot = list(self._frame_buffer)
+                    self._frames_since_last_dispatch = 0
+                    if not self._sliding_window:
+                        self._frame_buffer.clear()
                     self._batch_flush_event.clear()
                     self._cancel_batch_timer()
                 else:
-                    batch = None
-            if batch is not None:
+                    window_snapshot = None
+            if window_snapshot is not None:
+                batch = self.select_batch(window_snapshot)
                 flushed_results = self._execute_batch(batch)
                 for r in flushed_results:
                     self._send_frames(r, outputs_timeout)
@@ -1890,19 +1930,22 @@ class Filter:
             self._batch_pending_results.clear()
         with self._batch_lock:
             if self._frame_buffer:
-                batch = list(self._frame_buffer)
-                self._frame_buffer.clear()
+                window_snapshot = list(self._frame_buffer)
+                self._frames_since_last_dispatch = 0
+                if not self._sliding_window:
+                    self._frame_buffer.clear()
             else:
-                batch = None
-        if batch is not None:
+                window_snapshot = None
+        if window_snapshot is not None:
             try:
+                batch = self.select_batch(window_snapshot)
                 results = self._execute_batch(batch)
                 for r in results:
                     self.mq.send(r, POLL_TIMEOUT_MS)
             except Exception:
                 logger.warning(
                     "Failed to flush partial batch of %d frame(s) on shutdown",
-                    len(batch),
+                    len(window_snapshot),
                     exc_info=True,
                 )
         self._stop_metadata_worker()
@@ -1976,6 +2019,15 @@ class Filter:
                     f"accumulate_timeout_ms must be > 0, got {acc_timeout}"
                 )
             config.accumulate_timeout_ms = acc_timeout
+
+        if (acc_window := config.get("accumulate_window")) is not None:
+            acc_window = int(acc_window)
+            effective_batch = int(config.get("batch_size") or 1)
+            if acc_window < effective_batch:
+                raise ValueError(
+                    f"accumulate_window must be >= batch_size ({effective_batch}), got {acc_window}"
+                )
+            config.accumulate_window = acc_window
 
         return config
 
@@ -2075,6 +2127,34 @@ class Filter:
             results.append(r)
         return results
 
+    def select_batch(
+        self, window: Sequence[dict[str, Frame]]
+    ) -> list[dict[str, Frame]]:
+        """Pick which frames in the sliding-window ring go to process_batch().
+
+        Called by the runtime before every dispatch (count-driven, timeout-driven,
+        or shutdown drain). Override to implement temporal sampling — e.g. uniform
+        subsampling from a wider window than what fits in a single batch.
+
+        The default returns the most recent ``batch_size`` entries, which keeps
+        single-buffer mode (``accumulate_window`` unset or equal to ``batch_size``)
+        identical to pre-sliding-window behavior.
+
+        Contract:
+            * Must return a list of length <= batch_size; longer lists are
+              accepted but trigger a warning in _execute_batch.
+            * Must not mutate ``window``; the runtime owns the deque.
+            * May select non-contiguous slices.
+
+        Args:
+            window: Snapshot of the current ring buffer in arrival order
+                (oldest first). Always non-empty when this is called.
+
+        Returns:
+            The frames to hand to process_batch(), in the desired order.
+        """
+        return list(window)[-self._batch_size:]
+
     def _ensure_batch_watcher(self) -> None:
         """Start the batch watcher thread if not already running."""
         if self._batch_watcher is not None and self._batch_watcher.is_alive():
@@ -2126,14 +2206,22 @@ class Filter:
                 logger.exception("batch watcher loop raised; continuing")
 
     def _take_flush_batch(self) -> list[dict[str, Frame]] | None:
-        """If a flush is pending and buffer is non-empty, return the batch and reset state."""
+        """If a flush is pending and buffer is non-empty, return the batch and reset state.
+
+        Routes the snapshot through select_batch() so timeout-driven flushes go
+        through the same picking surface as count-driven dispatches. In non-sliding
+        mode the buffer is drained as before; in sliding-window mode the ring is
+        preserved (the deque's maxlen still bounds growth).
+        """
         with self._batch_lock:
             if self._batch_flush_event.is_set() and self._frame_buffer:
-                batch = list(self._frame_buffer)
-                self._frame_buffer.clear()
+                window_snapshot = list(self._frame_buffer)
+                self._frames_since_last_dispatch = 0
+                if not self._sliding_window:
+                    self._frame_buffer.clear()
                 self._batch_flush_event.clear()
                 self._cancel_batch_timer()
-                return batch
+                return self.select_batch(window_snapshot)
             self._batch_flush_event.clear()
             return None
 

--- a/openfilter/filter_runtime/filter.py
+++ b/openfilter/filter_runtime/filter.py
@@ -298,6 +298,9 @@ class FilterConfig(
     accumulate_window: (
         int | None
     )  # Ring buffer size in sliding-window mode; must be >= batch_size. Unset = one-shot buffer (current behavior).
+    batch_trigger: (
+        Literal["auto", "manual"] | None
+    )  # "auto" (default) fires on count or timeout; "manual" disables both — only Filter.flush_batch() drains.
 
     def clean(self):  # -> Self:
         """Return a clean instance of this config without any hidden items starting with '_'."""
@@ -547,6 +550,15 @@ class Filter:
             with temporal sampling needs (caption/VLM, re-ID, audio-visual sync) reach across a wider window than
             what fits in a single batch. Unset (the default) preserves the original one-shot drain-on-dispatch
             behavior — equivalent to accumulate_window=batch_size.
+
+        batch_trigger:
+            "auto" (default) or "manual". In auto mode dispatch fires on the count-based trigger
+            (batch_size new frames) and the accumulate_timeout_ms watcher — original behavior. In manual mode both
+            automatic triggers are suppressed (the watcher is never started) and dispatch only happens when the
+            filter explicitly calls self.flush_batch(). Use manual mode for cadence policies the runtime can't
+            express with (count, timeout) — e.g. media-time intervals, gate predicates, keyframe boundaries. Manual
+            mode applies a safety cap at batch_size * 4 buffered frames to surface forgotten flushes via a warning
+            and force-dispatch; configure accumulate_window > batch_size * 4 if you intentionally hold more.
 
     Environment variables:
         LOG_LEVEL:
@@ -814,6 +826,11 @@ class Filter:
         # mode the buffer itself doesn't reset on dispatch, so we need an
         # independent count to know when to fire again.
         self._frames_since_last_dispatch: int = 0
+        # "auto" (default) → count + timeout triggers fire; "manual" → only
+        # Filter.flush_batch() drains. Stored verbatim, normalized in config.
+        self._batch_trigger: str = (
+            str(config.get("batch_trigger") or "auto").strip().lower()
+        )
         self._batch_lock = threading.Lock()
         self._batch_flush_event = threading.Event()
         self._batch_wakeup = threading.Event()
@@ -1399,16 +1416,41 @@ class Filter:
     ) -> dict[str, Frame] | Callable[[], dict[str, Frame] | None] | None:
         if not frames:
             return None
+        manual = self._batch_trigger == "manual"
         with self._batch_lock:
-            self._cancel_batch_timer()
-            # Also clear any stale flush event: if the watcher's timeout just
-            # fired as a new frame arrives, we don't want a premature flush.
-            self._batch_flush_event.clear()
+            if not manual:
+                # In auto mode the watcher times the partial-batch flush; cancel
+                # the in-flight timer because we just received a frame.
+                self._cancel_batch_timer()
+            # Drain a pending manual flush set BEFORE this frame arrived, but
+            # don't clear it before checking — flush_batch() may have fired
+            # exactly to include this frame in the dispatch.
+            manual_flush_pending = self._batch_flush_event.is_set()
             self._frame_buffer.append(frames)
             self._frames_since_last_dispatch += 1
 
-            if self._frames_since_last_dispatch < self._batch_size:
-                self._reset_batch_timer()
+            count_trigger = (
+                not manual and self._frames_since_last_dispatch >= self._batch_size
+            )
+            safety_force = False
+            if manual and not manual_flush_pending:
+                # Safety cap: if a manual-mode filter forgets to call
+                # flush_batch(), force a dispatch once the buffer reaches
+                # batch_size * 4 so memory stays bounded. Log a warning so the
+                # forgotten flush is visible rather than silently absorbed.
+                if len(self._frame_buffer) >= self._batch_size * 4:
+                    logger.warning(
+                        "batch_trigger=manual but buffer reached %d frames "
+                        "(>= batch_size * 4 = %d) without flush_batch(); "
+                        "force-flushing to bound memory",
+                        len(self._frame_buffer),
+                        self._batch_size * 4,
+                    )
+                    safety_force = True
+
+            if not (manual_flush_pending or count_trigger or safety_force):
+                if not manual:
+                    self._reset_batch_timer()
                 return None
 
             # Snapshot the ring under the lock; selection happens outside so an
@@ -1421,7 +1463,14 @@ class Filter:
                 self._frame_buffer.clear()
             self._batch_flush_event.clear()
 
-        batch = self.select_batch(window_snapshot)
+        if safety_force:
+            # Safety dispatch is a bailout — drain everything we've accumulated
+            # rather than letting an overridden select_batch() decide. The user
+            # is already in a bug (forgot flush_batch); the priority is bounded
+            # memory, not picking semantics.
+            batch = window_snapshot
+        else:
+            batch = self.select_batch(window_snapshot)
 
         results = self._execute_batch(batch)
         # Stash intermediate results for loop_once to drain.
@@ -2029,6 +2078,14 @@ class Filter:
                 )
             config.accumulate_window = acc_window
 
+        if (trigger := config.get("batch_trigger")) is not None:
+            trigger = str(trigger).strip().lower()
+            if trigger not in ("auto", "manual"):
+                raise ValueError(
+                    f"batch_trigger must be 'auto' or 'manual', got {trigger!r}"
+                )
+            config.batch_trigger = trigger
+
         return config
 
     def setup(self, config: FilterConfig) -> None:
@@ -2126,6 +2183,28 @@ class Filter:
                 r = r()
             results.append(r)
         return results
+
+    def flush_batch(self) -> None:
+        """Trigger a dispatch of the current ring buffer on the next opportunity.
+
+        Safe to call from process() or from any other thread. Sets an event the
+        runtime checks at the next frame append (via _process_frames_batched)
+        and at every recv poll (via loop_once's _process_batch_flush path) so
+        the dispatch fires either when the next frame arrives OR when the loop
+        idles, whichever happens first.
+
+        Required for cadence policies the runtime can't express with
+        (batch_size, accumulate_timeout_ms) — for example a filter that fires
+        every N seconds of media-time, when an active-key gate opens, or on
+        detected keyframe boundaries. Combine with batch_trigger="manual" to
+        suppress the runtime's automatic count/timeout triggers entirely;
+        otherwise flush_batch() coexists with auto triggers and fires sooner.
+
+        In non-batch mode (batch_size == 1) this is a no-op.
+        """
+        if self._batch_size <= 1:
+            return
+        self._batch_flush_event.set()
 
     def select_batch(
         self, window: Sequence[dict[str, Frame]]

--- a/openfilter/filter_runtime/filter.py
+++ b/openfilter/filter_runtime/filter.py
@@ -716,16 +716,16 @@ class Filter:
         str, JSONType
     ]  # the last metrics that were sent out, including user metrics
 
+    @property
+    def metrics(self) -> dict[str, JSONType]:
+        return self.mq.metrics
+
     FILTER_TYPE = "User"
     _EMA_ALPHA = (
         0.05  # smoothing factor for exponential moving averages (timing metrics)
     )
     _batch_size: int = 1
     metric_specs: List[MetricSpec] = []  # subclasses override this to declare metrics
-
-    @property
-    def metrics(self) -> dict[str, JSONType]:
-        return self.mq.metrics
 
     class Exit(SystemExit):
         pass
@@ -792,7 +792,9 @@ class Filter:
         self._batch_stop = threading.Event()
         self._batch_watcher: threading.Thread | None = None
         # Accessed only from the loop_once thread — no lock needed.
-        self._batch_pending_results: list[dict[str, Frame]] = []
+        self._batch_pending_results: list[
+            dict[str, Frame] | Callable[[], dict[str, Frame] | None]
+        ] = []
 
         try:
             self.telemetry_enabled: bool = (
@@ -1366,7 +1368,7 @@ class Filter:
 
     def _process_frames_batched(
         self, frames: dict[str, Frame]
-    ) -> dict[str, Frame] | None:
+    ) -> dict[str, Frame] | Callable[[], dict[str, Frame] | None] | None:
         if not frames:
             return None
         with self._batch_lock:
@@ -1392,18 +1394,30 @@ class Filter:
             self._batch_pending_results.extend(results[:-1])
         return results[-1] if results else None
 
-    def _process_batch_flush(self) -> list[dict[str, Frame]] | None:
+    def _process_batch_flush(
+        self,
+    ) -> list[dict[str, Frame] | Callable[[], dict[str, Frame] | None]] | None:
         batch = self._take_flush_batch()
         if batch is None:
             return None
         results = self._execute_batch(batch)
         return results if results else None
 
-    def _execute_batch(self, batch: list[dict[str, Frame]]) -> list[dict[str, Frame]]:
+    def _execute_batch(
+        self, batch: list[dict[str, Frame]]
+    ) -> list[dict[str, Frame] | Callable[[], dict[str, Frame] | None]]:
         """Run process_batch() and return normalized, timing-injected results.
 
-        Returns a list of frame dicts (possibly empty). The caller is
-        responsible for sending each result downstream.
+        Returns a list of either resolved frame dicts or Callable closures that
+        the runtime will invoke later (via mq.send's existing Callable polling).
+        Heterogeneous lists are allowed: a process_batch() implementation may
+        return any per-slot mix of dict, Frame, None, or Callable.
+
+        Callable slots let a filter hand the batch's actual work to a worker
+        thread and return a poll closure rather than blocking the loop thread
+        on the batch's wall-clock duration — same shape as a Callable returned
+        from process(). Each closure carries its own per-slot timing: it does
+        the EMA update + _inject_timings on resolution, not at submission time.
         """
         t_in = time.time()
         try:
@@ -1425,18 +1439,26 @@ class Filter:
             )
 
         process_time_ms = (t_out - t_in) * 1000
-        # Use full batch duration for each frame: batch processing is indivisible,
-        # so per-frame timing should reflect the actual batch wall-clock time.
-        self._filter_time_in = t_in
-        self._filter_time_out = t_out
-        self._update_process_time_ema(process_time_ms)
+        has_callable = any(callable(r) for r in results)
+        if not has_callable:
+            # Pure synchronous batch: record the process_batch() wall-clock as
+            # the per-batch EMA. Mirrors the immediate path in
+            # _process_frames_single, which only updates EMA when the result
+            # isn't a Callable.
+            self._filter_time_in = t_in
+            self._filter_time_out = t_out
+            self._update_process_time_ema(process_time_ms)
 
-        # Normalize results: wrap bare Frames, skip Nones
-        normalized = []
+        normalized: list[dict[str, Frame] | Callable[[], dict[str, Frame] | None]] = []
         for result in results:
             if result is None:
                 continue
-            normalized.append(self._normalize_frame_result(result))
+            if callable(result):
+                normalized.append(self._wrap_batch_slot_callable(result))
+                continue
+            frames = self._normalize_frame_result(result)
+            self._finalize_frames(frames, t_in, t_out, process_time_ms)
+            normalized.append(frames)
 
         if not normalized:
             # Sink filter (all None results): inject timing into every input
@@ -1446,11 +1468,37 @@ class Filter:
                     self._inject_timings(b_frames, t_in, t_out, process_time_ms)
             return []
 
-        # Inject per-frame timing metadata into every result
-        for frames in normalized:
-            self._finalize_frames(frames, t_in, t_out, process_time_ms)
-
         return normalized
+
+    def _wrap_batch_slot_callable(
+        self, slot: Callable[[], dict[str, Frame] | Frame | None]
+    ) -> Callable[[], dict[str, Frame] | None]:
+        """Mirror _process_frames_single._timed_callable for a single batch slot.
+
+        Each slot records its own wall-clock so EMA reflects the per-slot
+        deferred work (e.g. a Future.result() wait), not the synchronous
+        portion of process_batch().
+        """
+
+        def _timed_batch_slot():
+            ct_in = time.time()
+            f = slot()
+            ct_out = time.time()
+            if f is None:
+                return None
+            result = self._normalize_frame_result(f)
+            ct_ms = (ct_out - ct_in) * 1000
+            self._filter_time_in = ct_in
+            self._filter_time_out = ct_out
+            self._update_process_time_ema(ct_ms)
+            self._inject_timings(result, ct_in, ct_out, ct_ms)
+            try:
+                self._metadata_queue.put_nowait((result, self.emitter))
+            except queue.Full:
+                pass
+            return result
+
+        return _timed_batch_slot
 
     def _send_frames(self, frames, outputs_timeout: float) -> None:
         while not self.mq.send(frames, min(POLL_TIMEOUT_MS, outputs_timeout)):
@@ -1991,7 +2039,12 @@ class Filter:
 
     def process_batch(
         self, batch: list[dict[str, Frame]]
-    ) -> list[dict[str, Frame] | Frame | None]:
+    ) -> list[
+        dict[str, Frame]
+        | Frame
+        | Callable[[], dict[str, Frame] | Frame | None]
+        | None
+    ]:
         """Process a batch of accumulated frames. Override this to implement batched processing.
 
         Called when batch_size > 1 and the batch is full or the accumulate timeout fires.
@@ -2003,9 +2056,16 @@ class Filter:
 
         Returns:
             List of results, one per input frame. Each element follows the same contract
-            as process() return values (dict, Frame, None). Callables returned from
-            this method are NOT supported. (The default implementation handles
-            Callable returns from process() by evaluating them eagerly.)
+            as process() return values: dict, Frame, None, or Callable. A Callable slot
+            is invoked by the runtime at the point downstream demand arrives (same
+            semantics as a Callable returned from process()) — use it to hand the batch
+            to a worker thread and return a poll closure instead of blocking the loop on
+            slow per-batch operations (e.g. remote VLM calls). Per-slot wall-clock is
+            recorded into the timing EMA when the closure resolves, not at submission.
+
+            The default implementation calls process() per frame and evaluates any
+            Callable returns eagerly to preserve pre-existing behavior; override
+            process_batch() to opt into deferred-callable semantics.
         """
         results = []
         for frames in batch:

--- a/openfilter/filter_runtime/filter.py
+++ b/openfilter/filter_runtime/filter.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import contextlib
 import json
 import logging
@@ -301,6 +302,12 @@ class FilterConfig(
     batch_trigger: (
         Literal["auto", "manual"] | None
     )  # "auto" (default) fires on count or timeout; "manual" disables both — only Filter.flush_batch() drains.
+    batch_workers: (
+        int | None
+    )  # >1 runs process_batch() on a ThreadPoolExecutor; loop accumulates next batch while current is in flight.
+    batch_shutdown_timeout_s: (
+        float | None
+    )  # Max seconds to wait for in-flight batches to drain on fini(). Default 60.
 
     def clean(self):  # -> Self:
         """Return a clean instance of this config without any hidden items starting with '_'."""
@@ -559,6 +566,19 @@ class Filter:
             express with (count, timeout) — e.g. media-time intervals, gate predicates, keyframe boundaries. Manual
             mode applies a safety cap at batch_size * 4 buffered frames to surface forgotten flushes via a warning
             and force-dispatch; configure accumulate_window > batch_size * 4 if you intentionally hold more.
+
+        batch_workers:
+            Concurrency cap for in-flight process_batch() calls. Default 1 (current behavior — process_batch runs
+            on the loop thread). When > 1, process_batch is dispatched to a bounded ThreadPoolExecutor and the
+            loop continues to accumulate the next batch while previous batches run. Each batch's result slots are
+            wrapped in Callables that mq.send polls in submission order, so downstream sees results in
+            flush-trigger order even when workers complete out of order. Submission BLOCKS when all workers are
+            busy (natural upstream backpressure rather than silent drops). Useful for network-bound batches
+            (remote VLM/retrieval calls) where call latency > flush interval.
+
+        batch_shutdown_timeout_s:
+            Maximum seconds to wait for in-flight batch workers to drain during fini(). Default 60. Batches still
+            running past this timeout are abandoned with a warning rather than blocking shutdown indefinitely.
 
     Environment variables:
         LOG_LEVEL:
@@ -831,6 +851,22 @@ class Filter:
         self._batch_trigger: str = (
             str(config.get("batch_trigger") or "auto").strip().lower()
         )
+        # Pool-based async dispatch: when batch_workers > 1, process_batch()
+        # runs on a ThreadPoolExecutor and the loop accumulates the next batch
+        # while previous ones are in flight. Pool created lazily on first use
+        # in _execute_batch so test setups that mock the filter don't pay the
+        # thread-creation cost for batch_workers=1 paths.
+        self._batch_workers: int = int(config.get("batch_workers") or 1)
+        self._batch_shutdown_timeout_s: float = float(
+            config.get("batch_shutdown_timeout_s") or 60.0
+        )
+        self._batch_pool = None  # type: concurrent.futures.ThreadPoolExecutor | None
+        self._batch_submit_sem: threading.Semaphore | None = None
+        # In-flight batch futures, tracked for shutdown drain. Manipulated only
+        # by the loop thread (submit) and worker thread (remove on done), so a
+        # lock guards mutations.
+        self._batch_inflight_lock = threading.Lock()
+        self._batch_inflight: set = set()
         self._batch_lock = threading.Lock()
         self._batch_flush_event = threading.Event()
         self._batch_wakeup = threading.Event()
@@ -1504,7 +1540,14 @@ class Filter:
         on the batch's wall-clock duration — same shape as a Callable returned
         from process(). Each closure carries its own per-slot timing: it does
         the EMA update + _inject_timings on resolution, not at submission time.
+
+        When batch_workers > 1, process_batch() runs on the pool — submission
+        blocks if the pool is full (natural upstream backpressure) and the
+        loop continues accumulating the next batch while previous batches are
+        in flight.
         """
+        if self._batch_workers > 1:
+            return self._execute_batch_pool(batch)
         t_in = time.time()
         try:
             results = self.process_batch(batch)
@@ -1585,6 +1628,128 @@ class Filter:
             return result
 
         return _timed_batch_slot
+
+    def _ensure_batch_pool(self) -> concurrent.futures.ThreadPoolExecutor:
+        """Lazily construct the ThreadPoolExecutor + submission semaphore.
+
+        Called on first dispatch when batch_workers > 1. Holding the pool's
+        lifetime to first-use means non-async-pool code paths (every
+        batch_workers == 1 filter, plus every test that mocks the filter) pay
+        zero thread-creation cost.
+        """
+        if self._batch_pool is None:
+            self._batch_pool = concurrent.futures.ThreadPoolExecutor(
+                max_workers=self._batch_workers,
+                thread_name_prefix=f"batch-{self.__class__.__name__}",
+            )
+            # Bound in-flight submissions at batch_workers — provides natural
+            # backpressure: when the pool is busy, _execute_batch_pool blocks
+            # on acquire() until a worker frees.
+            self._batch_submit_sem = threading.Semaphore(self._batch_workers)
+        return self._batch_pool
+
+    def _execute_batch_pool(
+        self, batch: list[dict[str, Frame]]
+    ) -> list[Callable[[], dict[str, Frame] | None]]:
+        """Async dispatch path: submit process_batch() to the pool, return
+        per-slot Callables that mq.send polls in submission order.
+
+        Submission blocks when the pool is full so the loop thread sees
+        backpressure rather than queuing without bound. Result ordering is
+        preserved automatically: loop_once feeds these Callables to mq.send
+        in batch order, and mq.send dispatches them sequentially per the
+        existing Callable contract on process().
+        """
+        pool = self._ensure_batch_pool()
+        # Capture stop_evt-aware semaphore wait. Acquire blocks here when all
+        # workers are busy; this is the backpressure point on the loop thread.
+        while not self._batch_submit_sem.acquire(timeout=POLL_TIMEOUT_MS / 1000.0):
+            if self.stop_evt.is_set():
+                # Shutting down — abandon this batch rather than wait forever.
+                logger.warning(
+                    "batch_workers pool busy during stop_evt; dropping batch of %d frame(s)",
+                    len(batch),
+                )
+                return []
+
+        future = pool.submit(self._batch_pool_worker, batch)
+        with self._batch_inflight_lock:
+            self._batch_inflight.add(future)
+
+        def _on_done(f: concurrent.futures.Future) -> None:
+            self._batch_submit_sem.release()
+            with self._batch_inflight_lock:
+                self._batch_inflight.discard(f)
+
+        future.add_done_callback(_on_done)
+
+        return [
+            self._wrap_pool_slot_callable(future, i, len(batch))
+            for i in range(len(batch))
+        ]
+
+    def _batch_pool_worker(
+        self, batch: list[dict[str, Frame]]
+    ) -> tuple[float, float, list]:
+        """Pool-thread entry point. Runs process_batch() and returns the raw
+        result list bracketed by start/end timestamps. Per-slot normalization
+        + EMA + metadata enqueue all happen on resolution, not here, so
+        results emerge with timing tied to when downstream actually pulls."""
+        t_in = time.time()
+        results = self.process_batch(batch)
+        t_out = time.time()
+        if results is None:
+            results = [None] * len(batch)
+        return (t_in, t_out, results)
+
+    def _wrap_pool_slot_callable(
+        self,
+        future: concurrent.futures.Future,
+        slot_idx: int,
+        batch_len: int,
+    ) -> Callable[[], dict[str, Frame] | None]:
+        """Closure that waits on a pool future and resolves a single slot.
+
+        Mirrors _wrap_batch_slot_callable's per-slot timing/normalization shape
+        but sources its data from a Future shared across all slots in the
+        batch. The first slot to resolve pays the wait; subsequent slots from
+        the same batch see the resolved future and return immediately.
+        """
+
+        def _resolve():
+            try:
+                t_in, t_out, results = future.result()
+            except Exception:
+                logger.exception(
+                    "Pool batch worker raised; slot %d/%d will not emit",
+                    slot_idx,
+                    batch_len,
+                )
+                raise
+            if slot_idx >= len(results):
+                return None
+            slot = results[slot_idx]
+            if slot is None:
+                return None
+            if callable(slot):
+                # FILTER-457: per-slot Callable returned by process_batch.
+                # Resolve inline so this acts as a single deferred slot.
+                slot = slot()
+                if slot is None:
+                    return None
+            frames = self._normalize_frame_result(slot)
+            process_time_ms = (t_out - t_in) * 1000
+            self._filter_time_in = t_in
+            self._filter_time_out = t_out
+            self._update_process_time_ema(process_time_ms)
+            self._inject_timings(frames, t_in, t_out, process_time_ms)
+            try:
+                self._metadata_queue.put_nowait((frames, self.emitter))
+            except queue.Full:
+                pass
+            return frames
+
+        return _resolve
 
     def _send_frames(self, frames, outputs_timeout: float) -> None:
         while not self.mq.send(frames, min(POLL_TIMEOUT_MS, outputs_timeout)):
@@ -1997,6 +2162,28 @@ class Filter:
                     len(window_snapshot),
                     exc_info=True,
                 )
+        # Drain the worker pool with the configured timeout. Batches still in
+        # flight past batch_shutdown_timeout_s are abandoned with a warning.
+        if self._batch_pool is not None:
+            with self._batch_inflight_lock:
+                pending = list(self._batch_inflight)
+            if pending:
+                done, not_done = concurrent.futures.wait(
+                    pending, timeout=self._batch_shutdown_timeout_s
+                )
+                if not_done:
+                    logger.warning(
+                        "batch_workers shutdown abandoned %d in-flight batch(es) "
+                        "after %.1fs timeout",
+                        len(not_done),
+                        self._batch_shutdown_timeout_s,
+                    )
+            # cancel_futures=False — futures already submitted should finish so
+            # mq.send can poll their slot callables; not_done futures are best-
+            # effort and will eventually resolve in the background.
+            self._batch_pool.shutdown(wait=False)
+            self._batch_pool = None
+            self._batch_submit_sem = None
         self._stop_metadata_worker()
         if hasattr(self, "emitter") and self.emitter is not None:
             self.emitter.emit_stop()
@@ -2085,6 +2272,20 @@ class Filter:
                     f"batch_trigger must be 'auto' or 'manual', got {trigger!r}"
                 )
             config.batch_trigger = trigger
+
+        if (workers := config.get("batch_workers")) is not None:
+            workers = int(workers)
+            if workers < 1:
+                raise ValueError(f"batch_workers must be >= 1, got {workers}")
+            config.batch_workers = workers
+
+        if (shutdown_to := config.get("batch_shutdown_timeout_s")) is not None:
+            shutdown_to = float(shutdown_to)
+            if shutdown_to <= 0:
+                raise ValueError(
+                    f"batch_shutdown_timeout_s must be > 0, got {shutdown_to}"
+                )
+            config.batch_shutdown_timeout_s = shutdown_to
 
         return config
 

--- a/tests/test_frame_accumulation.py
+++ b/tests/test_frame_accumulation.py
@@ -1026,5 +1026,190 @@ class TestManualBatchTrigger(unittest.TestCase):
         self.assertEqual(len(f._frame_buffer), 5)
 
 
+class TestBatchWorkersPool(unittest.TestCase):
+    """batch_workers > 1: process_batch runs on a ThreadPoolExecutor; per-slot
+    Callables wait on the future. Backpressure via submission semaphore.
+    """
+
+    def _make_filter(
+        self,
+        filter_cls,
+        batch_size,
+        workers,
+        shutdown_timeout=5.0,
+    ):
+        config = FilterConfig(
+            id="test-pool",
+            batch_size=batch_size,
+            accumulate_timeout_ms=1000.0,
+            batch_workers=workers,
+            batch_shutdown_timeout_s=shutdown_timeout,
+        )
+        stop_evt = threading.Event()
+        f = filter_cls(config, stop_evt)
+        f.mq = MagicMock()
+        f.mq.metrics = {}
+        f.mq.sender = None
+        f.logger = MagicMock()
+        f.logger.enabled = False
+        f._is_last_filter = False
+        f._metadata_queue = MagicMock()
+        f._metadata_queue.put_nowait = MagicMock()
+        f.emitter = None
+        f.setup(config)
+        return f
+
+    def test_invalid_batch_workers_zero(self):
+        config = FilterConfig(id="bad", batch_size=2, batch_workers=0)
+        with self.assertRaises(ValueError):
+            Filter.normalize_config(config)
+
+    def test_batch_workers_one_is_inline_path(self):
+        """batch_workers=1 keeps the synchronous path — no pool ever created."""
+        f = self._make_filter(CountingBatchFilter, batch_size=2, workers=1)
+        f.process_frames({"main": Frame({"val": 1})})
+        f.process_frames({"main": Frame({"val": 2})})
+        self.assertEqual(len(f.received_batches), 1)
+        # Pool was never instantiated.
+        self.assertIsNone(f._batch_pool)
+
+    def test_pool_returns_callables(self):
+        """In pool mode, _execute_batch returns Callables (not dicts)."""
+        f = self._make_filter(CountingBatchFilter, batch_size=2, workers=2)
+        try:
+            results = f._execute_batch([
+                {"main": Frame({"val": 1})},
+                {"main": Frame({"val": 2})},
+            ])
+            self.assertEqual(len(results), 2)
+            for r in results:
+                self.assertTrue(callable(r))
+            # Resolve one to verify it returns a real dict.
+            resolved = results[0]()
+            self.assertIsInstance(resolved, dict)
+        finally:
+            f.fini()
+
+    def test_pool_batches_overlap_in_wall_clock(self):
+        """Two batches submitted back-to-back actually run in parallel."""
+
+        barrier = threading.Barrier(2, timeout=5.0)
+
+        class OverlapFilter(Filter):
+            def setup(self, config):
+                self.started_at = []
+                self.ended_at = []
+
+            def process(self, frames):
+                return frames
+
+            def process_batch(self, batch):
+                self.started_at.append(time.time())
+                # Wait for both workers to enter before either returns —
+                # only possible if they ran concurrently.
+                barrier.wait()
+                self.ended_at.append(time.time())
+                return [{"main": Frame({"slot": 0})}] * len(batch)
+
+        f = self._make_filter(OverlapFilter, batch_size=1, workers=2)
+        try:
+            r1 = f._execute_batch([{"main": Frame({"a": 1})}])
+            r2 = f._execute_batch([{"main": Frame({"a": 2})}])
+            # Resolve both — this drives the futures to completion.
+            r1[0]()
+            r2[0]()
+            self.assertEqual(len(f.started_at), 2)
+            # Both batches must have entered the barrier at the same time
+            # (sequential execution would deadlock at barrier.wait()).
+            self.assertLess(abs(f.started_at[1] - f.started_at[0]), 1.0)
+        finally:
+            f.fini()
+
+    def test_pool_backpressure_blocks_submission_when_full(self):
+        """When the pool is full (all batch_workers slots in use),
+        _execute_batch_pool blocks on the semaphore until a worker frees."""
+
+        gate = threading.Event()
+
+        class GatedFilter(Filter):
+            def setup(self, config):
+                pass
+
+            def process(self, frames):
+                return frames
+
+            def process_batch(self, batch):
+                gate.wait(timeout=5.0)
+                return [{"main": Frame({"done": True})}] * len(batch)
+
+        # workers=2 so we can saturate with two submissions before the third
+        # backpressures. workers=1 would take the synchronous path entirely.
+        f = self._make_filter(GatedFilter, batch_size=1, workers=2)
+        try:
+            r1 = f._execute_batch([{"main": Frame({"a": 1})}])
+            r2 = f._execute_batch([{"main": Frame({"a": 2})}])
+            # Pool fully busy at 2/2. Third submit should block.
+            blocked = threading.Event()
+            released = threading.Event()
+            r3_holder = []
+
+            def submit_third():
+                blocked.set()
+                r3 = f._execute_batch([{"main": Frame({"a": 3})}])
+                r3_holder.append(r3)
+                released.set()
+
+            t = threading.Thread(target=submit_third)
+            t.start()
+            blocked.wait(timeout=1.0)
+            time.sleep(0.1)
+            self.assertFalse(
+                released.is_set(),
+                "third submit should be blocked while pool is full",
+            )
+            # Let workers finish — semaphore frees, third submission proceeds.
+            gate.set()
+            released.wait(timeout=5.0)
+            self.assertTrue(released.is_set())
+            t.join(timeout=5.0)
+            # Drain to release pool workers cleanly.
+            r1[0]()
+            r2[0]()
+            r3_holder[0][0]()
+        finally:
+            f.fini()
+
+    def test_pool_drains_on_fini(self):
+        """fini() waits for in-flight batches up to batch_shutdown_timeout_s."""
+
+        class SlowFilter(Filter):
+            def setup(self, config):
+                pass
+
+            def process(self, frames):
+                return frames
+
+            def process_batch(self, batch):
+                time.sleep(0.2)
+                return [{"main": Frame({"done": True})}] * len(batch)
+
+        f = self._make_filter(
+            SlowFilter, batch_size=1, workers=2, shutdown_timeout=5.0
+        )
+        # Submit but don't poll the callables — they're in flight.
+        f._execute_batch([{"main": Frame({"a": 1})}])
+        f._execute_batch([{"main": Frame({"a": 2})}])
+        # Fini should wait for both to finish (< 5s timeout).
+        t0 = time.time()
+        f.fini()
+        elapsed = time.time() - t0
+        self.assertLess(elapsed, 5.0)
+        # All futures should have completed (no warning would fire).
+        with f._batch_inflight_lock:
+            # add_done_callback fires async — give it a tick to drain.
+            time.sleep(0.05)
+            self.assertEqual(len(f._batch_inflight), 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_frame_accumulation.py
+++ b/tests/test_frame_accumulation.py
@@ -897,5 +897,134 @@ class TestAccumulateWindow(unittest.TestCase):
         self.assertEqual(len(f.received_batches), 2)
 
 
+class TestManualBatchTrigger(unittest.TestCase):
+    """batch_trigger='manual' disables auto count/timeout triggers; only
+    Filter.flush_batch() drains.
+    """
+
+    def _make_filter(
+        self,
+        filter_cls,
+        batch_size,
+        trigger="auto",
+        window=None,
+        timeout_ms=1000.0,
+    ):
+        kwargs = {
+            "id": "test-manual",
+            "batch_size": batch_size,
+            "accumulate_timeout_ms": timeout_ms,
+            "batch_trigger": trigger,
+        }
+        if window is not None:
+            kwargs["accumulate_window"] = window
+        config = FilterConfig(**kwargs)
+        stop_evt = threading.Event()
+        f = filter_cls(config, stop_evt)
+        f.mq = MagicMock()
+        f.mq.metrics = {}
+        f.mq.sender = None
+        f.logger = MagicMock()
+        f.logger.enabled = False
+        f._is_last_filter = False
+        f._metadata_queue = MagicMock()
+        f._metadata_queue.put_nowait = MagicMock()
+        f.emitter = None
+        f.setup(config)
+        return f
+
+    def test_invalid_batch_trigger(self):
+        config = FilterConfig(id="bad", batch_size=2, batch_trigger="sometimes")
+        with self.assertRaises(ValueError) as ctx:
+            Filter.normalize_config(config)
+        self.assertIn("batch_trigger", str(ctx.exception))
+
+    def test_default_trigger_is_auto(self):
+        f = self._make_filter(CountingBatchFilter, batch_size=2)
+        self.assertEqual(f._batch_trigger, "auto")
+
+    def test_manual_mode_suppresses_count_trigger(self):
+        """In manual mode, accumulating batch_size frames does NOT dispatch."""
+        f = self._make_filter(CountingBatchFilter, batch_size=2, trigger="manual")
+        f.process_frames({"main": Frame({"val": 1})})
+        f.process_frames({"main": Frame({"val": 2})})
+        f.process_frames({"main": Frame({"val": 3})})
+        self.assertEqual(len(f.received_batches), 0)
+        # Frames pile up in the buffer.
+        self.assertEqual(len(f._frame_buffer), 3)
+
+    def test_manual_mode_does_not_start_watcher(self):
+        """Manual mode skips the timeout watcher entirely."""
+        f = self._make_filter(
+            CountingBatchFilter, batch_size=5, trigger="manual", timeout_ms=50.0
+        )
+        f.process_frames({"main": Frame({"val": 1})})
+        # No watcher should have been started — _reset_batch_timer isn't called.
+        self.assertIsNone(f._batch_watcher)
+
+    def test_flush_batch_triggers_dispatch_on_next_frame(self):
+        """flush_batch() sets the event; the next frame append picks it up and
+        dispatches."""
+        f = self._make_filter(CountingBatchFilter, batch_size=5, trigger="manual")
+        f.process_frames({"main": Frame({"val": 1})})
+        f.process_frames({"main": Frame({"val": 2})})
+        self.assertEqual(len(f.received_batches), 0)
+        f.flush_batch()
+        f.process_frames({"main": Frame({"val": 3})})
+        self.assertEqual(len(f.received_batches), 1)
+        # All three frames should be in the dispatched batch (manual mode without
+        # accumulate_window keeps the simple list buffer that drains on dispatch).
+        dispatched = f.received_batches[0]
+        self.assertEqual(len(dispatched), 3)
+
+    def test_flush_batch_noop_in_non_batch_mode(self):
+        """At batch_size == 1, flush_batch is a documented no-op."""
+        f = self._make_filter(FallbackBatchFilter, batch_size=1)
+        # Should not raise, should not flip the event (event doesn't gate
+        # anything in batch_size=1 path, but verify the contract).
+        f.flush_batch()
+        self.assertFalse(f._batch_flush_event.is_set())
+
+    def test_manual_mode_safety_cap_force_flushes(self):
+        """If a manual-mode filter never calls flush_batch(), the runtime
+        force-flushes at batch_size * 4 to bound memory."""
+        f = self._make_filter(CountingBatchFilter, batch_size=2, trigger="manual")
+        # batch_size=2 → safety cap at 8 frames.
+        for i in range(8):
+            f.process_frames({"main": Frame({"val": i})})
+        # 8th frame should have tripped the safety cap and force-dispatched.
+        self.assertEqual(len(f.received_batches), 1)
+        self.assertEqual(len(f.received_batches[0]), 8)
+
+    def test_auto_mode_count_trigger_still_fires(self):
+        """batch_trigger='auto' (default) — count trigger behaves as before."""
+        f = self._make_filter(CountingBatchFilter, batch_size=2, trigger="auto")
+        f.process_frames({"main": Frame({"val": 1})})
+        f.process_frames({"main": Frame({"val": 2})})
+        self.assertEqual(len(f.received_batches), 1)
+
+    def test_manual_mode_with_sliding_window(self):
+        """Manual mode composes with accumulate_window: flush_batch() picks
+        from the ring via select_batch()."""
+        f = self._make_filter(
+            CountingBatchFilter, batch_size=2, trigger="manual", window=6
+        )
+        for i in range(4):
+            f.process_frames({"main": Frame({"val": i})})
+        self.assertEqual(len(f.received_batches), 0)
+        # Ring should hold all 4 frames.
+        self.assertEqual(len(f._frame_buffer), 4)
+        f.flush_batch()
+        f.process_frames({"main": Frame({"val": 4})})
+        self.assertEqual(len(f.received_batches), 1)
+        # Sliding mode preserves ring; default select_batch returns last batch_size.
+        dispatched = f.received_batches[0]
+        self.assertEqual(len(dispatched), 2)
+        vals = [b["main"].data["val"] for b in dispatched]
+        self.assertEqual(vals, [3, 4])
+        # Ring should still hold the 5 frames (capped at 6 maxlen).
+        self.assertEqual(len(f._frame_buffer), 5)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_frame_accumulation.py
+++ b/tests/test_frame_accumulation.py
@@ -177,9 +177,11 @@ class TestBatchAccumulation(unittest.TestCase):
         self.assertEqual(len(f._frame_buffer), 2)
         self.assertFalse(f._batch_flush_event.is_set())
 
-        time.sleep(0.1)
-
-        self.assertTrue(f._batch_flush_event.is_set())
+        # The 50ms watcher timeout should set the flush event. Wait on the
+        # event itself rather than sleeping a fixed window — Event.wait()
+        # returns the instant it fires and times out generously, so a loaded
+        # CI runner can't flake it.
+        self.assertTrue(f._batch_flush_event.wait(timeout=2.0))
 
     def test_flush_returns_partial_batch(self):
         f = self._make_filter(batch_size=5, timeout_ms=50.0)
@@ -187,7 +189,9 @@ class TestBatchAccumulation(unittest.TestCase):
         f.process_frames({"main": Frame({"val": 1})})
         f.process_frames({"main": Frame({"val": 2})})
 
-        time.sleep(0.1)
+        # Wait for the 50ms watcher to set the flush event before draining,
+        # rather than sleeping a fixed window.
+        self.assertTrue(f._batch_flush_event.wait(timeout=2.0))
 
         result = f._process_batch_flush()
         self.assertIsNotNone(result)
@@ -414,33 +418,36 @@ class TestTimerReset(unittest.TestCase):
                 continue
         Removing those lines causes a premature flush at the original deadline.
         """
-        # batch_size=5 so the batch never completes via accumulation in this test
-        f = self._make_filter(batch_size=5, timeout_ms=100.0)
+        # batch_size=5 so the batch never completes via accumulation in this
+        # test. The 200ms watcher timeout is deliberately generous so the
+        # negative assertion below sits ~160ms clear of the reset deadline —
+        # well above scheduler jitter on a loaded CI runner.
+        f = self._make_filter(batch_size=5, timeout_ms=200.0)
 
-        # Frame 1 at t≈0ms: starts the 100ms watcher timer
+        # Frame 1 at t≈0ms: starts the 200ms watcher timer
         f.process_frames({"main": Frame({"val": 1})})
 
-        # Sleep ~60ms, well inside the original 100ms window
-        time.sleep(0.06)
+        # Sleep ~120ms, well inside the original 200ms window
+        time.sleep(0.12)
 
-        # Frame 2 at t≈60ms: _reset_batch_timer() sets _batch_wakeup mid-sleep.
-        # The watcher only observes that signal when its initial ~100ms sleep
+        # Frame 2 at t≈120ms: _reset_batch_timer() sets _batch_wakeup mid-sleep.
+        # The watcher only observes that signal when its initial ~200ms sleep
         # completes, then restarts for another full timeout, so the effective
-        # flush deadline is ~original deadline + 100ms (~200ms), not ~160ms.
+        # flush deadline is ~original deadline + 200ms (~400ms), not ~320ms.
         f.process_frames({"main": Frame({"val": 2})})
 
-        # At t≈100ms (original deadline): flush must NOT have fired yet.
-        # The watcher's first sleep expires here; seeing _batch_wakeup set it restarts
-        # for another full timeout rather than flushing immediately.
-        time.sleep(0.04)
+        # At t≈240ms — past the original 200ms deadline, ~160ms before the
+        # reset deadline (~400ms): flush must NOT have fired yet. If the timer
+        # reset were broken the flush would have fired at the ~200ms deadline.
+        time.sleep(0.12)
         self.assertFalse(
             f._batch_flush_event.is_set(),
             "flush fired at the original deadline; timer reset is not working",
         )
 
-        # Watcher restarts at t≈100ms; expected flush at t≈200ms.  Wait up to
-        # 500ms so the test tolerates scheduler jitter on loaded CI runners.
-        fired = f._batch_flush_event.wait(timeout=0.5)
+        # Watcher restarts at t≈200ms; expected flush at t≈400ms.  Wait up to
+        # 1s so the test tolerates scheduler jitter on loaded CI runners.
+        fired = f._batch_flush_event.wait(timeout=1.0)
         self.assertTrue(fired, "flush never fired after the reset deadline")
 
         f._stop_batch_watcher()
@@ -1025,6 +1032,41 @@ class TestManualBatchTrigger(unittest.TestCase):
         # Ring should still hold the 5 frames (capped at 6 maxlen).
         self.assertEqual(len(f._frame_buffer), 5)
 
+    def test_manual_mode_not_drained_by_source_timeout(self):
+        """In manual mode loop_once's source-timeout path must NOT drain the
+        buffer — only flush_batch() drains. (Auto mode flushes partials there.)
+        Regression guard for the timeout-flush path bypassing batch_trigger.
+        """
+        f = self._make_filter(CountingBatchFilter, batch_size=5, trigger="manual")
+        f.mq.send = MagicMock(return_value=True)
+        # Short source timeout so loop_once's recv-timeout path is reached fast.
+        f.sources_timeout = 30.0
+        f.outputs_timeout = 5000.0
+        f.exit_after_t = None
+
+        # Accumulate two frames — batch never fills (batch_size=5).
+        f.mq.recv = MagicMock(return_value={"main": Frame({"val": 1})})
+        f.loop_once()
+        f.mq.recv = MagicMock(return_value={"main": Frame({"val": 2})})
+        f.loop_once()
+        self.assertEqual(len(f._frame_buffer), 2)
+        self.assertEqual(len(f.received_batches), 0)
+
+        # recv times out (slow source). In auto mode this flushes the partial
+        # batch; in manual mode the buffer must be left intact.
+        f.mq.recv = MagicMock(return_value=None)
+        f.loop_once()
+        self.assertEqual(len(f.received_batches), 0)
+        self.assertEqual(len(f._frame_buffer), 2)
+        self.assertFalse(f.mq.send.called)
+
+        # flush_batch() still drains: the next loop_once picks up the event.
+        f.flush_batch()
+        f.mq.recv = MagicMock(return_value=None)
+        f.loop_once()
+        self.assertEqual(len(f.received_batches), 1)
+        self.assertEqual(len(f.received_batches[0]), 2)
+
 
 class TestBatchWorkersPool(unittest.TestCase):
     """batch_workers > 1: process_batch runs on a ThreadPoolExecutor; per-slot
@@ -1161,17 +1203,25 @@ class TestBatchWorkersPool(unittest.TestCase):
 
             t = threading.Thread(target=submit_third)
             t.start()
-            blocked.wait(timeout=1.0)
-            time.sleep(0.1)
+            self.assertTrue(
+                blocked.wait(timeout=2.0), "submit_third thread never started"
+            )
+            # The third submission is now blocked on the semaphore (pool 2/2
+            # busy). `released` provably cannot be set until gate.set() below
+            # frees a worker, so assert thread liveness rather than sleeping a
+            # fixed window: the thread stays alive and `released` stays unset.
+            self.assertTrue(t.is_alive())
             self.assertFalse(
                 released.is_set(),
                 "third submit should be blocked while pool is full",
             )
             # Let workers finish — semaphore frees, third submission proceeds.
             gate.set()
-            released.wait(timeout=5.0)
-            self.assertTrue(released.is_set())
+            self.assertTrue(
+                released.wait(timeout=5.0), "third submit never unblocked"
+            )
             t.join(timeout=5.0)
+            self.assertFalse(t.is_alive())
             # Drain to release pool workers cleanly.
             r1[0]()
             r2[0]()
@@ -1204,11 +1254,69 @@ class TestBatchWorkersPool(unittest.TestCase):
         f.fini()
         elapsed = time.time() - t0
         self.assertLess(elapsed, 5.0)
-        # All futures should have completed (no warning would fire).
+        # All in-flight futures should have drained. add_done_callback fires
+        # asynchronously, so poll with a deadline rather than asserting once
+        # after a fixed sleep — and don't hold _batch_inflight_lock across the
+        # wait, since the done-callback needs that lock to discard the future.
+        deadline = time.time() + 2.0
+        while time.time() < deadline:
+            with f._batch_inflight_lock:
+                if not f._batch_inflight:
+                    break
+            time.sleep(0.01)
         with f._batch_inflight_lock:
-            # add_done_callback fires async — give it a tick to drain.
-            time.sleep(0.05)
             self.assertEqual(len(f._batch_inflight), 0)
+
+    def test_pool_worker_exception_drops_batch_and_continues(self):
+        """A process_batch() exception in pool mode is non-fatal: the worker
+        logs it, the batch is dropped (every slot resolves to None), and the
+        filter stays usable. This DIVERGES from the synchronous path, which
+        re-raises — the divergence is the locked-in contract (see
+        Filter._batch_pool_worker).
+        """
+
+        class FlakyFilter(Filter):
+            def setup(self, config):
+                self.calls = 0
+
+            def process(self, frames):
+                return frames
+
+            def process_batch(self, batch):
+                self.calls += 1
+                if self.calls == 1:
+                    raise RuntimeError("simulated batch failure")
+                return [{"main": Frame({"ok": True})}] * len(batch)
+
+        f = self._make_filter(FlakyFilter, batch_size=2, workers=2)
+        try:
+            # First batch raises in the pool worker. Submitting and resolving
+            # the slots must NOT raise — the failed batch is dropped (every
+            # slot resolves to None) and the failure is logged exactly once.
+            with self.assertLogs(
+                "openfilter.filter_runtime.filter", level="ERROR"
+            ) as cm:
+                bad = f._execute_batch([
+                    {"main": Frame({"val": 1})},
+                    {"main": Frame({"val": 2})},
+                ])
+                self.assertEqual(len(bad), 2)
+                for slot in bad:
+                    self.assertIsNone(slot())
+            dropped = [ln for ln in cm.output if "dropping the batch" in ln]
+            self.assertEqual(
+                len(dropped), 1, "batch failure should be logged exactly once"
+            )
+
+            # The filter is still usable: a subsequent batch succeeds.
+            good = f._execute_batch([
+                {"main": Frame({"val": 3})},
+                {"main": Frame({"val": 4})},
+            ])
+            for slot in good:
+                self.assertIsInstance(slot(), dict)
+        finally:
+            f.fini()
 
 
 if __name__ == "__main__":

--- a/tests/test_frame_accumulation.py
+++ b/tests/test_frame_accumulation.py
@@ -586,5 +586,189 @@ class TestLoopOncePendingResultsDrain(unittest.TestCase):
         f._batch_watcher.join(timeout=1.0)
 
 
+class TestBatchDeferredCallable(unittest.TestCase):
+    """process_batch() may return Callable slots that the runtime invokes later via
+    mq.send's existing Callable polling. Mirrors the deferred-result path that
+    process() already supports.
+    """
+
+    def _make_filter(self, filter_cls, batch_size=3, timeout_ms=1000.0):
+        config = FilterConfig(
+            id="test-deferred",
+            batch_size=batch_size,
+            accumulate_timeout_ms=timeout_ms,
+        )
+        stop_evt = threading.Event()
+        f = filter_cls(config, stop_evt)
+        f.mq = MagicMock()
+        f.mq.metrics = {}
+        f.mq.sender = None
+        f.logger = MagicMock()
+        f.logger.enabled = False
+        f._is_last_filter = False
+        f._metadata_queue = MagicMock()
+        f._metadata_queue.put_nowait = MagicMock()
+        f.emitter = None
+        f.setup(config)
+        return f
+
+    def test_all_callable_slots_returned_to_send_path(self):
+        """A batch where every slot is a Callable: process_frames returns the last
+        Callable, earlier Callables land in _batch_pending_results. Each is still
+        callable() at the point loop_once would hand it to mq.send."""
+
+        class DeferredFilter(Filter):
+            def setup(self, config):
+                pass
+
+            def process(self, frames):
+                return frames
+
+            def process_batch(self, batch):
+                # Capture each frame by value so each closure resolves to the right input.
+                return [(lambda fs=fs: fs) for fs in batch]
+
+        f = self._make_filter(DeferredFilter, batch_size=3)
+
+        f.process_frames({"main": Frame({"val": 1})})
+        f.process_frames({"main": Frame({"val": 2})})
+        last = f.process_frames({"main": Frame({"val": 3})})
+
+        self.assertTrue(callable(last))
+        self.assertEqual(len(f._batch_pending_results), 2)
+        for pending in f._batch_pending_results:
+            self.assertTrue(callable(pending))
+
+    def test_callable_slot_resolves_to_dict_on_invocation(self):
+        """Invoking a returned closure resolves it: dict comes out, EMA updates,
+        metadata is queued, _inject_timings stamps the frame.
+
+        Calls _execute_batch directly to keep the assertion focused on the
+        closure's resolution semantics (process_frames only goes through the
+        batched path at batch_size > 1).
+        """
+
+        class DeferredFilter(Filter):
+            def setup(self, config):
+                pass
+
+            def process(self, frames):
+                return frames
+
+            def process_batch(self, batch):
+                return [lambda: {"main": Frame({"resolved": True})}]
+
+        f = self._make_filter(DeferredFilter, batch_size=2)
+        prior_ema = f._process_time_ema
+        results = f._execute_batch([{"main": Frame({"val": 1})}])
+        self.assertEqual(len(results), 1)
+        closure = results[0]
+        self.assertTrue(callable(closure))
+
+        # EMA should NOT have been touched by the synchronous _execute_batch when
+        # any slot is a Callable — matches _process_frames_single's behavior.
+        self.assertEqual(f._process_time_ema, prior_ema)
+
+        resolved = closure()
+        self.assertIsInstance(resolved, dict)
+        self.assertIn("main", resolved)
+        self.assertTrue(resolved["main"].data["resolved"])
+
+        # Closure resolution should have updated the EMA and queued metadata.
+        self.assertNotEqual(f._process_time_ema, prior_ema)
+        f._metadata_queue.put_nowait.assert_called()
+
+    def test_mixed_dict_and_callable_batch(self):
+        """A batch where some slots are dicts and some are Callables: dicts emerge
+        finalized at submission time, Callables emerge as closures that finalize
+        on invocation. The list order is preserved.
+        """
+
+        class MixedFilter(Filter):
+            def setup(self, config):
+                pass
+
+            def process(self, frames):
+                return frames
+
+            def process_batch(self, batch):
+                # Slot 0 immediate, slot 1 deferred, slot 2 immediate.
+                return [
+                    {"main": Frame({"slot": 0})},
+                    lambda: {"main": Frame({"slot": 1, "deferred": True})},
+                    {"main": Frame({"slot": 2})},
+                ]
+
+        f = self._make_filter(MixedFilter, batch_size=3)
+        f.process_frames({"main": Frame({"val": 1})})
+        f.process_frames({"main": Frame({"val": 2})})
+        last = f.process_frames({"main": Frame({"val": 3})})
+
+        # Order: slot 0 dict, slot 1 closure, slot 2 dict — last is slot 2 (dict).
+        self.assertIsInstance(last, dict)
+        self.assertEqual(last["main"].data["slot"], 2)
+
+        self.assertEqual(len(f._batch_pending_results), 2)
+        first, middle = f._batch_pending_results
+        self.assertIsInstance(first, dict)
+        self.assertEqual(first["main"].data["slot"], 0)
+        self.assertTrue(callable(middle))
+        resolved_middle = middle()
+        self.assertEqual(resolved_middle["main"].data["slot"], 1)
+        self.assertTrue(resolved_middle["main"].data["deferred"])
+
+    def test_callable_slot_resolving_to_none(self):
+        """A Callable that returns None on resolution behaves as a sink for that
+        slot. mq.send already handles a None return from a Callable.
+        """
+
+        class DeferredSinkFilter(Filter):
+            def setup(self, config):
+                pass
+
+            def process(self, frames):
+                return frames
+
+            def process_batch(self, batch):
+                return [lambda: None]
+
+        f = self._make_filter(DeferredSinkFilter, batch_size=2)
+        results = f._execute_batch([{"main": Frame({"val": 1})}])
+        self.assertEqual(len(results), 1)
+        closure = results[0]
+        self.assertTrue(callable(closure))
+        self.assertIsNone(closure())
+
+    def test_ema_not_updated_when_any_slot_callable(self):
+        """If ANY slot is a Callable, the synchronous EMA update in _execute_batch
+        is skipped — each Callable does its own EMA update on resolution. Mirrors
+        _process_frames_single's behavior.
+        """
+
+        class PartialDeferFilter(Filter):
+            def setup(self, config):
+                pass
+
+            def process(self, frames):
+                return frames
+
+            def process_batch(self, batch):
+                # Two dicts and one Callable: the presence of a Callable should
+                # suppress the batch-level EMA update.
+                return [
+                    {"main": Frame({"slot": 0})},
+                    {"main": Frame({"slot": 1})},
+                    lambda: {"main": Frame({"slot": 2})},
+                ]
+
+        f = self._make_filter(PartialDeferFilter, batch_size=3)
+        prior_ema = f._process_time_ema
+        f.process_frames({"main": Frame({"val": 1})})
+        f.process_frames({"main": Frame({"val": 2})})
+        f.process_frames({"main": Frame({"val": 3})})
+
+        self.assertEqual(f._process_time_ema, prior_ema)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_frame_accumulation.py
+++ b/tests/test_frame_accumulation.py
@@ -682,9 +682,8 @@ class TestBatchDeferredCallable(unittest.TestCase):
         self.assertTrue(resolved["main"].data["resolved"])
 
         # Closure resolution should have updated the EMA and queued metadata.
-        self.assertNotEqual(f._process_time_ema, prior_ema)
+        self.assertNotEqual(f._filter_time_in, 0.0)
         f._metadata_queue.put_nowait.assert_called()
-
     def test_mixed_dict_and_callable_batch(self):
         """A batch where some slots are dicts and some are Callables: dicts emerge
         finalized at submission time, Callables emerge as closures that finalize

--- a/tests/test_frame_accumulation.py
+++ b/tests/test_frame_accumulation.py
@@ -770,5 +770,132 @@ class TestBatchDeferredCallable(unittest.TestCase):
         self.assertEqual(f._process_time_ema, prior_ema)
 
 
+class TestAccumulateWindow(unittest.TestCase):
+    """Sliding-window mode: keep accumulate_window frames in a deque, dispatch
+    every batch_size new frames, route through Filter.select_batch().
+    """
+
+    def _make_filter(self, filter_cls, batch_size, window=None, timeout_ms=1000.0):
+        kwargs = {
+            "id": "test-window",
+            "batch_size": batch_size,
+            "accumulate_timeout_ms": timeout_ms,
+        }
+        if window is not None:
+            kwargs["accumulate_window"] = window
+        config = FilterConfig(**kwargs)
+        stop_evt = threading.Event()
+        f = filter_cls(config, stop_evt)
+        f.mq = MagicMock()
+        f.mq.metrics = {}
+        f.mq.sender = None
+        f.logger = MagicMock()
+        f.logger.enabled = False
+        f._is_last_filter = False
+        f._metadata_queue = MagicMock()
+        f._metadata_queue.put_nowait = MagicMock()
+        f.emitter = None
+        f.setup(config)
+        return f
+
+    def test_window_default_is_one_shot_list(self):
+        """Unset accumulate_window: buffer stays a list, sliding mode off."""
+        f = self._make_filter(CountingBatchFilter, batch_size=2)
+        self.assertFalse(f._sliding_window)
+        self.assertEqual(f._accumulate_window, 2)
+        # list, not deque — so the original drain-on-dispatch contract holds.
+        self.assertIsInstance(f._frame_buffer, list)
+
+    def test_window_set_uses_bounded_deque(self):
+        f = self._make_filter(CountingBatchFilter, batch_size=2, window=8)
+        self.assertTrue(f._sliding_window)
+        self.assertEqual(f._accumulate_window, 8)
+        from collections import deque as _deque
+        self.assertIsInstance(f._frame_buffer, _deque)
+        self.assertEqual(f._frame_buffer.maxlen, 8)
+
+    def test_invalid_window_smaller_than_batch_size(self):
+        config = FilterConfig(id="bad", batch_size=4, accumulate_window=2)
+        with self.assertRaises(ValueError) as ctx:
+            Filter.normalize_config(config)
+        self.assertIn("accumulate_window", str(ctx.exception))
+
+    def test_default_select_batch_returns_last_batch_size(self):
+        """select_batch's default keeps tail semantics — preserves current
+        contract when accumulate_window is unset."""
+        f = self._make_filter(CountingBatchFilter, batch_size=2)
+        window = [
+            {"main": Frame({"val": i})} for i in range(5)
+        ]
+        picked = f.select_batch(window)
+        self.assertEqual(len(picked), 2)
+        self.assertEqual(picked[0]["main"].data["val"], 3)
+        self.assertEqual(picked[1]["main"].data["val"], 4)
+
+    def test_sliding_window_does_not_clear_on_dispatch(self):
+        """With accumulate_window set, the ring persists across dispatches —
+        a frame appended for dispatch K is still present for dispatch K+1."""
+        f = self._make_filter(CountingBatchFilter, batch_size=2, window=4)
+        # Feed batch_size frames → dispatch fires.
+        f.process_frames({"main": Frame({"val": 1})})
+        f.process_frames({"main": Frame({"val": 2})})
+        self.assertEqual(len(f.received_batches), 1)
+        # Ring should still hold both frames.
+        self.assertEqual(len(f._frame_buffer), 2)
+        # Feeding two more triggers the next dispatch; ring grows to 4.
+        f.process_frames({"main": Frame({"val": 3})})
+        f.process_frames({"main": Frame({"val": 4})})
+        self.assertEqual(len(f.received_batches), 2)
+        self.assertEqual(len(f._frame_buffer), 4)
+
+    def test_sliding_window_evicts_oldest_at_maxlen(self):
+        """When window is full and new frame arrives, deque drops the oldest."""
+        f = self._make_filter(CountingBatchFilter, batch_size=2, window=4)
+        for i in range(6):
+            f.process_frames({"main": Frame({"val": i})})
+        # Ring capped at 4; last four values present.
+        vals = [f._frame_buffer[i]["main"].data["val"] for i in range(len(f._frame_buffer))]
+        self.assertEqual(vals, [2, 3, 4, 5])
+
+    def test_custom_select_batch_routed_through_dispatch(self):
+        """Overriding select_batch lets a filter pick non-tail frames."""
+
+        class StridedFilter(CountingBatchFilter):
+            def select_batch(self, window):
+                # Every other frame, capped at batch_size.
+                return list(window)[::2][: self._batch_size]
+
+        f = self._make_filter(StridedFilter, batch_size=2, window=4)
+        for i in range(4):
+            f.process_frames({"main": Frame({"val": i})})
+        # 4 frames in ring: indices [0, 2] picked.
+        self.assertEqual(len(f.received_batches), 2)
+        # Look at the LAST batch dispatched: should be strided picks from the
+        # then-current ring.
+        last_batch = f.received_batches[-1]
+        picked_vals = [b["main"].data["val"] for b in last_batch]
+        # After 4 frames in a window of 4: ring = [0,1,2,3], stride picks [0,2].
+        self.assertEqual(picked_vals, [0, 2])
+
+    def test_window_frames_since_dispatch_counter_resets(self):
+        """The trigger counter (not the ring) is what advances toward batch_size."""
+        f = self._make_filter(CountingBatchFilter, batch_size=3, window=8)
+        # First two frames: counter at 2, no dispatch yet.
+        f.process_frames({"main": Frame({"val": 0})})
+        f.process_frames({"main": Frame({"val": 1})})
+        self.assertEqual(f._frames_since_last_dispatch, 2)
+        self.assertEqual(len(f.received_batches), 0)
+        # Third frame: counter hits 3 → dispatch, counter resets.
+        f.process_frames({"main": Frame({"val": 2})})
+        self.assertEqual(f._frames_since_last_dispatch, 0)
+        self.assertEqual(len(f.received_batches), 1)
+        # Next batch_size frames again → second dispatch.
+        f.process_frames({"main": Frame({"val": 3})})
+        f.process_frames({"main": Frame({"val": 4})})
+        f.process_frames({"main": Frame({"val": 5})})
+        self.assertEqual(f._frames_since_last_dispatch, 0)
+        self.assertEqual(len(f.received_batches), 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# 📦 Pull Request

## 📋 What does this PR do?

Extends `process_batch()` (from openfilter#61) with four composable additions that together let filters with the "ring buffer + curated dispatch + async network call" pattern (every remote-VLM / retrieval / captioning filter today) use the runtime-owned accumulator without reimplementing dispatch machinery per filter:

1. **[FILTER-457](https://plainsight-ai.atlassian.net/browse/FILTER-457) — deferred-callable `process_batch()`.** Each result slot in `process_batch()`'s returned list may now be a `Callable[[], dict[str, Frame] | None]` that `mq.send` invokes lazily — same shape as `process()`'s already-supported `Callable` return. Lets a filter hand the batch's actual work to a worker thread and return a poll closure instead of parking the loop thread on the batch's wall-clock duration. Each `Callable` slot is wrapped in a `_timed_batch_slot` closure that records its own per-slot wall-clock on resolution; pure-synchronous batches preserve existing EMA semantics. (`eefb995`)

2. **[FILTER-459](https://plainsight-ai.atlassian.net/browse/FILTER-459) — sliding window + `select_batch` hook.** New `accumulate_window: int` config decouples the runtime ring buffer from `batch_size`. When set, the buffer becomes a `deque(maxlen=window)`, frames are NOT removed on dispatch (the deque's maxlen handles eviction), and the dispatch trigger fires every `batch_size` new frames via a `_frames_since_last_dispatch` counter. The full ring is passed to a new public `Filter.select_batch()` hook that picks which frames go to `process_batch()`. Default `select_batch` returns the most recent `batch_size` entries, so unset or `window == batch_size` produces no behavior change. (`2f243a8`)

3. **[FILTER-458](https://plainsight-ai.atlassian.net/browse/FILTER-458) — filter-driven flush + `batch_trigger`.** Public `Filter.flush_batch()` schedules an immediate dispatch on the next opportunity (next frame append OR next `loop_once` idle poll). New `batch_trigger: "auto" | "manual"` config: `"manual"` suppresses both the count-based trigger AND the `accumulate_timeout_ms` watcher, leaving `flush_batch()` as the only drain path. Safety cap at `batch_size * 4` force-flushes the full buffer with a warning to surface forgotten flushes. (`4b9584a`)

4. **[FILTER-460](https://plainsight-ai.atlassian.net/browse/FILTER-460) — `batch_workers` pool.** New `batch_workers: int` config (default 1) runs `process_batch()` on a `ThreadPoolExecutor` so the loop accumulates the next batch while previous batches are in flight. Each pool submission returns one `Callable` per slot; the existing `mq.send` `Callable`-polling path resolves them in submission order (loop_once strictly feeds them to `mq.send` in order). Backpressure via `Semaphore(batch_workers)`: when all workers are busy, `_execute_batch_pool` blocks on `acquire()` and the loop stops `recv`'ing — natural upstream backpressure rather than silent drops. `batch_workers=1` (default) keeps the synchronous inline path. Shutdown drain via `concurrent.futures.wait` with `batch_shutdown_timeout_s` (default 60s). (`c33ab38`)

The four commits are independent in spec but they all touch the same `_execute_batch` / `_process_frames_batched` / `loop_once` cluster, so they land in 457 → 459 → 458 → 460 order on one branch rather than as four parallel PRs. Each is left as a separate commit for reviewability; final PR-level squash is reviewer's call.

---

## 🔍 Why is this needed?

openfilter#61's `process_batch()` covered the GPU-bound case: a single forward pass over a batched tensor, where the synchronous dispatch fits the runtime loop fine. It does **not** cover the "ring buffer + curated dispatch + async network call" pattern that every remote-VLM / retrieval / captioning filter re-implements with its own `deque` + `threading.Thread` + dispatch queue + keepalive-during-shutdown wait.

The reference offender is `filter-scene-caption` (`filter.py:305-326`, `642-660`, `427-467`): it keeps a `frame_count * 4` ring buffer, fires inference on `(media-time interval elapsed AND active_key gate open AND focus session valid)`, dispatches via a `threading.Thread` + `deque(maxlen=32)` queue, and emits keepalive frames during shutdown until the queue drains. Every comparable filter (remote-VLM caption, embedding-distance retrieval, re-ID over the last N detections) reimplements the same shape.

Promoting this pattern to a runtime affordance is the same playbook openfilter#82 followed for zero-copy local IPC: take a thing every filter reimplements, fold it into the runtime, delete the per-filter machinery. A follow-up PR in `filter-scene-caption` will validate the migration end-to-end by removing its `_inference_thread` + `_dispatch_queue` + `_wait_with_keepalive` and switching to `batch_workers=1` + `batch_trigger="manual"` + `accumulate_window=frame_count*4` + a `select_batch` override that mirrors its `_sample_frames` strategy.

Goldenrod.3 milestone candidate under epic [FILTER-367 — Inference Performance & Scaling](https://plainsight-ai.atlassian.net/browse/FILTER-367).

---

## 🧪 How was it tested?

**Unit tests:** 28 new tests added to `tests/test_frame_accumulation.py` (5 + 8 + 9 + 6 across the four tickets), covering:

- **Deferred callables:** all-callable batches return `Callable` slots, mixed dict/callable batches preserve slot order, `Callable` slots resolving to `None` route through `mq.send`'s existing None handling, batch-level EMA is skipped when any slot is a `Callable` (matching `_process_frames_single`).
- **Sliding window:** default `accumulate_window` uses the original list buffer; setting it switches to a bounded `deque`; ring persists across dispatches in sliding mode and gets evicted when maxlen is reached; custom `select_batch` overrides route through every dispatch path (count-driven, timeout-driven, shutdown drain); invalid `accumulate_window < batch_size` raises at config validation.
- **Manual trigger:** `batch_trigger="manual"` suppresses count + timeout triggers, the `_batch_watcher` never starts, `flush_batch()` from `process()` includes the just-appended frame, safety cap at `batch_size * 4` force-flushes the FULL buffer (bypasses `select_batch` because the cap is a bailout for a bug), `flush_batch()` at `batch_size=1` is a no-op, manual+sliding compose correctly.
- **Worker pool:** `batch_workers=1` stays on the inline path (no pool created), pool mode returns `Callable` slots, two batches submitted back-to-back actually overlap in wall-clock (verified via `threading.Barrier`), third submission to a `workers=2` pool blocks on the semaphore until a worker frees, `fini()` drains in-flight batches within `batch_shutdown_timeout_s`.

**Final counts:** 56/56 tests in `test_frame_accumulation.py` pass (28 original + 28 new). 536/536 of the broader runnable suite passes. The 37 pre-existing `test_filter_rest.py` failures and 41 pre-existing `test_filter_webvis.py` failures are missing-`fastapi` collection errors, unrelated to this branch.

**Not tested in this PR:** real-pipeline validation against a remote VLM. The pool's overlap, ordering, and backpressure are verified via unit tests with explicit barriers/semaphores, but a `filter-scene-caption` migration PR (follow-up) is what proves the end-to-end shape against Gemini Flash. Each ticket includes that migration as an acceptance criterion.

---

## 🔗 Related Issues

- [FILTER-367](https://plainsight-ai.atlassian.net/browse/FILTER-367) — Inference Performance & Scaling (parent epic, Goldenrod.3)
- [FILTER-457](https://plainsight-ai.atlassian.net/browse/FILTER-457) — Allow `process_batch()` to return a deferred callable
- [FILTER-458](https://plainsight-ai.atlassian.net/browse/FILTER-458) — Filter-driven flush trigger (`Filter.flush_batch`)
- [FILTER-459](https://plainsight-ai.atlassian.net/browse/FILTER-459) — Separate accumulation window from batch size (`Filter.select_batch` hook)
- [FILTER-460](https://plainsight-ai.atlassian.net/browse/FILTER-460) — Multiple in-flight batches via opt-in worker pool (`batch_workers`)

Builds on [FILTER-369](https://plainsight-ai.atlassian.net/browse/FILTER-369) (openfilter#61, frame accumulation foundation).
Same runtime-affordance playbook as openfilter#82 (zero-copy local IPC).

---

## 🖼️ Screenshots or Logs (if applicable)

N/A — runtime change, no UI. Test output:

```
$ uv run --extra dev python -m pytest tests/test_frame_accumulation.py -q
...
56 passed, 202 warnings in 4.94s
```

---

## ✅ Checklist

- [x] I have read and agreed to the terms of the [LICENSE](../LICENSE)
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have followed the [coding style](../CONTRIBUTING.md#coding-style)
- [x] I have signed all commits in compliance with the DCO (`git commit -s`)
- [x] I have added or updated **tests** as needed (28 new tests in `tests/test_frame_accumulation.py`)
- [x] I have added or updated **documentation** as needed — N/A


[FILTER-457]: https://plainsight-ai.atlassian.net/browse/FILTER-457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FILTER-459]: https://plainsight-ai.atlassian.net/browse/FILTER-459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ