### PR TITLE
fix(cascade): emit a bump bullet the changelog parser accepts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,7 @@ jobs:
             cascade:
               - 'scripts/cascade/**'
               - '.github/workflows/cascade-on-tag.yaml'
+              - 'tests/test_cascade_bump_strategy.py'
 
       - name: Set up Python
         if: steps.filter.outputs.cascade == 'true'
@@ -97,16 +98,15 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install constraint-check deps
+      - name: Install cascade check and test deps
         if: steps.filter.outputs.cascade == 'true'
         run: pip install --quiet packaging tomlkit mistletoe pytest
 
       # bump-strategy.sh's rewriters are Python heredocs, driven end-to-end by
-      # tests/test_cascade_bump_strategy.py. That file skips itself when
-      # tomlkit/mistletoe are absent, which is how the unit-test job stayed
-      # green while every one of its RELEASE.md cases was silently skipped.
-      # Run it here, where the deps are installed, so a cascade script change
-      # cannot land with stale assertions.
+      # tests/test_cascade_bump_strategy.py. tomlkit and mistletoe are declared
+      # in the dev extra, so run-unit-tests exercises that suite too. This job
+      # re-runs it on the cascade path filter, so a cascade script change cannot
+      # land with stale assertions without waiting on the full matrix.
       - name: Run cascade bump-strategy tests
         if: steps.filter.outputs.cascade == 'true'
         run: pytest tests/test_cascade_bump_strategy.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,17 @@ jobs:
 
       - name: Install constraint-check deps
         if: steps.filter.outputs.cascade == 'true'
-        run: pip install --quiet packaging
+        run: pip install --quiet packaging tomlkit mistletoe pytest
+
+      # bump-strategy.sh's rewriters are Python heredocs, driven end-to-end by
+      # tests/test_cascade_bump_strategy.py. That file skips itself when
+      # tomlkit/mistletoe are absent, which is how the unit-test job stayed
+      # green while every one of its RELEASE.md cases was silently skipped.
+      # Run it here, where the deps are installed, so a cascade script change
+      # cannot land with stale assertions.
+      - name: Run cascade bump-strategy tests
+        if: steps.filter.outputs.cascade == 'true'
+        run: pytest tests/test_cascade_bump_strategy.py
 
       - name: shellcheck cascade scripts
         if: steps.filter.outputs.cascade == 'true'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,12 @@ dev = [
   "jq~=1.12.0",
   "pytest-cov~=7.1.0",
   "pytest-benchmark>=5.1.0",
+
+  # Drive the Python rewriters inside scripts/cascade/bump-strategy.sh. Without
+  # them tests/test_cascade_bump_strategy.py skips itself and the unit-test job
+  # goes green over an unexercised suite.
+  "tomlkit~=0.15.1",
+  "mistletoe~=1.6.0",
 ]
 
 mqtt_out = ["paho-mqtt~=2.1.0", "setuptools~=83.0.0"]

--- a/scripts/cascade/bump-strategy.sh
+++ b/scripts/cascade/bump-strategy.sh
@@ -234,14 +234,15 @@ if changed:
 PY
 done
 
-# 3. RELEASE.md — append `- Bump openfilter to ${OF_VERSION}` under the
-#    Unreleased section's `### Changed` subsection, creating either as
-#    needed. If no Unreleased section exists, inject a fresh `## [Unreleased]`
-#    block immediately before the first released `## v...` header — never
-#    write into a tagged release block. Idempotency check is line-anchored
-#    so 0.1.9 doesn't match 0.1.99.
+# 3. RELEASE.md — append a dependency-bump bullet under the Unreleased
+#    section's `### Changed` subsection, creating either as needed. If no
+#    Unreleased section exists, inject a fresh `## [Unreleased]` block
+#    immediately before the first released `## v...` header — never write into
+#    a tagged release block. Idempotency check is line-anchored so 0.1.9
+#    doesn't match 0.1.99.
 python3 <<'PY'
 import os
+import re
 import sys
 
 import mistletoe
