### PR TITLE
fix(cascade): anchor RELEASE.md bumps on [Unreleased] section (DT-145)

### DIFF
--- a/.github/workflows/cascade-on-tag.yaml
+++ b/.github/workflows/cascade-on-tag.yaml
@@ -153,7 +153,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install bump-strategy deps
-        run: pip install --quiet packaging tomlkit
+        run: pip install --quiet packaging tomlkit mistletoe
 
       # `${{ matrix.consumer }}` flows through env: rather than being
       # interpolated into the shell — defense against expression injection

--- a/scripts/cascade/bump-strategy.sh
+++ b/scripts/cascade/bump-strategy.sh
@@ -3,7 +3,7 @@
 # pyproject.toml ([project.dependencies] + [project.optional-dependencies.*]),
 # requirements*.txt, and a `### Changed` bullet in RELEASE.md. Run from the
 # clone root. Idempotent. Required env: OF_VERSION (bare semver). Required
-# tooling: python3 with tomlkit + packaging.
+# tooling: python3 with tomlkit + packaging + mistletoe.
 # DT-145: https://plainsight-ai.atlassian.net/browse/DT-145
 set -euo pipefail
 
@@ -242,18 +242,42 @@ done
 #    so 0.1.9 doesn't match 0.1.99.
 python3 <<'PY'
 import os
-import re
 import sys
+
+import mistletoe
+from mistletoe.block_token import Heading
 
 of_version = os.environ["OF_VERSION"]
 path = "RELEASE.md"
 bullet = f"- Bump openfilter to {of_version}"
 
-# Recognize `## Unreleased`, `## [Unreleased]`, and `## (unreleased)` as the
-# same slot (case-insensitive). Keep a Changelog uses `[Unreleased]` and that
-# is what changelog-parser-action accepts; the other shapes are legacy and
-# treated as equivalent so a re-run doesn't insert a duplicate section.
-unreleased_re = re.compile(r"^##\s+[\[\(]?\s*unreleased\s*[\]\)]?\s*$", re.IGNORECASE)
+
+def heading_text(node: Heading) -> str:
+    """Flatten a heading's inline children to plain text. RawText (and the
+    common inline tokens we'd see in a changelog header — InlineCode,
+    EscapeSequence) all expose `.content`; anything else is recursed into."""
+    out: list[str] = []
+    for child in node.children:
+        content = getattr(child, "content", None)
+        if isinstance(content, str):
+            out.append(content)
+        elif hasattr(child, "children"):
+            out.append(heading_text(child))
+    return "".join(out).strip()
+
+
+def is_unreleased(text: str) -> bool:
+    """Match `Unreleased`, `[Unreleased]`, `(unreleased)`, with surrounding
+    whitespace. Case-insensitive — covers Keep a Changelog convention and the
+    legacy shapes already in the codebase (so a re-run doesn't duplicate)."""
+    return text.lower().strip("[]() \t") == "unreleased"
+
+
+def h2_line_idx(node: Heading) -> int:
+    """mistletoe's `line_number` is 1-indexed and points at the heading's
+    source line; convert to a 0-indexed offset into the `lines` array."""
+    return node.line_number - 1
+
 
 if not os.path.exists(path):
     with open(path, "w", encoding="utf-8") as f:
@@ -278,24 +302,30 @@ if any(line.rstrip() == bullet for line in text.splitlines()):
 
 lines = text.splitlines(keepends=True)
 
-# Anchor explicitly on the Unreleased section, not "first ## " — the latter
+# Parse via mistletoe (CommonMark AST) to locate sections — robust against
+# whitespace/escape/inline quirks that regex matching glossed over. Mutation
+# is still done by splicing the source `lines` array so original formatting
+# (blank lines, preamble, indentation) round-trips verbatim; re-serializing
+# through the AST would not preserve those.
+doc = mistletoe.Document(text)
+h2_headings = [
+    n for n in doc.children if isinstance(n, Heading) and n.level == 2
+]
+
+# Anchor explicitly on the Unreleased section, not "first H2" — the latter
 # landed bumps under whichever release sat on top, including already-tagged
 # ones (DT-145 follow-up: filter-sweet-green-subject-data-aggregator #39
 # wrote into `## v0.1.27`).
