### PR TITLE
feat(supply-chain): sign SPDX SBOM for built-in images (keyless cosign)

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -406,13 +406,20 @@ jobs:
           - plainsightai/openfilter-rest
           - plainsightai/openfilter-webvis
     steps:
+      # cosign-installer and download-syft run in a job holding id-token: write; whoever
+      # controls a mutable tag on either could mint a Fulcio certificate as this repo's
+      # identity, so these two signing actions are pinned by full commit SHA — the
+      # load-bearing exception to floating tags, matching how sast-secrets.yml pins
+      # trufflehog. cosign-release pins the cosign binary (v2 flag spelling); syft-version
+      # pins the SBOM generator so its output can't shift silently.
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
         with:
-          # Pin the cosign binary (not the action) to v2.5.2 — the attest flags are v2 spelling.
           cosign-release: v2.5.2
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: v1.50.0
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -394,9 +394,12 @@ jobs:
     needs: [prepare-pypi-publish, publish-docker-images]
     # !cancelled() so a single failing publish leg (fail-fast: false leaves the whole
     # publish-docker-images job at failure) does not skip attesting the images that did
-    # push. The matrix is fail-fast: false, so legs whose image is missing fail on their
-    # own without blocking the rest. already_exists gate keeps this to real releases.
-    if: ${{ !cancelled() && needs.prepare-pypi-publish.outputs.already_exists == 'false' }}
+    # push. But require it not to be 'skipped' — if publish-docker-images was skipped
+    # outright (e.g. an upstream wait-for-pypi timeout), nothing was pushed and every leg
+    # here would fail on a non-existent tag; that stays a clean skip. The matrix is
+    # fail-fast: false, so legs whose image is missing fail on their own without blocking
+    # the rest. already_exists gate keeps this to real releases.
+    if: ${{ !cancelled() && needs.publish-docker-images.result != 'skipped' && needs.prepare-pypi-publish.outputs.already_exists == 'false' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -309,12 +309,12 @@ jobs:
 
   publish-docker-images:
     runs-on: ubuntu-latest
-    # id-token: write for keyless cosign SBOM attestation (below). contents: read
-    # matches the workflow default; the Docker Hub push uses DOCKERHUB_ACCESS_TOKEN,
-    # not GITHUB_TOKEN, so scoping the token here does not affect publishing.
+    # contents: read matches the workflow default; the Docker Hub push uses
+    # DOCKERHUB_ACCESS_TOKEN, not GITHUB_TOKEN. SBOM attestation runs in the separate
+    # attest-docker-images job (which holds id-token: write), so a Sigstore failure
+    # there cannot gate cascade-pipeline-bumps, which only needs the push here.
     permissions:
       contents: read
-      id-token: write
     needs: [prepare-pypi-publish, publish-to-pypi, wait-for-pypi]
     strategy:
       fail-fast: false
@@ -377,26 +377,63 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Supply-chain: attach a signed SPDX SBOM to each built-in image — the same
-      # keyless cosign attestation the shared publish composites add for filters, so the
-      # grype-release-metric daily scanner can re-scan these images from their SBOM (no
-      # pull). openfilter is open source, so the public Sigstore Rekor log is fine.
-      # (syft scans the default-platform image of the multi-arch tag — the amd64 build.)
+  # Supply-chain: attach a signed SPDX SBOM to each built-in image — the same keyless
+  # cosign attestation the shared publish composites add for filters, so the
+  # grype-release-metric daily scanner can re-scan these images from their SBOM (no pull).
+  # openfilter is open source, so the public Sigstore Rekor log is fine.
+  #
+  # Deliberately a SEPARATE job from publish-docker-images: it runs after the push but
+  # cascade-pipeline-bumps needs only publish-docker-images, so a transient Sigstore/Fulcio
+  # failure here surfaces as a red attest job WITHOUT skipping the version-bump cascade for
+  # images that published fine.
+  attest-docker-images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    needs: [prepare-pypi-publish, publish-docker-images]
+    if: needs.prepare-pypi-publish.outputs.already_exists == 'false'
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - plainsightai/openfilter-video-in
+          - plainsightai/openfilter-video-out
+          - plainsightai/openfilter-image-in
+          - plainsightai/openfilter-image-out
+          - plainsightai/openfilter-mqtt-out
+          - plainsightai/openfilter-recorder
+          - plainsightai/openfilter-rest
+          - plainsightai/openfilter-webvis
+    steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        with:
+          cosign-release: v2.5.2
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: plainsightai
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       - name: SBOM + keyless attest
         shell: bash
         env:
-          IMAGE: ${{ matrix.filter.image }}
+          IMAGE: ${{ matrix.image }}
           VERSION: ${{ needs.prepare-pypi-publish.outputs.package_version }}
         run: |
           set -euo pipefail
           REF="${IMAGE}:${VERSION}"
-          syft "$REF" -o spdx-json=sbom.spdx.json
-          # --type spdxjson sets predicateType https://spdx.dev/Document (what the scanner filters on).
-          cosign attest --yes --type spdxjson --predicate sbom.spdx.json "$REF"
+          # These images build linux/amd64,linux/arm64. syft catalogs one platform of a
+          # manifest-list, so attest one SBOM per platform to the index digest; the scanner
+          # reads every spdxjson attestation on the ref.
+          for plat in linux/amd64 linux/arm64; do
+            sbom="sbom.$(echo "$plat" | tr '/' '-').spdx.json"
+            syft "$REF" --platform "$plat" -o spdx-json="$sbom"
+            # --type spdxjson sets predicateType https://spdx.dev/Document (scanner filter).
+            cosign attest --yes --type spdxjson --predicate "$sbom" "$REF"
+          done
 
   # Second-level pipeline-manifest cascade for the built-in filter images.
   # Standalone filter-* repos fire cascade-pipeline-bumps through

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -309,6 +309,12 @@ jobs:
 
   publish-docker-images:
     runs-on: ubuntu-latest
+    # id-token: write for keyless cosign SBOM attestation (below). contents: read
+    # matches the workflow default; the Docker Hub push uses DOCKERHUB_ACCESS_TOKEN,
+    # not GITHUB_TOKEN, so scoping the token here does not affect publishing.
+    permissions:
+      contents: read
+      id-token: write
     needs: [prepare-pypi-publish, publish-to-pypi, wait-for-pypi]
     strategy:
       fail-fast: false
@@ -370,6 +376,27 @@ jobs:
           tags: ${{ steps.prepare-tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Supply-chain: attach a signed SPDX SBOM to each built-in image — the same
+      # keyless cosign attestation the shared publish composites add for filters, so the
+      # grype-release-metric daily scanner can re-scan these images from their SBOM (no
+      # pull). openfilter is open source, so the public Sigstore Rekor log is fine.
+      # (syft scans the default-platform image of the multi-arch tag — the amd64 build.)
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
+      - name: SBOM + keyless attest
+        shell: bash
+        env:
+          IMAGE: ${{ matrix.filter.image }}
+          VERSION: ${{ needs.prepare-pypi-publish.outputs.package_version }}
+        run: |
+          set -euo pipefail
+          REF="${IMAGE}:${VERSION}"
+          syft "$REF" -o spdx-json=sbom.spdx.json
+          # --type spdxjson sets predicateType https://spdx.dev/Document (what the scanner filters on).
+          cosign attest --yes --type spdxjson --predicate sbom.spdx.json "$REF"
 
   # Second-level pipeline-manifest cascade for the built-in filter images.
   # Standalone filter-* repos fire cascade-pipeline-bumps through

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -392,7 +392,11 @@ jobs:
       contents: read
       id-token: write
     needs: [prepare-pypi-publish, publish-docker-images]
-    if: needs.prepare-pypi-publish.outputs.already_exists == 'false'
+    # !cancelled() so a single failing publish leg (fail-fast: false leaves the whole
+    # publish-docker-images job at failure) does not skip attesting the images that did
+    # push. The matrix is fail-fast: false, so legs whose image is missing fail on their
+    # own without blocking the rest. already_exists gate keeps this to real releases.
+    if: ${{ !cancelled() && needs.prepare-pypi-publish.outputs.already_exists == 'false' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -407,11 +407,12 @@ jobs:
           - plainsightai/openfilter-webvis
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        uses: sigstore/cosign-installer@v3
         with:
+          # Pin the cosign binary (not the action) to v2.5.2 — the attest flags are v2 spelling.
           cosign-release: v2.5.2
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        uses: anchore/sbom-action/download-syft@v0
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,16 @@ OpenFilter Library release notes
   SLSA provenance — the SBOM is an opt-in input the workflow never set, so no SBOM was
   actually produced until now. This adds it.
 
+  Verify a published image's SBOM attestation (the signing identity is the release
+  workflow dispatched from `main`, since it creates the tag within the same run):
+
+  ```
+  cosign verify-attestation --type spdxjson \
+    --certificate-identity 'https://github.com/PlainsightAI/openfilter/.github/workflows/create-release.yaml@refs/heads/main' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    plainsightai/openfilter-video-in:<version>
+  ```
+
 ## v1.2.0 - 2026-07-27
 
 ### Added
@@ -161,7 +171,7 @@ This release rolls up the `v0.2.0` declarative-configuration work and the `v0.2.
 
 - **Shared security scan workflow**: Replaced standalone Grype security scan with the shared `PlainsightAI/gh-actions-public` reusable workflow.
 - **GitHub Actions bumped to latest versions**: `actions/checkout` v4→v6, `actions/setup-python` v5→v6, `actions/upload-artifact` v4→v7, `actions/download-artifact` v4.1.3→v8, `docker/setup-buildx-action` v3→v4, `docker/login-action` v3→v4, `docker/build-push-action` v5→v6, `dorny/paths-filter` v3→v4, `mukunku/tag-exists-action` v1.6.0→v1.7.0. Resolves Node.js <24 deprecation warnings.
-- **Docker images now include SLSA provenance** via `docker/build-push-action` v6 defaults (SBOM attestations are added separately by the release workflow's cosign step; see Unreleased).
+- **Docker images now include SLSA provenance** via `docker/build-push-action` v6 defaults (SBOM attestations are added separately starting with the next release; see Unreleased).
 
 ### Fixed
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,16 @@
 
 OpenFilter Library release notes
 
+## [Unreleased]
+
+### Security
+
+- **Built-in images now carry a real SBOM attestation.** Each published built-in image
+  (video-in/out, image-in/out, mqtt-out, recorder, rest, webvis) gets a signed SPDX SBOM
+  attached as a keyless cosign attestation (`--type spdxjson`), in a dedicated
+  `attest-docker-images` job. `docker/build-push-action` defaults only attach SLSA
+  provenance, not an SBOM, so this closes the gap the earlier changelog entries assumed.
+
 ## v1.2.0 - 2026-07-27
 
 ### Added
@@ -77,7 +87,7 @@ Two runtime improvements teams have been asking for, landed underneath the compa
 ### Production-Grade Engineering
 
 - **First-class observability**: per-filter OpenTelemetry distributed tracing (#79), OpenLineage events (v0.1.5), per-frame timing metrics, and a turn-key Grafana stack (v0.1.21–22). Wall-clock latency dashboards separate `process` time from ZMQ and queue overhead.
-- **Supply-chain hygiene**: SLSA provenance and SBOM attestations on every Docker image; token auth and CORS for HTTP-exposed filters (v0.1.30).
+- **Supply-chain hygiene**: SLSA provenance on every Docker image; token auth and CORS for HTTP-exposed filters (v0.1.30).
 - **GPU and deployment ergonomics**: framework-agnostic GPU detection via `ctypes` (v0.1.28); GKE-compatible `LD_LIBRARY_PATH` injection (v0.1.26), so CUDA-dependent images deploy without per-cluster fixups.
 - **Filter library refresh**: new `ImageIn` / `ImageOut` filters for still-image pipelines (#21, #29); `VideoIn` moved off `vidgear` to `cv2` / PyAV (#66, #67) for stability against odd-codec sources.
 
@@ -149,7 +159,7 @@ This release rolls up the `v0.2.0` declarative-configuration work and the `v0.2.
 
 - **Shared security scan workflow**: Replaced standalone Grype security scan with the shared `PlainsightAI/gh-actions-public` reusable workflow.
 - **GitHub Actions bumped to latest versions**: `actions/checkout` v4→v6, `actions/setup-python` v5→v6, `actions/upload-artifact` v4→v7, `actions/download-artifact` v4.1.3→v8, `docker/setup-buildx-action` v3→v4, `docker/login-action` v3→v4, `docker/build-push-action` v5→v6, `dorny/paths-filter` v3→v4, `mukunku/tag-exists-action` v1.6.0→v1.7.0. Resolves Node.js <24 deprecation warnings.
-- **Docker images now include SLSA provenance and SBOM attestations** via `docker/build-push-action` v6 defaults.
+- **Docker images now include SLSA provenance** via `docker/build-push-action` v6 defaults (SBOM attestations are added separately by the release workflow's cosign step; see Unreleased).
 
 ### Fixed
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,8 +9,10 @@ OpenFilter Library release notes
 - **Built-in images now carry a real SBOM attestation.** Each published built-in image
   (video-in/out, image-in/out, mqtt-out, recorder, rest, webvis) gets a signed SPDX SBOM
   attached as a keyless cosign attestation (`--type spdxjson`), in a dedicated
-  `attest-docker-images` job. `docker/build-push-action` defaults only attach SLSA
-  provenance, not an SBOM, so this closes the gap the earlier changelog entries assumed.
+  `attest-docker-images` job. The v0.1.30 and v1.0.0 entries below claimed the images
+  already carried SBOM attestations, but `docker/build-push-action` defaults attach only
+  SLSA provenance — the SBOM is an opt-in input the workflow never set, so no SBOM was
+  actually produced until now. This adds it.
 
 ## v1.2.0 - 2026-07-27
 


### PR DESCRIPTION
Closes the openfilter gap in the released-artifact vulnerability reporting effort: the 8 built-in images (video-in/out, image-in/out, mqtt-out, recorder, rest, webvis) publish via a bespoke `docker/build-push-action` matrix, not the shared publish composites — so the SBOM-attest work added there does not reach them (they would show up as `released_image_no_sbom` in the scanner). Adds `id-token: write` to the job + Syft + keyless `cosign attest` after each push. Open source, so the public Rekor log is fine.

Related: gh-actions#90, gh-actions-public#32, infrastructure-tooling#8.

**Smoke test:** the first openfilter release after merge confirms the attestation attaches (publish job green + `cosign download attestation --predicate-type=https://spdx.dev/Document <image>` returns the SBOM).