@@ -249,7 +250,29 @@ from mistletoe.block_token import Heading
 
 of_version = os.environ["OF_VERSION"]
 path = "RELEASE.md"
-bullet = f"- Bump openfilter to {of_version}"
+
+# The wording is load-bearing, not cosmetic. changelog-parser-action rejects any
+# bullet matching /^-\s+Bump\s+\S+\s+to\s+\d+(?:\.\d+)+/ once it sits in a dated
+# release section, and check-release-log runs that parser on every pull request
+# to main. So the literal `- Bump openfilter to X.Y.Z` this script used to emit
+# turned into a release-blocker the moment a consumer promoted `[Unreleased]` to
+# a version heading, which each one then had to hand-patch. Naming the
+# dependency keeps the imperative mood of the surrounding entries while putting
+# a word between `Bump` and `to`, so the pattern no longer matches.
+bullet = f"- Bump the openfilter dependency to {of_version}"
+
+# Recognize every phrasing that has reached a consumer changelog: what this
+# script emits now, the literal it emitted before, and the hand-reworded past
+# tense used when repos were patched by hand. Without this a re-run would not
+# see the older shapes and would append a near-duplicate beside them. Anchored
+# at both ends and on the exact version, preserving the 0.1.9-vs-0.1.99
+# guarantee the line-anchored check gave.
+bullet_seen = re.compile(
+    r"^-\s+Bump(?:ed)?\s+(?:the\s+)?openfilter(?:\s+dependency)?\s+to\s+"
+    + re.escape(of_version)
+    + r"\.?\s*$",
+    re.IGNORECASE,
+)
 
 
 def heading_text(node: Heading) -> str:
@@ -296,7 +319,7 @@ if not os.path.exists(path):
 with open(path, "r", encoding="utf-8") as f:
     text = f.read()
 
-if any(line.rstrip() == bullet for line in text.splitlines()):
+if any(bullet_seen.match(line) for line in text.splitlines()):
     print(f"{path}: bump entry already present")
     sys.exit(0)
 

