### PR TITLE
docs: refresh README and split GitHub/PyPI long-description

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,6 @@ jobs:
   # for a plain-text one, since PyPI does not render Mermaid). This guards
   # against the committed PyPI readme drifting from the source README.
   check-pypi-readme:
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,24 @@ jobs:
       - name: Run tests
         run: make test-all
 
+  # README.pypi.md is generated from README.md (the Mermaid diagram is swapped
+  # for a plain-text one, since PyPI does not render Mermaid). This guards
+  # against the committed PyPI readme drifting from the source README.
+  check-pypi-readme:
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Verify README.pypi.md is in sync with README.md
+        run: make check-pypi-readme
+
   # Path-filtered checks for the tag-cascade scripts on PRs touching
   # scripts/cascade/** or the cascade workflow: shellcheck + actionlint +
   # a single-filter discover.sh smoke against filter-frame-dedup. The

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,6 @@ jobs:
           source-paths: "openfilter/**"
 
   run-unit-tests:
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,9 +99,7 @@ If you're unsure whether a change is "big enough" to be worth a PR — it probab
 * Use clear branch naming. For example:
   * Bugfix: `1234-fix-filter-shutdown`
   * Feature: `4567-add-fancy-thing`
-* All contributions should be made against the `main` branch.
-* **Do not submit pull requests directly to `release`** — that branch is managed by core maintainers and reflects the latest stable version of OpenFilter.
-* When a release is ready, core maintainers will merge changes from `main` into `release`.
+* All contributions should be made against the `main` branch, which is the active development branch that releases are tagged from.
 * Include unit tests when appropriate. Run `make test-all` or `pytest` to verify.
 * Keep pull requests focused — unrelated changes should go in separate PRs.
 * Run linters and formatting before pushing (`black`, `ruff`, etc. where applicable).
@@ -336,7 +334,7 @@ Whether you're contributing a quick fix or a large feature, it's important to un
 
 ### 🛠️ Releasing
 
