### PR TITLE
ci: pin trufflehog scanner image to 3.95.9

### DIFF
--- a/.github/workflows/sast-secrets.yml
+++ b/.github/workflows/sast-secrets.yml
@@ -41,3 +41,4 @@ jobs:
         uses: trufflesecurity/trufflehog@27b0417c16317ca9a472a9a8092acce143b49c55 # v3.95.9
         with:
           extra_args: --only-verified
+          version: "3.95.9"


### PR DESCRIPTION
Follow-up to the SAST/secret-scan PR. The `trufflesecurity/trufflehog` composite action defaults its `version` input to `latest`, so despite the wrapper SHA pin it pulled `ghcr.io/trufflesecurity/trufflehog:latest` at runtime — most of the mutable-ref exposure the pin was meant to remove. Adds `version: "3.95.9"` under `with:` to pin the scanner image too. Caught by @shingonoide on PlainsightAI/infrastructure#374.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787348731&installation_model_id=20112&pr_number=126&repository=PlainsightAI%2Fopenfilter&return_to=https%3A%2F%2Fgithub.com%2FPlainsightAI%2Fopenfilter%2Fpull%2F126&signature=033b9be8b70e2a71b5b80fa7c42bda26fd88dd60b45f0848b1586009122e057f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->