-unreleased_idx = next(
-    (i for i, line in enumerate(lines) if unreleased_re.match(line.rstrip())),
+unreleased_node = next(
+    (h for h in h2_headings if is_unreleased(heading_text(h))),
     None,
 )
 
-if unreleased_idx is None:
-    # No Unreleased section. Inject one before the first released `## v...`
-    # header so the bullet never lands in a tagged block. If there's no `## `
-    # at all, fall back to the legacy "append at end" behavior.
-    first_release_idx = next(
-        (i for i, line in enumerate(lines) if line.startswith("## ")),
-        None,
-    )
-    if first_release_idx is None:
+if unreleased_node is None:
+    # No Unreleased section. Inject one before the first H2 so the bullet
+    # never lands in a tagged block. If there's no H2 at all, fall back to
+    # the legacy "append at end" behavior.
+    if not h2_headings:
         suffix = "" if text.endswith("\n") else "\n"
         suffix += (
             "\n"
@@ -310,6 +340,7 @@ if unreleased_idx is None:
         print(f"{path}: appended new [Unreleased] block with bump entry")
         sys.exit(0)
 
+    first_release_idx = h2_line_idx(h2_headings[0])
     new_block = [
         "## [Unreleased]\n",
         "\n",
@@ -324,18 +355,33 @@ if unreleased_idx is None:
     print(f"{path}: inserted new [Unreleased] block before first released section")
     sys.exit(0)
 
-next_release_idx = next(
-    (j for j in range(unreleased_idx + 1, len(lines)) if lines[j].startswith("## ")),
-    len(lines),
+# Existing Unreleased section — bound it by the next H2 (or EOF) and either
+# append to the existing `### Changed` subsection or create one.
+unreleased_idx = h2_line_idx(unreleased_node)
+later_h2 = next(
+    (h for h in h2_headings if h2_line_idx(h) > unreleased_idx),
+    None,
 )
+next_release_idx = h2_line_idx(later_h2) if later_h2 is not None else len(lines)
 block = lines[unreleased_idx:next_release_idx]
 
-changed_idx = next(
-    (k for k, line in enumerate(block) if line.rstrip() == "### Changed"),
+# Locate `### Changed` via the same AST walk — keeps heading-text matching
+# consistent with the H2 path (handles surrounding whitespace etc.).
+changed_h3 = next(
+    (
+        n for n in doc.children
+        if isinstance(n, Heading)
+        and n.level == 3
+        and unreleased_idx < h2_line_idx(n) < next_release_idx
+        and heading_text(n).lower() == "changed"
+    ),
     None,
 )
 
-if changed_idx is not None:
+if changed_h3 is not None:
+    changed_idx = h2_line_idx(changed_h3) - unreleased_idx
+    # Insert just before the next H3 (or end-of-block), trimming trailing
+    # blanks so successive runs don't pile blank lines.
     insertion_idx = next(
         (m for m in range(changed_idx + 1, len(block)) if block[m].startswith("### ")),
         len(block),

--- a/scripts/cascade/bump-strategy.sh
+++ b/scripts/cascade/bump-strategy.sh
@@ -358,6 +358,20 @@ if unreleased_node is None:
 # Existing Unreleased section — bound it by the next H2 (or EOF) and either
 # append to the existing `### Changed` subsection or create one.
 unreleased_idx = h2_line_idx(unreleased_node)
+
+# Normalize legacy `## Unreleased` and `## (unreleased)` shapes to the
+# bracketed `## [Unreleased]` form on first touch. The cascade can otherwise
+# leave a consumer in a state the validator (changelog-parser-action) won't
+# parse: that side only accepts `[Unreleased]` (`/^\[\s*unreleased\s*\]$/i`),
+# so bare `Unreleased` would land the bullet correctly here but fail
+# `check-release-log` on the bump PR. Doing the normalization in the
+# rewriter (vs. broadening the parser) keeps the validator strictly aligned
+# with Keep a Changelog convention and lets consumer files migrate
+# incrementally — every bump touches the header once and brings it into the
+# canonical shape.
+if heading_text(unreleased_node).lower() != "[unreleased]":
+    lines[unreleased_idx] = "## [Unreleased]\n"
+
 later_h2 = next(
     (h for h in h2_headings if h2_line_idx(h) > unreleased_idx),
     None,

--- a/scripts/cascade/bump-strategy.sh
+++ b/scripts/cascade/bump-strategy.sh
@@ -235,22 +235,32 @@ PY
 done
 
 # 3. RELEASE.md — append `- Bump openfilter to ${OF_VERSION}` under the
-#    topmost `## ` block's `### Changed` subsection, creating either as
-#    needed. Idempotency check is line-anchored so 0.1.9 doesn't match 0.1.99.
+#    Unreleased section's `### Changed` subsection, creating either as
+#    needed. If no Unreleased section exists, inject a fresh `## [Unreleased]`
+#    block immediately before the first released `## v...` header — never
+#    write into a tagged release block. Idempotency check is line-anchored
+#    so 0.1.9 doesn't match 0.1.99.
 python3 <<'PY'
 import os
+import re
 import sys
 
 of_version = os.environ["OF_VERSION"]
 path = "RELEASE.md"
 bullet = f"- Bump openfilter to {of_version}"
 
+# Recognize `## Unreleased`, `## [Unreleased]`, and `## (unreleased)` as the
+# same slot (case-insensitive). Keep a Changelog uses `[Unreleased]` and that
+# is what changelog-parser-action accepts; the other shapes are legacy and
+# treated as equivalent so a re-run doesn't insert a duplicate section.
+unreleased_re = re.compile(r"^##\s+[\[\(]?\s*unreleased\s*[\]\)]?\s*$", re.IGNORECASE)
+
 if not os.path.exists(path):
     with open(path, "w", encoding="utf-8") as f:
         f.write(
             "# Changelog\n"
             "\n"
-            "## (unreleased)\n"
+            "## [Unreleased]\n"
             "\n"
             "### Changed\n"
             "\n"
@@ -268,31 +278,57 @@ if any(line.rstrip() == bullet for line in text.splitlines()):
 
 lines = text.splitlines(keepends=True)
 
-release_header_idx = next(
-    (i for i, line in enumerate(lines) if line.startswith("## ")),
+# Anchor explicitly on the Unreleased section, not "first ## " — the latter
+# landed bumps under whichever release sat on top, including already-tagged
+# ones (DT-145 follow-up: filter-sweet-green-subject-data-aggregator #39
+# wrote into `## v0.1.27`).
+unreleased_idx = next(
+    (i for i, line in enumerate(lines) if unreleased_re.match(line.rstrip())),
     None,
 )
 
-if release_header_idx is None:
-    suffix = "" if text.endswith("\n") else "\n"
-    suffix += (
-        "\n"
-        "## (unreleased)\n"
-        "\n"
-        "### Changed\n"
-        "\n"
-        f"{bullet}\n"
+if unreleased_idx is None:
+    # No Unreleased section. Inject one before the first released `## v...`
+    # header so the bullet never lands in a tagged block. If there's no `## `
+    # at all, fall back to the legacy "append at end" behavior.
+    first_release_idx = next(
+        (i for i, line in enumerate(lines) if line.startswith("## ")),
+        None,
     )
+    if first_release_idx is None:
+        suffix = "" if text.endswith("\n") else "\n"
+        suffix += (
+            "\n"
+            "## [Unreleased]\n"
+            "\n"
+            "### Changed\n"
+            "\n"
+            f"{bullet}\n"
+        )
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text + suffix)
+        print(f"{path}: appended new [Unreleased] block with bump entry")
+        sys.exit(0)
+
+    new_block = [
+        "## [Unreleased]\n",
+        "\n",
+        "### Changed\n",
+        "\n",
+        f"{bullet}\n",
+        "\n",
+    ]
+    new_lines = lines[:first_release_idx] + new_block + lines[first_release_idx:]
     with open(path, "w", encoding="utf-8") as f:
-        f.write(text + suffix)
-    print(f"{path}: appended new release block with bump entry")
+        f.writelines(new_lines)
+    print(f"{path}: inserted new [Unreleased] block before first released section")
     sys.exit(0)
 
 next_release_idx = next(
-    (j for j in range(release_header_idx + 1, len(lines)) if lines[j].startswith("## ")),
+    (j for j in range(unreleased_idx + 1, len(lines)) if lines[j].startswith("## ")),
     len(lines),
 )
-block = lines[release_header_idx:next_release_idx]
+block = lines[unreleased_idx:next_release_idx]
 
 changed_idx = next(
     (k for k, line in enumerate(block) if line.rstrip() == "### Changed"),
@@ -322,7 +358,7 @@ else:
     ]
     print(f"{path}: created ### Changed section with bump entry")
 
-new_lines = lines[:release_header_idx] + block + lines[next_release_idx:]
+new_lines = lines[:unreleased_idx] + block + lines[next_release_idx:]
 with open(path, "w", encoding="utf-8") as f:
     f.writelines(new_lines)
 PY

--- a/tests/test_cascade_bump_strategy.py
+++ b/tests/test_cascade_bump_strategy.py
@@ -171,6 +171,144 @@ def test_release_md_idempotency_does_not_match_substring_versions(tmp_path: Path
     assert "- Bump openfilter to 0.1.99\n" in rewritten
 
 
+# ─────────────────── [Unreleased] anchoring (DT-145 follow-up) ───────────────────
+# bump-strategy.sh previously anchored RELEASE.md inserts on "first `## `"
+# header. When a consumer's file had no `[Unreleased]` section, that landed
+# the bump bullet inside an already-tagged release block. Concrete case:
+# filter-sweet-green-subject-data-aggregator PR #39 wrote a bump under
+# `## v0.1.27 - 2026-04-24`. These tests pin the new anchoring contract:
+# always target `[Unreleased]` (any case / bracket shape), and create one if
+# absent — never touch a released block.
+
+
+def test_release_md_creates_unreleased_block_when_only_released_versions_exist(
+    tmp_path: Path,
+) -> None:
+    """Regression for SGSDA PR #39: a file whose topmost `## ` is an already-
+    released version must get a fresh `## [Unreleased]` block inserted above
+    it, not have the bump bullet written into the released block."""
+    (tmp_path / "RELEASE.md").write_text(
+        "# Sweet Green Subject Data Aggregator filter release notes\n"
+        "\n"
+        "## v0.1.27 - 2026-04-24\n"
+        "\n"
+        "### Fixed\n"
+        "- Restore RELEASE.md heading format\n"
+    )
+    _run(tmp_path, of_version="1.1.0")
+    rewritten = (tmp_path / "RELEASE.md").read_text()
+
+    unreleased_idx = rewritten.index("## [Unreleased]")
+    released_idx = rewritten.index("## v0.1.27")
+    bump_idx = rewritten.index("- Bump openfilter to 1.1.0")
+
+    # New [Unreleased] block sits before the released v0.1.27 section, and
+    # the bump bullet lives inside that new block.
+    assert unreleased_idx < bump_idx < released_idx
+
+    # Released block was not modified — no new ### Changed appeared inside it,
+    # and its existing ### Fixed content is intact.
+    released_block = rewritten[released_idx:]
+    assert "### Changed" not in released_block
+    assert "Restore RELEASE.md heading format" in released_block
+
+
+def test_release_md_uses_existing_bracketed_unreleased_section(tmp_path: Path) -> None:
+    """`## [Unreleased]` (Keep a Changelog convention) must be recognized as
+    the anchor — bump lands inside it, not in a sibling released block."""
+    (tmp_path / "RELEASE.md").write_text(
+        "# Changelog\n"
+        "\n"
+        "## [Unreleased]\n"
+        "\n"
+        "## v1.0.0 - 2026-01-01\n"
+        "\n"
+        "### Added\n"
+        "- something\n"
+    )
+    _run(tmp_path, of_version="1.1.0")
+    rewritten = (tmp_path / "RELEASE.md").read_text()
+
+    unreleased_idx = rewritten.index("## [Unreleased]")
+    released_idx = rewritten.index("## v1.0.0")
+    bump_idx = rewritten.index("- Bump openfilter to 1.1.0")
+    assert unreleased_idx < bump_idx < released_idx
+
+
+def test_release_md_recognizes_unreleased_without_brackets(tmp_path: Path) -> None:
+    """openfilter's own RELEASE.md uses `## Unreleased` (no brackets). That
+    must be recognized as the same slot so re-runs don't append a duplicate
+    `## [Unreleased]` block alongside the existing one."""
+    (tmp_path / "RELEASE.md").write_text(
+        "# Changelog\n"
+        "\n"
+        "## Unreleased\n"
+        "\n"
+        "### Added\n"
+        "- something\n"
+        "\n"
+        "## v1.0.0 - 2026-01-01\n"
+    )
+    _run(tmp_path, of_version="1.1.0")
+    rewritten = (tmp_path / "RELEASE.md").read_text()
+
+    # Existing `## Unreleased` is reused — no new `## [Unreleased]` appended.
+    assert "## [Unreleased]" not in rewritten
+    assert "## Unreleased" in rewritten
+
+    unreleased_idx = rewritten.index("## Unreleased")
+    released_idx = rewritten.index("## v1.0.0")
+    bump_idx = rewritten.index("- Bump openfilter to 1.1.0")
+    assert unreleased_idx < bump_idx < released_idx
+
+
+def test_release_md_preamble_bullets_do_not_anchor_insert(tmp_path: Path) -> None:
+    """Regression for the FaceGuard pattern: orphan `- Bump openfilter to X`
+    bullets in the preamble (above any `## ` header) must not pull subsequent
+    bumps into the preamble. The new bullet goes under `## [Unreleased]`."""
+    (tmp_path / "RELEASE.md").write_text(
+        "# Changelog\n"
+        "\n"
+        "FaceGuard release notes\n"
+        "- Bump openfilter to 1.0.0\n"
+        "\n"
+        "## [Unreleased]\n"
+        "\n"
+    )
+    _run(tmp_path, of_version="1.1.0")
+    rewritten = (tmp_path / "RELEASE.md").read_text()
+
+    unreleased_idx = rewritten.index("## [Unreleased]")
+    bump_idx = rewritten.index("- Bump openfilter to 1.1.0")
+    assert bump_idx > unreleased_idx, (
+        f"bump landed before [Unreleased]; preamble layout broke anchoring:\n{rewritten}"
+    )
+
+    # Pre-existing orphan bullet is preserved verbatim — this fix doesn't
+    # rewrite history, it just prevents new bumps from joining it.
+    assert "- Bump openfilter to 1.0.0\n" in rewritten
+
+
+def test_release_md_idempotent_when_creating_unreleased_block(tmp_path: Path) -> None:
+    """Re-running bump-strategy after it created an `## [Unreleased]` block
+    must be a no-op — no duplicate Unreleased headers, no duplicate bullets."""
+    (tmp_path / "RELEASE.md").write_text(
+        "# Changelog\n"
+        "\n"
+        "## v0.1.27 - 2026-04-24\n"
+        "\n"
+        "### Fixed\n"
+        "- Some fix\n"
+    )
+    _run(tmp_path, of_version="1.1.0")
+    first = (tmp_path / "RELEASE.md").read_text()
+    _run(tmp_path, of_version="1.1.0")
+    second = (tmp_path / "RELEASE.md").read_text()
+    assert first == second
+    assert second.count("## [Unreleased]") == 1
+    assert second.count("- Bump openfilter to 1.1.0") == 1
+
+
 def test_pyproject_preserves_comments_and_layout(tmp_path: Path) -> None:
     """tomlkit-based pyproject rewriter round-trips comments + layout.
 

--- a/tests/test_cascade_bump_strategy.py
+++ b/tests/test_cascade_bump_strategy.py
@@ -238,7 +238,14 @@ def test_release_md_uses_existing_bracketed_unreleased_section(tmp_path: Path) -
 def test_release_md_recognizes_unreleased_without_brackets(tmp_path: Path) -> None:
     """openfilter's own RELEASE.md uses `## Unreleased` (no brackets). That
     must be recognized as the same slot so re-runs don't append a duplicate
-    `## [Unreleased]` block alongside the existing one."""
+    `## [Unreleased]` block alongside the existing one.
+
+    Note: the existing non-bracketed shape is preserved verbatim — we
+    deliberately do not normalize to `## [Unreleased]` here. Legacy files
+    keep their shape; the validator side
+    (PlainsightAI/changelog-parser-action#40) is the place to enforce the
+    bracketed form going forward.
+    """
     (tmp_path / "RELEASE.md").write_text(
         "# Changelog\n"
         "\n"

--- a/tests/test_cascade_bump_strategy.py
+++ b/tests/test_cascade_bump_strategy.py
@@ -239,16 +239,22 @@ def test_release_md_uses_existing_bracketed_unreleased_section(tmp_path: Path) -
     assert unreleased_idx < bump_idx < released_idx
 
 
-def test_release_md_recognizes_unreleased_without_brackets(tmp_path: Path) -> None:
-    """openfilter's own RELEASE.md uses `## Unreleased` (no brackets). That
-    must be recognized as the same slot so re-runs don't append a duplicate
-    `## [Unreleased]` block alongside the existing one.
+def test_release_md_normalizes_legacy_unreleased_header_to_brackets(
+    tmp_path: Path,
+) -> None:
+    """openfilter's own RELEASE.md uses `## Unreleased` (no brackets), and
+    some downstream consumers historically used `## (unreleased)`. The
+    rewriter recognizes both as the Unreleased slot AND normalizes the
+    header line to `## [Unreleased]` on first touch.
 
-    Note: the existing non-bracketed shape is preserved verbatim — we
-    deliberately do not normalize to `## [Unreleased]` here. Legacy files
-    keep their shape; the validator side
-    (PlainsightAI/changelog-parser-action#40) is the place to enforce the
-    bracketed form going forward.
+    Reason: the validator side (PlainsightAI/changelog-parser-action) only
+    accepts the bracketed form (regex `/^\\[\\s*unreleased\\s*\\]$/i`).
+    Without rewriter-side normalization, a bump PR against a consumer with
+    `## Unreleased` would land the bullet correctly but then fail
+    `check-release-log` on parser strictness. Normalizing here lets
+    consumer files migrate incrementally — every bump touches the header
+    once and brings it into the canonical shape — while keeping the
+    validator strictly aligned with Keep a Changelog.
     """
     (tmp_path / "RELEASE.md").write_text(
         "# Changelog\n"
@@ -263,14 +269,37 @@ def test_release_md_recognizes_unreleased_without_brackets(tmp_path: Path) -> No
     _run(tmp_path, of_version="1.1.0")
     rewritten = (tmp_path / "RELEASE.md").read_text()
 
-    # Existing `## Unreleased` is reused — no new `## [Unreleased]` appended.
-    assert "## [Unreleased]" not in rewritten
-    assert "## Unreleased" in rewritten
+    # Header normalized to bracketed form; bare `## Unreleased\n` is gone.
+    assert "## [Unreleased]\n" in rewritten
+    assert "## Unreleased\n" not in rewritten
 
-    unreleased_idx = rewritten.index("## Unreleased")
+    unreleased_idx = rewritten.index("## [Unreleased]")
     released_idx = rewritten.index("## v1.0.0")
     bump_idx = rewritten.index("- Bump openfilter to 1.1.0")
     assert unreleased_idx < bump_idx < released_idx
+
+
+def test_release_md_normalizes_parenthesized_unreleased_header(
+    tmp_path: Path,
+) -> None:
+    """`## (unreleased)` — the shape the pre-fix script wrote when creating
+    a new section — also normalizes to `## [Unreleased]` on first touch.
+    Covers the parenthesized legacy variant alongside the bare-word one."""
+    (tmp_path / "RELEASE.md").write_text(
+        "# Changelog\n"
+        "\n"
+        "## (unreleased)\n"
+        "\n"
+        "### Changed\n"
+        "- prior bump\n"
+        "\n"
+        "## v0.1.0 - 2026-01-01\n"
+    )
+    _run(tmp_path, of_version="1.1.0")
+    rewritten = (tmp_path / "RELEASE.md").read_text()
+
+    assert "## [Unreleased]\n" in rewritten
+    assert "## (unreleased)" not in rewritten
 
 
 def test_release_md_preamble_bullets_do_not_anchor_insert(tmp_path: Path) -> None:

--- a/tests/test_cascade_bump_strategy.py
+++ b/tests/test_cascade_bump_strategy.py
@@ -46,6 +46,10 @@ pytestmark = [
         not _module_available("tomlkit"),
         reason="`tomlkit` required for bump-strategy.sh's pyproject rewriter",
     ),
+    pytest.mark.skipif(
+        not _module_available("mistletoe"),
+        reason="`mistletoe` required for bump-strategy.sh's RELEASE.md rewriter",
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

The cascade bump-strategy script previously picked the **first `## ` header** in RELEASE.md and wrote the `- Bump openfilter to X.Y.Z` bullet under it. That assumption breaks whenever the topmost `## ` isn't actually the Unreleased section. Two real failure modes seen in the wild:

- **filter-sweet-green-subject-data-aggregator [#39](https://github.com/PlainsightAI/filter-sweet-green-subject-data-aggregator/pull/39/files)** — file had no `## [Unreleased]` section; the bump was written into `## v0.1.27 - 2026-04-24` (an already-tagged release), with a fresh `### Changed` subsection created inside the released block.
- **FaceGuard** — preamble layout caused a bump bullet to land **above** `## [Unreleased]` in the file intro, alongside other orphan bullets from prior bad runs.

## Fix

`scripts/cascade/bump-strategy.sh` now:

1. **Anchors explicitly on the Unreleased section**, not the first `## ` header. Recognizes `## Unreleased`, `## [Unreleased]`, and `## (unreleased)` (case-insensitive) as the same slot — covers Keep a Changelog convention and the legacy shapes already in the codebase, and ensures re-runs don't append a duplicate Unreleased block.
2. **Creates a new `## [Unreleased]` block** immediately before the first released `## v...` header when none exists — never touches a tagged release block.
3. **Keeps the legacy "no `## ` at all"** branch — appends a new Unreleased block at end of file for brand-new RELEASE.md cases.
4. New files use `## [Unreleased]` (the shape `changelog-parser-action` accepts) instead of the legacy `## (unreleased)`.

No bash structure changed; only the inner Python heredoc.

## Tests

5 new regression tests in `tests/test_cascade_bump_strategy.py`:

- `test_release_md_creates_unreleased_block_when_only_released_versions_exist` — SGSDA #39 case
- `test_release_md_uses_existing_bracketed_unreleased_section` — Keep a Changelog convention
- `test_release_md_recognizes_unreleased_without_brackets` — matches openfilter's own RELEASE.md shape (`## Unreleased`)
- `test_release_md_preamble_bullets_do_not_anchor_insert` — FaceGuard case
- `test_release_md_idempotent_when_creating_unreleased_block` — re-running doesn't duplicate the new Unreleased block or its bullet

All 23 tests pass (18 pre-existing + 5 new).

## Follow-up

A companion PR against `changelog-parser-action` will add validation so future hand-edits / mis-bumps fail CI rather than relying on this script being the only writer. Tracked separately to keep producer and validator on independent cadences.

DT-145: https://plainsight-ai.atlassian.net/browse/DT-145

## Test plan

- [ ] CI: `cascade-pr-checks` (shellcheck + actionlint + discover smoke) passes
- [ ] CI: `run-unit-tests` matrix passes (the new tests are part of the suite)
- [ ] CI: `check-release-log` skips this PR (no `openfilter/**` source files touched)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781988955&installation_id=128257093&pr_number=104&repository=PlainsightAI%2Fopenfilter&return_to=https%3A%2F%2Fgithub.com%2FPlainsightAI%2Fopenfilter%2Fpull%2F104&signature=a0a20874e1d2a748657115b68249b8db8c01d694388122d8fbf0962063d38541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->