### PR TITLE
ci: add SAST (Semgrep) + secret scanning to CI

### DIFF
--- a/.github/workflows/sast-secrets.yml
+++ b/.github/workflows/sast-secrets.yml
@@ -1,4 +1,4 @@
-name: SAST name: Security Scan Secret Scan
+name: SAST and Secret Scan
 
 # SAST + secret scanning for the API. Free CI tooling (no GitHub Advanced
 # Security license required). SAST is REPORT-ONLY during rollout so it surfaces

--- a/.github/workflows/sast-secrets.yml
+++ b/.github/workflows/sast-secrets.yml
@@ -1,0 +1,43 @@
+name: SAST name: Security Scan Secret Scan
+
+# SAST + secret scanning for the API. Free CI tooling (no GitHub Advanced
+# Security license required). SAST is REPORT-ONLY during rollout so it surfaces
+# findings without blocking merges on the pre-existing backlog — ratchet it to
+# blocking (remove `continue-on-error`) once the initial findings are triaged.
+# Secret scanning IS blocking: it is diff-aware and only fails on a NEW verified
+# secret, which is always actionable.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "23 6 * * 1" # weekly Monday 06:23 UTC (off-minute)
+
+permissions:
+  contents: read
+
+jobs:
+  sast:
+    name: SAST (Semgrep)
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@v4
+      - name: Semgrep scan (report-only during rollout)
+        continue-on-error: true
+        run: semgrep scan --config=auto --error --severity=ERROR --metrics=off
+
+  secrets:
+    name: Secret scan (TruffleHog)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: TruffleHog (verified secrets only)
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified

--- a/.github/workflows/sast-secrets.yml
+++ b/.github/workflows/sast-secrets.yml
@@ -38,6 +38,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: TruffleHog (verified secrets only)
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@27b0417c16317ca9a472a9a8092acce143b49c55 # v3.95.9
         with:
           extra_args: --only-verified


### PR DESCRIPTION
## Summary

Adds **SAST (Semgrep)** + **secret scanning (TruffleHog)** to CI — closing two gaps flagged in the 2026-07 security review (we had container/dependency CVE scanning + Dependabot, but **no source-code SAST and no secret scanning**). Free CI tooling, no GitHub Advanced Security license required.

## Behavior

- **SAST (Semgrep `--config=auto`)** — runs on every PR + push + weekly. **Report-only during rollout** (`continue-on-error`) so it surfaces findings in the job log without blocking merges on the pre-existing backlog. Ratchet to blocking (remove `continue-on-error`) once the initial ERROR-severity findings are triaged.
- **Secret scan (TruffleHog, `--only-verified`)** — **blocking**: diff-aware, fails only on a *new verified* secret (always actionable, low false-positive).

Part of the "shift-left" set going onto the main code repos this week (api, portal, protege-ml, openfilter). IaC scanning lands on `infrastructure` separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787272480&installation_model_id=20112&pr_number=125&repository=PlainsightAI%2Fopenfilter&return_to=https%3A%2F%2Fgithub.com%2FPlainsightAI%2Fopenfilter%2Fpull%2F125&signature=0de8a74f4118ecdc914c75307b84c2d171231cb856d5bf70cd44cb9e8368debf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->