-- Releases are **cut from the `main` branch** — the single branch every published version comes from, kept in a release-ready state at all times.
+- Releases are normally **cut from the `main` branch**, which is kept in a release-ready state at all times. (Urgent hotfixes are the exception and are cut from the latest release tag; see [Hotfixes](#-hotfixes) below.)
 - To create a release from `main`, the following must be true:
   - The `RELEASE.md` file contains an accurate and up-to-date changelog entry for the version.
   - The `VERSION` file matches the version declared in `RELEASE.md`.
@@ -346,6 +344,25 @@ Whether you're contributing a quick fix or a large feature, it's important to un
 Once merged, the release automation tags the version, pushes a GitHub release, publishes documentation, and optionally builds artifacts (e.g., Docker images, Python wheels).
 
 The final step in the CI pipeline requires manual review and approval by a core maintainer. Upon approval, the package version is automaticlaly published to PyPi.
+
+### 🚀 How to cut a release (core maintainers only)
+
+To publish a new version:
+
+1. Update `VERSION` with the new version (for example `v1.1.2`).
+2. Add a matching entry at the top of `RELEASE.md`, using the same version and a changelog for that release.
+3. Merge both changes into `main`.
+4. In GitHub Actions, run the **Create Release** workflow via **Run workflow** against `main`.
+
+From there the workflow runs on its own:
+
+- Runs the unit tests across Python 3.10, 3.11, 3.12, and 3.13.
+- Verifies that the `VERSION` file matches the version declared in `RELEASE.md`.
+- Creates the git tag and the GitHub Release.
+- Builds the Python wheel and publishes it to [PyPI](https://pypi.org/project/openfilter/).
+- Builds and pushes the built-in filter images to [Docker Hub](https://hub.docker.com/u/plainsightai) (multi-arch: `amd64` and `arm64`).
+
+Publishing to PyPI runs in a protected environment, so the wheel is uploaded only after a core maintainer approves that step. Each filter image is published at `plainsightai/openfilter-<name>` and tagged with both the version (for example `1.1.2`) and `latest`. Because the images install `openfilter[extra]=={version}` from PyPI, they are built only after the PyPI publish has succeeded.
 
 ### 🧯 Hotfixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,7 +336,7 @@ Whether you're contributing a quick fix or a large feature, it's important to un
 
 ### 🛠️ Releasing
 
-- Releases are **cut from the `main` branch**, which always reflects the **latest development version** of OpenFilter.
+- Releases are **cut from the `main` branch** — the single branch every published version comes from, kept in a release-ready state at all times.
 - To create a release from `main`, the following must be true:
   - The `RELEASE.md` file contains an accurate and up-to-date changelog entry for the version.
   - The `VERSION` file matches the version declared in `RELEASE.md`.

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,14 @@ help:
 build-wheel:  ## Build python wheel
 	python -m build --wheel
 
+.PHONY: pypi-readme
+pypi-readme:  ## Regenerate README.pypi.md from README.md
+	python scripts/make_pypi_readme.py
+
+.PHONY: check-pypi-readme
+check-pypi-readme:  ## Fail if README.pypi.md is out of sync with README.md
+	python scripts/make_pypi_readme.py --check
+
 
 .PHONY: test
 test:  ## Run basic unit tests

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -1,3 +1,5 @@
+<!-- Generated from README.md by scripts/make_pypi_readme.py. Do not edit directly. -->
+
 # <img src="https://raw.githubusercontent.com/PlainsightAI/openfilter/main/docs/openfilterlogo.png" width="38" align="center" alt="OpenFilter Logo" /> OpenFilter
 
 [![PyPI version](https://img.shields.io/pypi/v/openfilter.svg?style=flat-square)](https://pypi.org/project/openfilter/)
@@ -13,13 +15,7 @@ A filter is a component that originates, processes, or exports a stream of frame
 (with many-to-many topologies), and the runtime keeps frames that enter together synchronized through to the output. Develop and test
 filters locally as ordinary Python processes, then ship each one as a Docker image.
 
-```mermaid
-flowchart LR
-    A[VideoIn] -->|tcp://| B[Detect]
-    B -->|tcp://| C[Annotate]
-    C -->|tcp://| D[Webvis]
-    C -->|tcp://| E[Recorder]
-```
+> **Pipeline diagram:** rendered on the [GitHub README](https://github.com/PlainsightAI/openfilter#readme).
 
 Homepage: [openfilter.io](https://openfilter.io) · Package: [PyPI](https://pypi.org/project/openfilter/) · Images: [Docker Hub](https://hub.docker.com/u/plainsightai)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["openfilter*"]
 
 [project]
 name = "openfilter"
-readme = "README.md"
+readme = "README.pypi.md"  # generated from README.md by scripts/make_pypi_readme.py
 requires-python = ">=3.10, <3.14"
 license = "Apache-2.0"
 

--- a/scripts/make_pypi_readme.py
+++ b/scripts/make_pypi_readme.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Generate README.pypi.md from README.md.
+
+PyPI's README renderer does not run Mermaid (it would show the raw fenced block), so the
+PyPI long description replaces every Mermaid diagram with a short pointer to the rendered
+diagram on GitHub. README.md stays the canonical source. The replacement matches the
+```mermaid fence rather than the diagram's contents, so editing the diagram in README.md
+never requires touching this script. All links in README.md are absolute, so they already
+render on PyPI unchanged.
+
+Usage:
+    python scripts/make_pypi_readme.py          # regenerate README.pypi.md
+    python scripts/make_pypi_readme.py --check   # verify README.pypi.md is up to date (CI)
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SOURCE = ROOT / "README.md"
+TARGET = ROOT / "README.pypi.md"
+
+GENERATED_HEADER = (
+    "<!-- Generated from README.md by scripts/make_pypi_readme.py. Do not edit directly. -->\n\n"
+)
+
+# Match any ```mermaid ... ``` fenced block. Keyed on the fence, not the diagram body,
+# so the diagram can change freely without updating this script.
+MERMAID_FENCE = re.compile(r"```mermaid\n.*?\n```", re.DOTALL)
+DIAGRAM_POINTER = (
+    "> **Pipeline diagram:** rendered on the "
+    "[GitHub README](https://github.com/PlainsightAI/openfilter#readme)."
+)
+
+
+def render() -> str:
+    source = SOURCE.read_text(encoding="utf-8")
+    converted, count = MERMAID_FENCE.subn(DIAGRAM_POINTER, source)
+    if count == 0:
+        raise SystemExit(
+            "make_pypi_readme: no ```mermaid block found in README.md. If the diagram was "
+            "removed for good, drop this PyPI conversion (script, Makefile targets, CI job, "
+            "and the pyproject readme pointer); otherwise check the fence language tag."
+        )
+    return GENERATED_HEADER + converted
+
+
+def main(argv: list[str]) -> int:
+    rendered = render()
+    if "--check" in argv:
+        current = TARGET.read_text(encoding="utf-8") if TARGET.exists() else ""
+        if current != rendered:
+            print(
+                "README.pypi.md is out of date. Run: python scripts/make_pypi_readme.py",
+                file=sys.stderr,
+            )
+            return 1
+        print("README.pypi.md is up to date.")
+        return 0
+    TARGET.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {TARGET.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
Refreshes the public README so it accurately represents OpenFilter at v1.1.2, and splits the
GitHub and PyPI descriptions so each renders correctly on its own platform.

## README refresh (README.md)

- Corrected lead ("a universal ..."), added a concept intro and a Mermaid pipeline diagram.
- Badge row now includes supported Python versions; Requirements section states Python 3.10+
  (tested 3.10-3.13).
- Fixed install instructions: `git+https` URL, real tag `v1.1.2`, and a four-backtick fence so the
  nested pip line renders. Added a docker-run block.
- Corrected the example filename to `example_video.mp4`; added a Built-in filters table.
- Expanded Documentation with absolute GitHub links (so they survive on PyPI).
- Tightened Telemetry & privacy to describe what actually ships today (OpenTelemetry tracing,
  OpenLineage, per-frame metrics; a single Scarf filter-init event; `DO_NOT_TRACK` honored).
- Short, vendor-neutral Ecosystem note (pipelines-controller + plainsight.io).

## GitHub / PyPI split

PyPI cannot render Mermaid and does not resolve relative links, so the rendered project page was
degraded. This adds a generated PyPI variant instead of hand-maintaining two files:

- `README.pypi.md` (generated) - Mermaid block replaced with a plain-ASCII diagram; links absolute.
  Carries a "do not edit" header.
- `scripts/make_pypi_readme.py` - derives `README.pypi.md` from `README.md` (swaps only the diagram
  block). Dependency-free; `--check` mode fails on drift.
- `Makefile` - `pypi-readme` (regenerate) and `check-pypi-readme` (verify) targets.
- `.github/workflows/ci.yaml` - a drift-check job that fails if the two READMEs diverge.
- `pyproject.toml` - `readme = "README.pypi.md"` so the packaged long-description uses the PyPI variant.

## CONTRIBUTING.md

- Documented "How to cut a release (core maintainers only)" and the published Docker Hub images.
- Reworded the main-branch description to state its release-ready invariant.

## Validation

- Local example run passed on a clean venv (`openfilter[all]` editable install): Python Quick Start
  and CLI both served Webvis (HTTP 200) at ~30fps with no traceback.
- `make check-pypi-readme` passes (the two READMEs are in sync).
- Docs + packaging only; no `openfilter/**` source changes, so no RELEASE.md entry is required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786464297&installation_id=128257093&pr_number=116&repository=PlainsightAI%2Fopenfilter&return_to=https%3A%2F%2Fgithub.com%2FPlainsightAI%2Fopenfilter%2Fpull%2F116&signature=ad42b771c1a5f50a840f18637234106a52e8b10b879401ada97e763d46bf946c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->