### PR TITLE
ci: gate openfilter/** PRs on a RELEASE.md entry via check-release-log

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -37,7 +37,8 @@
           { "context": "security-scan / grype (3.11)" },
           { "context": "security-scan / grype (3.12)" },
           { "context": "security-scan / grype (3.13)" },
-          { "context": "cascade-pr-checks" }
+          { "context": "cascade-pr-checks" },
+          { "context": "check-release-log" }
         ]
       }
     }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,24 @@ env:
   DO_NOT_TRACK: true
 
 jobs:
+  # PR backstop: any change under openfilter/** — the importable package, the
+  # only thing that ships in the wheel — must come with a RELEASE.md entry.
+  # `source-paths: openfilter/**` scopes the gate to shipped code, so
+  # test-only, docs, CI, and release-tooling PRs are no-ops; dependabot PRs
+  # are skipped by the action. check-release-log also validates VERSION <->
+  # changelog consistency and that VERSION is not behind the base branch.
+  check-release-log:
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run release log check
+        uses: PlainsightAI/gh-actions-public/check-release-log@main
+        with:
+          source-paths: "openfilter/**"
+
   run-unit-tests:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest


### PR DESCRIPTION
# 📦 Pull Request

## 📋 What does this PR do?

Adds a `check-release-log` job to `ci.yaml` and makes it a required status check in `main.json`. The job runs `PlainsightAI/gh-actions-public/check-release-log` — the same composite the `filter-*` repos already get through the shared `filter-ci.yaml` reusable workflow — which fails a PR that ships code without a `RELEASE.md` entry and validates VERSION <-> changelog consistency.

The gate is scoped with `source-paths: openfilter/**` so it fires only on changes to the importable package — the only thing shipped in the wheel. Test-only, docs, CI, and release-tooling PRs are no-ops; dependabot PRs are skipped by the action.

---

## 🔍 Why is this needed?

openfilter's standalone `ci.yaml` never inherited the changelog backstop the shared `filter-ci.yaml` gives the `filter-*` repos. The only VERSION <-> changelog check today lives in `create-release.yaml` and runs at release- dispatch time — far too late to catch a missing entry. As a result a substantive runtime change can merge to `main` with no `RELEASE.md` entry and silently miss the next release notes.

---

## 🧪 How was it tested?

- `ci.yaml` and `main.json` validated locally as well-formed YAML/JSON.
- `check-release-log` is a no-op pass on this PR — it touches only `.github/**`, no `openfilter/**` changes.
- Post-merge verification: `apply-rulesets.yaml` reconciles `main.json`; confirm `check-release-log` shows as a required check on a subsequent PR.
- A PR touching `openfilter/**` without a `RELEASE.md` change fails the job; the same PR with a `RELEASE.md` entry passes.

---

## 🔗 Related Issues

Surfaced while reviewing #95, which merged a runtime patch with no `RELEASE.md` entry.

## 🖼️ Screenshots or Logs (if applicable)

N/A — CI configuration change, no runtime behavior.

---

## ✅ Checklist

- [x] I have read and agreed to the terms of the [LICENSE](../LICENSE)
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have followed the [coding style](../CONTRIBUTING.md#coding-style)
- [x] I have signed all commits in compliance with the DCO (`git commit -s`)
- [x] I have added or updated **tests** as needed — N/A (CI workflow change)
- [x] I have added or updated **documentation** as needed — N/A

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781976951&installation_id=128257093&pr_number=103&repository=PlainsightAI%2Fopenfilter&return_to=https%3A%2F%2Fgithub.com%2FPlainsightAI%2Fopenfilter%2Fpull%2F103&signature=1d5aefe4b3d42668561705cfd9d2260323cd162266145367d483b98e8b7fc9ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->