--- a/tests/test_cascade_bump_strategy.py
+++ b/tests/test_cascade_bump_strategy.py
@@ -154,9 +154,11 @@ def test_requirements_non_openfilter_lines_untouched(tmp_path: Path) -> None:
 def test_release_md_idempotency_does_not_match_substring_versions(tmp_path: Path) -> None:
     """Regression for the `bullet in text` substring-match bug.
 
-    `0.1.9` would previously match an existing `- Bump openfilter to 0.1.99`
-    line in RELEASE.md, silently suppressing the new entry. The fix anchors
-    the idempotency check to whole rstripped lines.
+    `0.1.9` would previously match an existing
+    `- Bump the openfilter dependency to 0.1.99` line in RELEASE.md, silently
+    suppressing the new entry. The fix anchors the idempotency check to whole
+    lines — now an end-anchored regex over the accepted bullet wordings, which
+    keeps the same guarantee.
     """
     (tmp_path / "RELEASE.md").write_text(
         "# Changelog\n"
@@ -165,14 +167,14 @@ def test_release_md_idempotency_does_not_match_substring_versions(tmp_path: Path
         "\n"
         "### Changed\n"
         "\n"
-        "- Bump openfilter to 0.1.99\n"
+        "- Bump the openfilter dependency to 0.1.99\n"
     )
     _run(tmp_path, of_version="0.1.9")
     rewritten = (tmp_path / "RELEASE.md").read_text()
     # Both lines must be present — the new 0.1.9 entry was added; the
     # existing 0.1.99 entry was not removed or treated as a duplicate.
-    assert "- Bump openfilter to 0.1.9\n" in rewritten
-    assert "- Bump openfilter to 0.1.99\n" in rewritten
+    assert "- Bump the openfilter dependency to 0.1.9\n" in rewritten
+    assert "- Bump the openfilter dependency to 0.1.99\n" in rewritten
 
 
 # ─────────────────── [Unreleased] anchoring (DT-145 follow-up) ───────────────────
@@ -204,7 +206,7 @@ def test_release_md_creates_unreleased_block_when_only_released_versions_exist(
 
     unreleased_idx = rewritten.index("## [Unreleased]")
     released_idx = rewritten.index("## v0.1.27")
-    bump_idx = rewritten.index("- Bump openfilter to 1.1.0")
+    bump_idx = rewritten.index("- Bump the openfilter dependency to 1.1.0")
 
     # New [Unreleased] block sits before the released v0.1.27 section, and
     # the bump bullet lives inside that new block.
@@ -235,7 +237,7 @@ def test_release_md_uses_existing_bracketed_unreleased_section(tmp_path: Path) -
 
     unreleased_idx = rewritten.index("## [Unreleased]")
     released_idx = rewritten.index("## v1.0.0")
-    bump_idx = rewritten.index("- Bump openfilter to 1.1.0")
+    bump_idx = rewritten.index("- Bump the openfilter dependency to 1.1.0")
     assert unreleased_idx < bump_idx < released_idx
 
 
@@ -275,7 +277,7 @@ def test_release_md_normalizes_legacy_unreleased_header_to_brackets(
 
     unreleased_idx = rewritten.index("## [Unreleased]")
     released_idx = rewritten.index("## v1.0.0")
-    bump_idx = rewritten.index("- Bump openfilter to 1.1.0")
+    bump_idx = rewritten.index("- Bump the openfilter dependency to 1.1.0")
     assert unreleased_idx < bump_idx < released_idx
 
 
@@ -319,7 +321,7 @@ def test_release_md_preamble_bullets_do_not_anchor_insert(tmp_path: Path) -> Non
     rewritten = (tmp_path / "RELEASE.md").read_text()
 
     unreleased_idx = rewritten.index("## [Unreleased]")
-    bump_idx = rewritten.index("- Bump openfilter to 1.1.0")
+    bump_idx = rewritten.index("- Bump the openfilter dependency to 1.1.0")
     assert bump_idx > unreleased_idx, (
         f"bump landed before [Unreleased]; preamble layout broke anchoring:\n{rewritten}"
     )
@@ -346,7 +348,92 @@ def test_release_md_idempotent_when_creating_unreleased_block(tmp_path: Path) ->
     second = (tmp_path / "RELEASE.md").read_text()
     assert first == second
     assert second.count("## [Unreleased]") == 1
-    assert second.count("- Bump openfilter to 1.1.0") == 1
+    assert second.count("- Bump the openfilter dependency to 1.1.0") == 1
+
+
+# Bullet-wording tolerance. The emitted bullet moved from
+# `- Bump openfilter to X.Y.Z` to `- Bump the openfilter dependency to X.Y.Z`
+# because changelog-parser-action rejects the former once a consumer promotes
+# `[Unreleased]` to a dated release heading. Consumer changelogs still carry
+# the old literal, and the repos that were patched by hand carry a past-tense
+# variant with a trailing period, so the idempotency check has to recognize
+# every shape — otherwise the next cascade run appends a near-duplicate bullet
+# right next to the entry that is already there.
+
+
+def test_release_md_idempotency_recognizes_legacy_bullet_wording(tmp_path: Path) -> None:
+    """An existing `- Bump openfilter to X.Y.Z` — the literal this script used
+    to emit — counts as already present, so no bullet in the new wording is
+    appended beside it."""
+    original = (
+        "# Changelog\n"
+        "\n"
+        "## [Unreleased]\n"
+        "\n"
+        "### Changed\n"
+        "\n"
+        "- Bump openfilter to 1.1.0\n"
+    )
+    (tmp_path / "RELEASE.md").write_text(original)
+    _run(tmp_path, of_version="1.1.0")
+    rewritten = (tmp_path / "RELEASE.md").read_text()
+
+    assert rewritten == original
+    assert "- Bump the openfilter dependency to 1.1.0" not in rewritten
+
+
+def test_release_md_idempotency_recognizes_hand_patched_past_tense_bullet(
+    tmp_path: Path,
+) -> None:
+    """The hand-reworded `- Bumped the openfilter dependency to X.Y.Z.` shape
+    that consumers patched in to get past the parser also counts as already
+    present."""
+    original = (
+        "# Changelog\n"
+        "\n"
+        "## [Unreleased]\n"
+        "\n"
+        "### Changed\n"
+        "\n"
+        "- Bumped the openfilter dependency to 1.1.0.\n"
+    )
+    (tmp_path / "RELEASE.md").write_text(original)
+    _run(tmp_path, of_version="1.1.0")
+    rewritten = (tmp_path / "RELEASE.md").read_text()
+
+    assert rewritten == original
+    assert "- Bump the openfilter dependency to 1.1.0" not in rewritten
+
+
+@pytest.mark.parametrize(
+    "existing_bullet",
+    [
+        "- Bump the openfilter dependency to 1.1.0\n",
+        "- Bump the openfilter dependency to 1.1.0.\n",
+    ],
+    ids=["no-trailing-period", "trailing-period"],
+)
+def test_release_md_idempotency_tolerates_trailing_period(
+    tmp_path: Path, existing_bullet: str
+) -> None:
+    """A trailing `.` is optional for the idempotency check: the bullet exactly
+    as emitted and the same bullet closed with a period are both recognized, so
+    a re-run over either shape is a no-op."""
+    original = (
+        "# Changelog\n"
+        "\n"
+        "## [Unreleased]\n"
+        "\n"
+        "### Changed\n"
+        "\n"
+        f"{existing_bullet}"
+    )
+    (tmp_path / "RELEASE.md").write_text(original)
+    _run(tmp_path, of_version="1.1.0")
+    rewritten = (tmp_path / "RELEASE.md").read_text()
+
+    assert rewritten == original
+    assert rewritten.count("openfilter dependency to 1.1.0") == 1
 
 
 def test_pyproject_preserves_comments_and_layout(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -889,6 +889,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mistletoe"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/ea/ee6e364d62197e427f1d260500eac659a8855df207a77f74451658d749f3/mistletoe-1.6.0.tar.gz", hash = "sha256:92f066c4720a25fa24bf260e6413702bbff3a5b8a93af314cb6cd8589726a8e1", size = 113730, upload-time = "2026-07-11T14:14:18.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/5c/3681c676d79726e3b8b72bc78e83ac472b0c96e3c99b28d72b9470f12170/mistletoe-1.6.0-py3-none-any.whl", hash = "sha256:53f9dfb859e9b2d309915d0f06c3876253d1e24d568d0b728a32679eb4f0a187", size = 55931, upload-time = "2026-07-11T14:14:17.056Z" },
+]
+
+[[package]]
 name = "more-itertools"
 version = "11.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1043,10 +1052,12 @@ dev = [
     { name = "build" },
     { name = "docker" },
     { name = "jq" },
+    { name = "mistletoe" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "setuptools" },
+    { name = "tomlkit" },
     { name = "twine" },
     { name = "wheel" },
 ]
@@ -1090,6 +1101,7 @@ requires-dist = [
     { name = "google-cloud-storage", marker = "extra == 'all'", specifier = "~=3.13.0" },
     { name = "google-cloud-storage", marker = "extra == 'image-in'", specifier = "~=3.13.0" },
     { name = "jq", marker = "extra == 'dev'", specifier = "~=1.12.0" },
+    { name = "mistletoe", marker = "extra == 'dev'", specifier = "~=1.6.0" },
     { name = "numpy", specifier = "~=2.2.6" },
     { name = "opencv-python-headless", specifier = "~=5.0.0.93" },
     { name = "openlineage-python", specifier = "~=1.51.0" },
@@ -1118,6 +1130,7 @@ requires-dist = [
     { name = "scarf-sdk", specifier = "~=0.2.1" },
     { name = "setuptools", marker = "extra == 'dev'", specifier = "~=83.0.0" },
     { name = "setuptools", marker = "extra == 'mqtt-out'", specifier = "~=83.0.0" },
+    { name = "tomlkit", marker = "extra == 'dev'", specifier = "~=0.15.1" },
     { name = "twine", marker = "extra == 'dev'", specifier = "~=6.2.0" },
     { name = "typing-extensions", specifier = ">=4.6" },
     { name = "uvicorn", marker = "extra == 'all'", specifier = "~=0.51.0" },
@@ -1909,6 +1922,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
     { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

The cascade's dependency-bump script now writes `- Bump the openfilter dependency to X.Y.Z` into a consumer's `RELEASE.md` instead of `- Bump openfilter to X.Y.Z`.

## Why the old wording was a release blocker

`changelog-parser-action` rejects any bullet matching `/^-\s+Bump\s+\S+\s+to\s+\d+(?:\.\d+)+/` once that bullet sits inside a dated release section. Our `check-release-log` job runs that parser on every pull request to `main`, so the rule is not advisory: it gates merges.

Under `## [Unreleased]` the old bullet was harmless, and the cascade always targets `[Unreleased]`, so nothing failed at bump time. The failure arrived later. As soon as a consumer cut a release and promoted `[Unreleased]` to a version heading, every bump bullet that had accumulated underneath came along with it and started failing the parser. Each repo then had to hand-patch its own changelog to get back to green.

## Evidence

On `PlainsightAI/filter-protege-model`:

- Commit 2e9a14872c60e266fc56aaae1584315383c44451 cut the accumulated `[Unreleased]` content into a dated `v0.1.28` section, carrying the bump bullets with it. `check-release-log` failed.
- Commit 85f8e6cef4218dc3b3c81cf701d365ad80b802f7 moved those same bullets back under `[Unreleased]`, changing nothing else about them. `check-release-log` passed.

Same bullets, same parser, different section. That isolates the wording plus placement as the cause rather than anything else in the release cut.

## The fix

Naming the dependency puts a word between `Bump` and `to`, so the bullet no longer matches the rejection pattern, and it stays readable and consistent with the imperative mood of the surrounding entries.

The idempotency check moves from an exact line comparison to a regex that also recognizes the previous literal and the past-tense phrasing (`Bumped ... to ...`) used when repos were patched by hand. A re-run over a changelog that already carries one of the older shapes will recognize it instead of appending a near-duplicate beside it. The regex is anchored at both ends and matches the exact version, so it keeps the guarantee the line-anchored check gave: `0.1.9` does not match `0.1.99`.

## Making the guard suite actually run

`tests/test_cascade_bump_strategy.py` drives those rewriters end to end, so its assertions move with the new bullet. It also gains three cases for the widened idempotency check: the old literal already present, the past-tense `- Bumped the openfilter dependency to X.Y.Z.` shape left behind by hand patches, and tolerance for a trailing period.

That suite was not running anywhere. It skips itself when `tomlkit` or `mistletoe` is missing, and neither package was declared in the project, so `run-unit-tests` collected the file and skipped every case in it on all four Python versions. `make install && make test-all` did the same locally. Both are now in the `dev` extra, with `uv.lock` regenerated: two packages added, nothing else moved. A clean `pip install -e .[all,dev]` now gives 28 passed, 0 skipped.

`cascade-pr-checks` runs the file directly as well, so a change to the cascade scripts gets that signal in about thirty seconds rather than waiting on the full matrix. Its path filter now covers the test file itself, so a pull request touching only the tests still triggers it.

## Why this should land before the next tag

The cascade fans out to roughly 39 consumer repos. Tagging openfilter with the current template would seed all of them with the old bullet, and each one would hit the same failure at its own next release cut and need its own hand patch. Landing this first means the next round of bump pull requests carries wording that survives the release cut.

Surfaced by the review discussion on PlainsightAI/filter-protege-model#46.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787783447&installation_model_id=20112&pr_number=132&repository=PlainsightAI%2Fopenfilter&return_to=https%3A%2F%2Fgithub.com%2FPlainsightAI%2Fopenfilter%2Fpull%2F132&signature=3391a3c86c2d28556111f56624d51f3fe70218a677b92d5b68b8aedb4c0903ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
