### PR TITLE
feat(create-release): cascade pipeline-manifest bumps for built-in filter images (PLAT-1052)

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -368,3 +368,41 @@ jobs:
           tags: ${{ steps.prepare-tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Second-level pipeline-manifest cascade for the built-in filter images.
+  # Standalone filter-* repos fire cascade-pipeline-bumps through
+  # filter-release.yaml; the built-in filters (video-in/out, image-in/out,
+  # mqtt-out, recorder, rest, webvis) have no standalone repo — they are
+  # built by the publish-docker-images matrix above — so the cascade has
+  # to be fired here, once per published image, or their pins in
+  # pipeline-manifest consumers (e.g. openfilter-pipelines-controller
+  # Pipeline CRs) are never bumped. PLAT-1052.
+  #
+  # The matrix mirrors publish-docker-images. The reusable workflow no-ops
+  # cleanly for a consumer with no matching pins, so cascading every
+  # built-in image — rather than a hand-picked subset — is safe and keeps
+  # this list in lockstep with what is actually published.
+  #
+  # NOTE: cascade-pipeline-bumps.yaml ships in gh-actions-public via
+  # PLAT-1052 (PR #19); this job's `@main` ref only resolves once that PR
+  # is merged. Do not merge this branch before it.
+  cascade-pipeline-bumps:
+    needs: [prepare-pypi-publish, publish-docker-images]
+    if: needs.prepare-pypi-publish.outputs.already_exists == 'false'
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - plainsightai/openfilter-video-in
+          - plainsightai/openfilter-video-out
+          - plainsightai/openfilter-image-in
+          - plainsightai/openfilter-image-out
+          - plainsightai/openfilter-mqtt-out
+          - plainsightai/openfilter-recorder
+          - plainsightai/openfilter-rest
+          - plainsightai/openfilter-webvis
+    uses: PlainsightAI/gh-actions-public/.github/workflows/cascade-pipeline-bumps.yaml@main
+    with:
+      docker_image: ${{ matrix.image }}
+      version: ${{ needs.prepare-pypi-publish.outputs.package_version }}
+    secrets: inherit

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -41,6 +41,7 @@ jobs:
     outputs:
       is_release_created: ${{ steps.release_meta.outputs.is_release_created }}
       version: ${{ steps.release_meta.outputs.version }}
+      is_production_release: ${{ steps.release_meta.outputs.is_production_release }}
     runs-on: ubuntu-latest
     needs: run-unit-tests
     if: github.event_name == 'workflow_dispatch'
@@ -120,6 +121,7 @@ jobs:
             echo "is_release_created=false" >> $GITHUB_OUTPUT
           fi
           echo "version=${{ env.CHANGELOG_VERSION }}" >> $GITHUB_OUTPUT
+          echo "is_production_release=${{ steps.changelog.outputs.isProductionRelease }}" >> $GITHUB_OUTPUT
 
 
   prepare-pypi-publish:
@@ -383,12 +385,16 @@ jobs:
   # built-in image — rather than a hand-picked subset — is safe and keeps
   # this list in lockstep with what is actually published.
   #
-  # NOTE: cascade-pipeline-bumps.yaml ships in gh-actions-public via
-  # PLAT-1052 (PR #19); this job's `@main` ref only resolves once that PR
-  # is merged. Do not merge this branch before it.
+  # Gated on is_production_release: a dev/prerelease dispatch (e.g.
+  # v0.2.0.dev0, v1.0.1-rc1) publishes non-prod image coordinates and
+  # must not rewrite production pipeline-manifest consumer pins. This
+  # mirrors the is_production_release gate in filter-release.yaml's
+  # cascade-gate job in gh-actions-public.
   cascade-pipeline-bumps:
-    needs: [prepare-pypi-publish, publish-docker-images]
-    if: needs.prepare-pypi-publish.outputs.already_exists == 'false'
+    needs: [create-release, prepare-pypi-publish, publish-docker-images]
+    if: >-
+      needs.prepare-pypi-publish.outputs.already_exists == 'false'
+      && needs.create-release.outputs.is_production_release == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## 📋 What does this PR do?

Adds a `cascade-pipeline-bumps` job to `create-release.yaml` that fires the second-level pipeline-manifest cascade for OpenFilter's built-in filter images. After the `publish-docker-images` matrix pushes the eight built-in images (video-in/out, image-in/out, mqtt-out, recorder, rest, webvis), the new job calls the reusable workflow
`gh-actions-public/.github/workflows/cascade-pipeline-bumps.yaml` once per image — a matrix mirroring `publish-docker-images` — so each built-in filter's version pins are bumped in pipeline-manifest consumers (e.g. `openfilter-pipelines-controller` `Pipeline` CRs).

## 🔍 Why is this needed?

PLAT-1052 added the second-level cascade and wired it into `filter-release.yaml`, so a standalone `filter-*` repo release bumps that filter's image pins in pipeline manifests. The built-in filters have no standalone repo — they are built and pushed by this workflow's `publish-docker-images` matrix — so they never flow through `filter-release.yaml` and never triggered the cascade. Their pins in pipeline-manifest consumers would go stale on every OpenFilter release.

These are the most-pinned images of all: every pipeline has an input and an output filter, and those are always built-ins. Covering them is what makes the cascade actually keep running pipelines current.

## 🧪 How was it tested?

CI-workflow change; no unit-test surface. Verified by:

- `yaml.safe_load` on the modified `create-release.yaml` — parses clean.
- Static review of the call contract: `docker_image` / `version` match the reusable workflow's `workflow_call` inputs; the matrix mirrors `publish-docker-images`; `secrets: inherit` forwards `GH_BOT_USER_PAT` (already present in this repo) and the optional `SLACK_WEBHOOK_URL`.

End-to-end exercise happens on the next `Create Release` dispatch — the reusable workflow no-ops cleanly per consumer when an image has no matching pins, so cascading all eight built-in images is safe.

## 🔗 Related Issues

- [PLAT-1052](https://plainsight-ai.atlassian.net/browse/PLAT-1052) — second-level pipeline-manifest cascade; this extends it to the built-in filter images that have no standalone `filter-*` repo.
- Depends on PLAT-1052's `gh-actions-public` PR #19 (merged) — the `cascade-pipeline-bumps.yaml@main` ref only resolves once it is on `main`.
- Distinct from `cascade-on-tag.yaml`, the first-level cascade (SDK dependency bumps into `filter-*` repo sources).

## 🖼️ Screenshots or Logs (if applicable)

N/A — CI workflow change; no runtime or UI surface.

## ✅ Checklist

- [x] I have read and agreed to the terms of the [LICENSE](../LICENSE)
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have followed the [coding style](../CONTRIBUTING.md#coding-style)
- [x] I have signed all commits in compliance with the DCO (`git commit -s`)
- [x] I have added or updated **tests** as needed (CI-workflow change; no unit-test surface — validated via `yaml.safe_load` and reviewed against the reusable workflow's inputs)
- [x] I have added or updated **documentation** as needed (16-line inline rationale comment on the new job)

[PLAT-1052]: https://plainsight-ai.atlassian.net/browse/PLAT-1052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->