### PR TITLE
docker: add openfilter-base image (apt-upgraded python-slim) + weekly build

### DIFF
--- a/.github/workflows/build-base.yaml
+++ b/.github/workflows/build-base.yaml
@@ -1,0 +1,86 @@
+name: Build base images
+
+# openfilter-base: a minimal fresh-OS python-slim (apt upgrade only) published per
+# supported Python version to plainsightai/openfilter-base:py3.X. Rebuilt weekly so the
+# OS stays patched — downstream images (the built-in filters here and standalone filter
+# repos) inherit the patched base on their next build instead of each pinning a stale
+# python:X.Y.Z-slim. Also runnable on demand.
+on:
+  schedule:
+    # Mondays 06:00 UTC — ahead of anything that consumes the base that day.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+  # Rebuild when the base definition itself changes.
+  push:
+    branches: [main]
+    paths:
+      - docker/base.Dockerfile
+      - .github/workflows/build-base.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  build-base:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Compute date tag
+        id: date
+        run: echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: plainsightai
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Build and push base (py${{ matrix.python }})
+        uses: docker/build-push-action@v7
+        with:
+          context: "."
+          file: docker/base.Dockerfile
+          build-args: PYTHON_VERSION=${{ matrix.python }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          # Rolling per-version tag for consumers + an immutable dated tag for reproducibility.
+          tags: |
+            plainsightai/openfilter-base:py${{ matrix.python }}
+            plainsightai/openfilter-base:py${{ matrix.python }}-${{ steps.date.outputs.date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # Attach a signed SPDX SBOM to each base image (keyless cosign, public Rekor — openfilter
+  # is open source), the same attestation the built-in filter images get, so the
+  # grype-release-metric scanner can re-scan the base from its SBOM without a pull.
+  attest-base:
+    needs: build-base
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: plainsightai
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: SBOM + keyless attest (py${{ matrix.python }})
+        uses: PlainsightAI/gh-actions-public/attest-sbom@main
+        with:
+          image: plainsightai/openfilter-base:py${{ matrix.python }}
+          platforms: linux/amd64,linux/arm64

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.4
+#
+# openfilter-base — a fresh-OS Python base shared by openfilter images (the built-in
+# filter images here, and standalone filter repos alike).
+#
+# Its whole job is to be a `python:X-slim` with every outstanding Debian security update
+# already applied (apt upgrade). Downstream images inherit a patched OS from ONE place
+# instead of each pinning a stale `python:X.Y.Z-slim` that silently drifts behind Debian's
+# point releases (openssl, gnutls, the python apt package, …). Rebuilt on a weekly schedule
+# so the OS stays current.
+#
+# Deliberately MINIMAL: no system libraries are installed here. Each filter installs only
+# the libraries IT needs (e.g. ffmpeg + libGL for video filters, libzbar0 for QR) in its
+# own Dockerfile, so the shared base stays small and no filter inherits a library — and its
+# CVEs — it never uses.
+#
+# Published per supported Python version: plainsightai/openfilter-base:py3.10 .. py3.13
+# (openfilter's requires-python is >=3.10,<3.14). Consumers pick the tag for their version:
+#   FROM plainsightai/openfilter-base:py3.11
+ARG PYTHON_VERSION=3.11
+FROM python:${PYTHON_VERSION}-slim
+
+# The one thing this image does: apply all outstanding Debian security patches on top of
+# the python base. That clears the OS-package CVEs (openssl/libssl3, gnutls, python) that
+# every filter inherits from a stale python:X.Y.Z-slim pin.
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Standard non-root runtime layout shared by openfilter images. USER is deliberately NOT
+# set here: downstream images COPY build artifacts in as root and switch to appuser at the
+# end, so flipping the user is the consumer's last step.
+RUN useradd -ms /bin/bash appuser \
+    && mkdir -p /app/logs \
+    && chown -R appuser:appuser /app
+WORKDIR /app


### PR DESCRIPTION
## What

Adds a shared **`openfilter-base`** image so downstream images inherit a patched OS from one place.

Today the built-in filter images and the standalone filter repos each pin a `python:X.Y.Z-slim` base. A pinned patch tag silently drifts behind Debian's point releases, so OS packages (`openssl`/`libssl3`, `gnutls`, the `python` apt package, …) accumulate fixable CVEs that no filter individually patches.

### `docker/base.Dockerfile`
Deliberately **minimal**: `python:${PYTHON_VERSION}-slim` with `apt-get upgrade` applied, plus the common non-root `ENV` / `appuser` / `WORKDIR` layout every openfilter image already repeats. **No system libraries are installed here** — each filter keeps installing only what it needs (ffmpeg + libGL for video, `libzbar0` for QR, …), so the base stays small and no filter inherits a library — and its CVEs — it never uses.

### `.github/workflows/build-base.yaml`
- Builds the matrix `py3.10 .. py3.13` (openfilter's `requires-python` is `>=3.10,<3.14`), multi-arch `amd64`/`arm64`.
- Publishes `plainsightai/openfilter-base:py3.X` (rolling, for consumers) plus an immutable `:py3.X-YYYYMMDD` tag.
- Rebuilt on a **weekly schedule** (so the OS stays current), on demand, and when the base definition changes.
- Attaches a signed SPDX SBOM (keyless cosign, public Rekor) via the shared `attest-sbom` action — same attestation the built-in images get.

## Scope

This PR **only adds the base and its build** — nothing downstream changes yet. Consumers migrate in follow-ups:
1. Built-in images (`docker/*.Dockerfile`) → `FROM plainsightai/openfilter-base:py3.13`, with the base built before them (`needs:`) in the release.
2. Standalone filter repos → `FROM plainsightai/openfilter-base:py3.X`.

## Validation

The build itself is the proof: after `apt-get upgrade`, a grype scan of the base's SBOM should be clean of the OS-package CVEs that the pinned `python:X.Y.Z-slim` carries. I'll dispatch the workflow once this is approved and attach the result.

## Relationship to the Grype release scanner

This is complementary to the released-image Grype scan, not a competing CVE mechanism:

- **openfilter-base patches the OS layer proactively** — `apt upgrade` on every rebuild, before CVEs ever surface in a scan.
- **The scanner catches OS/dependency CVEs reactively** on already-released images.

The base shrinks what the scanner finds; the scanner still covers app/pip-level CVEs (e.g. the ffmpeg bundled inside the PyAV wheel) and anything the base doesn't touch. As filters migrate onto the base, the released-image OS-CVE counts should fall to near zero.
