### PR TITLE
fix(ci): make Semgrep SAST actually run (pin p/default, no telemetry)

### DIFF
--- a/.github/workflows/sast-secrets.yml
+++ b/.github/workflows/sast-secrets.yml
@@ -28,7 +28,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Semgrep scan (report-only during rollout)
         continue-on-error: true
-        run: semgrep scan --config=auto --error --severity=ERROR --metrics=off
+        # `--config=auto` requires `--metrics=on` and hard-errors under
+        # `--metrics=off` (exit 2), which `continue-on-error` was masking — the
+        # scan never actually ran. Pin the `p/default` ruleset so it scans for
+        # real without sending telemetry.
+        run: semgrep scan --config=p/default --error --severity=ERROR --metrics=off
 
   secrets:
     name: Secret scan (TruffleHog)


### PR DESCRIPTION
## Problem

The SAST job was **green but never scanned a single file**. `semgrep scan --config=auto` requires `--metrics=on`; combined with the deliberate `--metrics=off`, Semgrep hard-errors (exit 2). `continue-on-error: true` (correct for the report-only rollout) then swallowed that exit code, so every run reported success while scanning nothing.

## Fix

Pin the `p/default` ruleset instead of `auto`. Pinned registry rulesets run under `--metrics=off` (no telemetry), so the scan runs for real. Report-only during rollout is unchanged — `continue-on-error` stays until the initial backlog is triaged, then we ratchet to blocking.

Added an inline comment documenting the `auto` + `--metrics=off` gotcha so it doesn't regress.

## Validation

The `SAST (Semgrep)` job on this PR now executes the ruleset and reports findings in the step log (previously it printed the config error and exited). See this run's job log.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787497898&installation_model_id=20112&pr_number=129&repository=PlainsightAI%2Fopenfilter&return_to=https%3A%2F%2Fgithub.com%2FPlainsightAI%2Fopenfilter%2Fpull%2F129&signature=57bdebb865d177edcfc2954810f8479c55dd5cc7982eeba4e07bf2fd0bf34f4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->