### PR TITLE
fix(webvis): support multi-topic subject data streaming

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,12 @@
 
 OpenFilter Library release notes
 
+## [Unreleased]
+
+### Fixed
+
+- **Multi-topic Subject Data Streaming support for Webvis ([FILTER-477](https://plainsight-ai.atlassian.net/browse/FILTER-477))**: Webvis now maintains isolated frame subject metadata per-topic, exposing them individually at `/{topic}/data` while providing a combined overview of all topic data at `/data` or `/main/data` for multi-topic pipelines. Backwards compatibility for single-topic pipelines is fully preserved. Added cheap concurrency snapshots of current data and reordered FastAPI routes to ensure that `/data` requests are not incorrectly matched by the `/topic` wildcard image endpoint.
+
 ## v1.1.0 - 2026-05-21
 
 ### Added

--- a/openfilter/filter_runtime/filters/webvis.py
+++ b/openfilter/filter_runtime/filters/webvis.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import json
+import time
 from queue import Queue
 from threading import Thread
 
@@ -62,10 +63,54 @@ class Webvis(Filter):
 
         configure_http_security(app, auth_token=auth_token, cors_origins=cors_origins)
 
+        async def stream_data(topic: str | None = None):
+            configured_topics = getattr(self, 'configured_topics', set())
+            is_multi_topic_config = len(configured_topics) > 1
+
+            # If topic is 'main' but not in streams, treat it as default fallback (None)
+            is_default = (topic is None or (topic == 'main' and 'main' not in self.streams))
+
+            # Decide on connection whether this stream is in flat mode (locked for this connection's lifetime)
+            if is_default:
+                # Flat mode if not statically multi-topic, and at most one active topic in current data
+                is_flat = (not is_multi_topic_config) and (len(self.current_data) <= 1)
+            else:
+                is_flat = True
+
+            def gen(flat: bool):
+                while True:
+                    current_data_snapshot = dict(self.current_data)
+                    if flat:
+                        if is_default:
+                            # Use the single active topic if present, otherwise default to 'main'
+                            active_topic = list(current_data_snapshot.keys())[0] if current_data_snapshot else 'main'
+                        else:
+                            active_topic = topic
+                        data = current_data_snapshot.get(active_topic, {})
+                    else:
+                        data = current_data_snapshot
+                    
+                    if self.enable_json:
+                        yield f"data: {json.dumps(data)}\n\n"
+                    else:
+                        yield f"data: {data}\n\n"
+                    time.sleep(self.sleep_interval)
+
+            return StreamingResponse(gen(is_flat), media_type='text/event-stream')
+
+        @app.get('/data')
+        async def get_data_default():
+            return await stream_data(topic=None)
+
+        @app.get('/{topic:str}/data')
+        async def get_data(topic: str):
+            return await stream_data(topic=topic)
+
         @app.get('/')
         @app.get('/{topic:str}')
         def topic(topic: str | None = None):
-            topic = (list(self.streams) + ['main'])[0] if topic is None else topic
+            if topic is None or (topic == 'main' and 'main' not in self.streams):
+                topic = (list(self.streams) + ['main'])[0]
             queue = self.streams.get(topic) or self.streams.setdefault(topic, Queue(QUEUE_LEN))
 
             def gen():
@@ -73,20 +118,6 @@ class Webvis(Filter):
                     yield (b'--frame\r\n' b'Content-Type: image/jpeg\r\n\r\n' + queue.get().bgr.jpg + b'\r\n')
 
             return StreamingResponse(gen(), media_type='multipart/x-mixed-replace; boundary=frame')
-        
-        @app.get('/{topic:str}/data')
-        async def get_data():
-            from fastapi.responses import StreamingResponse
-            import time
-            def gen():
-                while True:
-                    if self.enable_json:
-                        yield f"data: {json.dumps(self.current_data)}\n\n"
-                    else:
-                        yield f"data: {self.current_data}\n\n"
-                    time.sleep(self.sleep_interval)
-
-            return StreamingResponse(gen(), media_type='text/event-stream')
 
         return app
 
@@ -159,8 +190,21 @@ class Webvis(Filter):
 
     def setup(self, config):
         self.streams = {}  # {'topic': Queue, ...}
+        self.current_data = {}  # {'topic': dict, ...}
         self.enable_json = config.enable_json
         self.sleep_interval = config.sleep_interval
+
+        # Parse configured topics to know if we are in a static multi-topic configuration
+        self.configured_topics = set()
+        if config.sources:
+            for source in config.sources:
+                try:
+                    parsed = self.parse_topics(source)
+                    if parsed and parsed[1]:
+                        for _, target in parsed[1]:
+                            self.configured_topics.add(target)
+                except Exception:
+                    pass
 
         Thread(target=self.serve, args=(config.host, config.port, config.auth_token, config.cors_origins), daemon=True).start()
 
@@ -169,7 +213,7 @@ class Webvis(Filter):
             if frame.has_image:
                 if (queue := self.streams.get(topic) or self.streams.setdefault(topic, Queue(QUEUE_LEN))).empty():
                     queue.put(frame)
-                    self.current_data = frame.data
+                    self.current_data[topic] = frame.data
                 else:
                     logger.debug('Skipping frames')
 

--- a/tests/test_filter_webvis.py
+++ b/tests/test_filter_webvis.py
@@ -144,6 +144,278 @@ class TestWebvisCreateApp(unittest.TestCase):
             'https://portal.plainsight.tech',
         )
 
+    def test_get_data_with_multiple_topics(self):
+        import asyncio
+        import json
+        from queue import Queue
+        
+        webvis = self._make_webvis()
+        # Setup multi-topic streams and their current_data
+        webvis.streams = {"front": Queue(), "back": Queue()}
+        webvis.current_data = {
+            "front": {"camera": "front", "detected": ["person"]},
+            "back": {"camera": "back", "detected": ["car"]}
+        }
+        webvis.enable_json = True
+        webvis.sleep_interval = 0.01  # small interval for test speed
+        
+        app = webvis.create_app()
+        
+        # Find the route endpoints
+        default_route = next(r for r in app.routes if r.path == "/data")
+        topic_route = next(r for r in app.routes if r.path == "/{topic:str}/data")
+        
+        get_data_default_endpoint = default_route.endpoint
+        get_data_topic_endpoint = topic_route.endpoint
+        
+        def parse_sse_chunk(chunk):
+            payload_str = chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+            if payload_str.startswith("data: "):
+                payload_str = payload_str[6:]
+            return json.loads(payload_str.strip())
+
+        # Setup multi-topic streams where 'main' is actually present in streams
+        webvis_with_main = self._make_webvis()
+        webvis_with_main.streams = {"main": Queue(), "front": Queue()}
+        webvis_with_main.current_data = {
+            "main": {"camera": "main", "detected": ["person"]},
+            "front": {"camera": "front", "detected": ["car"]}
+        }
+        webvis_with_main.enable_json = True
+        webvis_with_main.sleep_interval = 0.01
+        
+        app_with_main = webvis_with_main.create_app()
+        topic_route_with_main = next(r for r in app_with_main.routes if r.path == "/{topic:str}/data")
+        get_data_topic_endpoint_with_main = topic_route_with_main.endpoint
+
+        # Run async test
+        async def run_test():
+            # Test default topic /data (combined view of both 'front' and 'back')
+            response = await get_data_default_endpoint()
+            iterator = response.body_iterator
+            first_chunk = await iterator.__anext__()
+            payload = parse_sse_chunk(first_chunk)
+            self.assertEqual(payload, {
+                "front": {"camera": "front", "detected": ["person"]},
+                "back": {"camera": "back", "detected": ["car"]}
+            })
+            
+            # Test explicit 'main' topic /main/data (combined view since 'main' is not in streams)
+            response_main = await get_data_topic_endpoint(topic="main")
+            iterator_main = response_main.body_iterator
+            main_chunk = await iterator_main.__anext__()
+            payload_main = parse_sse_chunk(main_chunk)
+            self.assertEqual(payload_main, {
+                "front": {"camera": "front", "detected": ["person"]},
+                "back": {"camera": "back", "detected": ["car"]}
+            })
+            
+            # Test "back" topic explicitly
+            response_back = await get_data_topic_endpoint(topic="back")
+            iterator_back = response_back.body_iterator
+            back_chunk = await iterator_back.__anext__()
+            payload_back = parse_sse_chunk(back_chunk)
+            self.assertEqual(payload_back, {"camera": "back", "detected": ["car"]})
+
+            # Test 'main' topic when 'main' is actually in streams (should return ONLY 'main' data, not combined)
+            response_main_exists = await get_data_topic_endpoint_with_main(topic="main")
+            iterator_main_exists = response_main_exists.body_iterator
+            chunk_main_exists = await iterator_main_exists.__anext__()
+            payload_main_exists = parse_sse_chunk(chunk_main_exists)
+            self.assertEqual(payload_main_exists, {"camera": "main", "detected": ["person"]})
+
+        asyncio.run(run_test())
+
+    def test_route_registration_order(self):
+        from starlette.routing import Match
+        webvis = self._make_webvis()
+        app = webvis.create_app()
+        
+        # Verify that GET /data matches get_data_default endpoint rather than image catch-all
+        scope_data = {'type': 'http', 'method': 'GET', 'path': '/data'}
+        matching_route_data = None
+        for route in app.routes:
+            match, _ = route.matches(scope_data)
+            if match == Match.FULL:
+                matching_route_data = route
+                break
+        
+        self.assertIsNotNone(matching_route_data)
+        self.assertEqual(matching_route_data.path, '/data')
+        self.assertEqual(matching_route_data.endpoint.__name__, 'get_data_default')
+
+        # Verify that GET /front/data matches get_data endpoint rather than image catch-all
+        scope_topic_data = {'type': 'http', 'method': 'GET', 'path': '/front/data'}
+        matching_route_topic_data = None
+        for route in app.routes:
+            match, _ = route.matches(scope_topic_data)
+            if match == Match.FULL:
+                matching_route_topic_data = route
+                break
+                
+        self.assertIsNotNone(matching_route_topic_data)
+        self.assertEqual(matching_route_topic_data.path, '/{topic:str}/data')
+        self.assertEqual(matching_route_topic_data.endpoint.__name__, 'get_data')
+
+    def test_get_data_with_single_topic_main(self):
+        import asyncio
+        import json
+        from queue import Queue
+        
+        webvis = self._make_webvis()
+        # Setup single-topic stream named 'main'
+        webvis.streams = {"main": Queue()}
+        webvis.current_data = {
+            "main": {"camera": "main", "detected": ["person"]}
+        }
+        webvis.enable_json = True
+        webvis.sleep_interval = 0.01
+        
+        app = webvis.create_app()
+        default_route = next(r for r in app.routes if r.path == "/data")
+        get_data_default_endpoint = default_route.endpoint
+        
+        async def run_test():
+            # For a single 'main' topic, /data should return the flat dict (backwards compatibility)
+            response = await get_data_default_endpoint()
+            iterator = response.body_iterator
+            chunk = await iterator.__anext__()
+            
+            payload_str = chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+            if payload_str.startswith("data: "):
+                payload_str = payload_str[6:]
+            payload = json.loads(payload_str.strip())
+            
+            self.assertEqual(payload, {"camera": "main", "detected": ["person"]})
+
+        asyncio.run(run_test())
+
+    def test_get_data_with_single_topic_non_main(self):
+        import asyncio
+        import json
+        from queue import Queue
+        
+        webvis = self._make_webvis()
+        # Setup single-topic stream named 'front' (no 'main')
+        webvis.streams = {"front": Queue()}
+        webvis.current_data = {
+            "front": {"camera": "front", "detected": ["person"]}
+        }
+        webvis.enable_json = True
+        webvis.sleep_interval = 0.01
+        
+        app = webvis.create_app()
+        default_route = next(r for r in app.routes if r.path == "/data")
+        get_data_default_endpoint = default_route.endpoint
+        
+        async def run_test():
+            # For a single non-'main' topic, /data should also return the flat dict (backwards compatibility)
+            response = await get_data_default_endpoint()
+            iterator = response.body_iterator
+            chunk = await iterator.__anext__()
+            
+            payload_str = chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+            if payload_str.startswith("data: "):
+                payload_str = payload_str[6:]
+            payload = json.loads(payload_str.strip())
+            
+            self.assertEqual(payload, {"camera": "front", "detected": ["person"]})
+
+        asyncio.run(run_test())
+
+    def test_get_data_schema_stability(self):
+        import asyncio
+        import json
+        from queue import Queue
+        
+        webvis = self._make_webvis()
+        # Statically configure multiple topics to test configuration-based multi-topic detection
+        webvis.configured_topics = {"front", "back"}
+        webvis.current_data = {
+            "front": {"camera": "front", "detected": ["person"]}
+        }
+        webvis.enable_json = True
+        webvis.sleep_interval = 0.01
+        
+        app = webvis.create_app()
+        default_route = next(r for r in app.routes if r.path == "/data")
+        get_data_default_endpoint = default_route.endpoint
+
+        def parse_sse_chunk(chunk):
+            payload_str = chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+            if payload_str.startswith("data: "):
+                payload_str = payload_str[6:]
+            return json.loads(payload_str.strip())
+
+        async def run_test():
+            # 1. Even though only 1 topic exists in current_data, it is configured for multi-topic,
+            # so it should immediately serve the combined view.
+            response1 = await get_data_default_endpoint()
+            iterator1 = response1.body_iterator
+            chunk1 = await iterator1.__anext__()
+            self.assertEqual(parse_sse_chunk(chunk1), {
+                "front": {"camera": "front", "detected": ["person"]}
+            })
+
+            # 2. Test schema lock-on-connection (no flipping mid-stream).
+            # If we start a connection in flat mode:
+            webvis_single = self._make_webvis()
+            webvis_single.current_data = {
+                "front": {"camera": "front", "detected": ["person"]}
+            }
+            webvis_single.enable_json = True
+            webvis_single.sleep_interval = 0.01
+            app_single = webvis_single.create_app()
+            get_data_endpoint_single = next(r for r in app_single.routes if r.path == "/data").endpoint
+
+            response_single = await get_data_endpoint_single()
+            iterator_single = response_single.body_iterator
+
+            # First chunk is flat
+            chunk_f = await iterator_single.__anext__()
+            self.assertEqual(parse_sse_chunk(chunk_f), {"camera": "front", "detected": ["person"]})
+
+            # Now add a second topic's data mid-stream
+            webvis_single.current_data["back"] = {"camera": "back", "detected": ["car"]}
+
+            # Second chunk from the SAME connection should still be flat (schema locked to flat)
+            chunk_s = await iterator_single.__anext__()
+            self.assertEqual(parse_sse_chunk(chunk_s), {"camera": "front", "detected": ["person"]})
+
+            # But a NEW connection should see the combined schema
+            response_new = await get_data_endpoint_single()
+            iterator_new = response_new.body_iterator
+            chunk_new = await iterator_new.__anext__()
+            self.assertEqual(parse_sse_chunk(chunk_new), {
+                "front": {"camera": "front", "detected": ["person"]},
+                "back": {"camera": "back", "detected": ["car"]}
+            })
+
+            # 3. Test that image request (mutating self.streams via setdefault) does NOT pollute or flip the schema.
+            webvis_single_clean = self._make_webvis()
+            webvis_single_clean.current_data = {
+                "front": {"camera": "front", "detected": ["person"]}
+            }
+            webvis_single_clean.enable_json = True
+            webvis_single_clean.sleep_interval = 0.01
+            app_clean = webvis_single_clean.create_app()
+
+            # Trigger an image wildcard route matching (mutates webvis.streams)
+            image_endpoint = next(r for r in app_clean.routes if r.path == "/{topic:str}").endpoint
+            image_endpoint(topic="foo") # Creates Queue in streams for 'foo'
+
+            # Verify that webvis.streams now has 'foo'
+            self.assertIn("foo", webvis_single_clean.streams)
+
+            # Get data default should still be flat (since len(current_data) is 1 and not statically configured for multi-topic)
+            get_data_clean = next(r for r in app_clean.routes if r.path == "/data").endpoint
+            response_clean = await get_data_clean()
+            iterator_clean = response_clean.body_iterator
+            chunk_clean = await iterator_clean.__anext__()
+            self.assertEqual(parse_sse_chunk(chunk_clean), {"camera": "front", "detected": ["person"]})
+
+        asyncio.run(run_test())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -1089,12 +1089,6 @@ webvis = [
     { name = "uvicorn" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-benchmark" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "av", marker = "extra == 'all'", specifier = "~=16.1.0" },
@@ -1147,12 +1141,6 @@ requires-dist = [
     { name = "wheel", marker = "extra == 'dev'", specifier = "~=0.46.2" },
 ]
 provides-extras = ["dev", "mqtt-out", "recorder", "image-in", "image-out", "rest", "util", "video", "video-in", "video-out", "webvis", "all"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.0.2" },
-    { name = "pytest-benchmark", specifier = ">=5.1.0" },
-]
 
 [[package]]
 name = "openlineage-python"


### PR DESCRIPTION
## 📋 What does this PR do?

Webvis now correctly supports multi-topic subject data streaming:
- **Per-topic Metadata Isolation**: Metadata is stored keyed by topic, so multi-topic pipelines (e.g., `front` and `back`) do not non-deterministically overwrite each other.
- **Route Order Correction**: Reordered route registration in `create_app` so that `/data` and `/{topic}/data` requests are registered before the catch-all image streaming wildcard `/{topic}`.
- **Combined Metadata on Default/Main**: Querying `/data` or `/main/data` in a multi-topic scenario streams a merged dictionary of all active topics (`{"front": {...}, "back": {...}}`), providing a complete overview. For single-topic pipelines, backwards compatibility is preserved by continuing to serve the flat, unwrapped metadata dictionary.
- **Concurrency Safety**: Takes a shallow copy copy snapshot (`dict(self.current_data)`) of current data prior to serialization, preventing `dictionary changed size during iteration` runtime errors when uvicorn threads read while the process loop thread writes.
- **Schema Stability**: Locks the stream mode on client connection (using statically parsed configured sources or the count of active topics) and isolates metadata tracking from image queue mutations, preventing schema flipping and pollution.

---

## 🔍 Why is this needed?

Fixes the issue where multiple topics in a pipeline had their subject metadata non-deterministically overwritten and ignored by the Webvis endpoints.

---

## 🧪 How was it tested?

1. **Unit Tests**: Added comprehensive test coverage in `tests/test_filter_webvis.py`:
   - `test_route_registration_order` to verify that route registration order is correct and catch-all wildcards do not intercept `/data`.
   - `test_get_data_with_single_topic_main` to verify backwards compatible flat dict shape for `"main"` topic.
   - `test_get_data_with_single_topic_non_main` to verify backwards compatible flat dict shape for single non-`"main"` topic (e.g. `"front"`).
   - Enhanced `test_get_data_with_multiple_topics` to test combined view dictionary structure under `/data` and `/main/data`.
   - `test_get_data_schema_stability` to assert and prevent regressions on connection-locked schema stability and image queue isolation.
2. **Local Reproduction**: Successfully verified with reproduction scripts.