### PR TITLE
docker: build the built-in images on openfilter-base and drop unused system libs (X11/GL, ffmpeg)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,18 @@ OpenFilter Library release notes
 
 ## [Unreleased]
 
+### Security
+
+- **Built-in images now build on the shared `openfilter-base`.** Each built-in image
+  (video-in/out, image-in/out, mqtt-out, recorder, rest, webvis) now derives from
+  `plainsightai/openfilter-base:py3.13` — a `python:3.13-slim` with all outstanding
+  Debian security patches applied (`apt upgrade`), rebuilt weekly — instead of a bare
+  pinned `python:3.13-slim`, so their OS-layer packages (openssl, gnutls, …) stay
+  patched. The images also drop system libraries they never used: the X11/GL libs
+  (`libxcb1`, `libxcb-shm0`, `libxcb-render0`, `libx11-6`, `libgl1`, `libglib2.0-0`),
+  since openfilter uses `opencv-python-headless`; and the `ffmpeg` apt package, since
+  video I/O uses the ffmpeg bundled in OpenCV and PyAV. Smaller images, fewer CVEs.
+
 ## v1.2.1 - 2026-08-04
 
 ### Security

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -10,9 +10,10 @@
 # so the OS stays current.
 #
 # Deliberately MINIMAL: no system libraries are installed here. Each filter installs only
-# the libraries IT needs (e.g. ffmpeg + libGL for video filters, libzbar0 for QR) in its
-# own Dockerfile, so the shared base stays small and no filter inherits a library — and its
-# CVEs — it never uses.
+# the libraries IT actually needs (e.g. libzbar0 for QR decoding) in its own Dockerfile, so
+# the shared base stays small and no filter inherits a library — and its CVEs — it never
+# uses. (The built-in video filters need nothing extra: OpenCV is headless and PyAV bundles
+# its own ffmpeg, so no system ffmpeg/libGL/X11 is required.)
 #
 # Published per supported Python version: plainsightai/openfilter-base:py3.10 .. py3.13
 # (openfilter's requires-python is >=3.10,<3.14). Consumers pick the tag for their version:

--- a/docker/image_in.Dockerfile
+++ b/docker/image_in.Dockerfile
@@ -10,10 +10,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 FROM plainsightai/openfilter-base:py3.13
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
-    && rm -rf /var/lib/apt/lists/*
-
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/image_in.Dockerfile
+++ b/docker/image_in.Dockerfile
@@ -8,18 +8,12 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[image_in]==${VERSION}"
 
-FROM python:3.13-slim
-
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+FROM plainsightai/openfilter-base:py3.13
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -ms /bin/bash appuser
-
-WORKDIR /app
-RUN mkdir -p /app/logs && chown -R appuser:appuser /app
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/image_out.Dockerfile
+++ b/docker/image_out.Dockerfile
@@ -8,18 +8,12 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[image_out]==${VERSION}"
 
-FROM python:3.13-slim
-
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+FROM plainsightai/openfilter-base:py3.13
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -ms /bin/bash appuser
-
-WORKDIR /app
-RUN mkdir -p /app/logs && chown -R appuser:appuser /app
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/image_out.Dockerfile
+++ b/docker/image_out.Dockerfile
@@ -10,10 +10,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 FROM plainsightai/openfilter-base:py3.13
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
-    && rm -rf /var/lib/apt/lists/*
-
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/mqtt_out.Dockerfile
+++ b/docker/mqtt_out.Dockerfile
@@ -8,18 +8,12 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[mqtt_out]==${VERSION}"
 
-FROM python:3.13-slim
-
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+FROM plainsightai/openfilter-base:py3.13
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -ms /bin/bash appuser
-
-WORKDIR /app
-RUN mkdir -p /app/logs && chown -R appuser:appuser /app
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/mqtt_out.Dockerfile
+++ b/docker/mqtt_out.Dockerfile
@@ -10,10 +10,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 FROM plainsightai/openfilter-base:py3.13
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
-    && rm -rf /var/lib/apt/lists/*
-
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/recorder.Dockerfile
+++ b/docker/recorder.Dockerfile
@@ -8,18 +8,12 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[recorder]==${VERSION}"
 
-FROM python:3.13-slim
-
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+FROM plainsightai/openfilter-base:py3.13
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -ms /bin/bash appuser
-
-WORKDIR /app
-RUN mkdir -p /app/logs && chown -R appuser:appuser /app
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/recorder.Dockerfile
+++ b/docker/recorder.Dockerfile
@@ -10,10 +10,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 FROM plainsightai/openfilter-base:py3.13
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
-    && rm -rf /var/lib/apt/lists/*
-
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/rest.Dockerfile
+++ b/docker/rest.Dockerfile
@@ -8,18 +8,12 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[rest]==${VERSION}"
 
-FROM python:3.13-slim
-
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+FROM plainsightai/openfilter-base:py3.13
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -ms /bin/bash appuser
-
-WORKDIR /app
-RUN mkdir -p /app/logs && chown -R appuser:appuser /app
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/rest.Dockerfile
+++ b/docker/rest.Dockerfile
@@ -10,10 +10,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 FROM plainsightai/openfilter-base:py3.13
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
-    && rm -rf /var/lib/apt/lists/*
-
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/video_in.Dockerfile
+++ b/docker/video_in.Dockerfile
@@ -8,18 +8,12 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[video_in]==${VERSION}"
 
-FROM python:3.13-slim
-
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+FROM plainsightai/openfilter-base:py3.13
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -ms /bin/bash appuser
-
-WORKDIR /app
-RUN mkdir -p /app/logs && chown -R appuser:appuser /app
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/video_in.Dockerfile
+++ b/docker/video_in.Dockerfile
@@ -10,10 +10,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 FROM plainsightai/openfilter-base:py3.13
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ffmpeg libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
-    && rm -rf /var/lib/apt/lists/*
-
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/video_out.Dockerfile
+++ b/docker/video_out.Dockerfile
@@ -8,18 +8,12 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[video_out]==${VERSION}"
 
-FROM python:3.13-slim
-
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+FROM plainsightai/openfilter-base:py3.13
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -ms /bin/bash appuser
-
-WORKDIR /app
-RUN mkdir -p /app/logs && chown -R appuser:appuser /app
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/video_out.Dockerfile
+++ b/docker/video_out.Dockerfile
@@ -10,10 +10,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 FROM plainsightai/openfilter-base:py3.13
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ffmpeg libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
-    && rm -rf /var/lib/apt/lists/*
-
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/webvis.Dockerfile
+++ b/docker/webvis.Dockerfile
@@ -8,18 +8,12 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[webvis]==${VERSION}"
 
-FROM python:3.13-slim
-
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+FROM plainsightai/openfilter-base:py3.13
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -ms /bin/bash appuser
-
-WORKDIR /app
-RUN mkdir -p /app/logs && chown -R appuser:appuser /app
 USER appuser
 
 COPY --from=builder /usr/local /usr/local

--- a/docker/webvis.Dockerfile
+++ b/docker/webvis.Dockerfile
@@ -10,10 +10,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 FROM plainsightai/openfilter-base:py3.13
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libxcb1 libxcb-shm0 libxcb-render0 libx11-6 libgl1 libglib2.0-0 \
-    && rm -rf /var/lib/apt/lists/*
-
 USER appuser
 
 COPY --from=builder /usr/local /usr/local


### PR DESCRIPTION
## What

Step 2 of the base-image migration (follows #139): point the 8 **built-in filter images** (video_in/out, image_in/out, mqtt_out, recorder, rest, webvis) at the shared `openfilter-base`, and drop the system libraries they never needed.

### 1. Build on `openfilter-base`

Each runtime stage now derives from `plainsightai/openfilter-base:py3.13` instead of a bare `python:3.13-slim`, and drops the `ENV` / `appuser` / `WORKDIR` / logs boilerplate now inherited from the base. The builder stage is untouched.

So the images inherit the base's applied Debian security patches (`apt upgrade`, rebuilt weekly) instead of whatever the pinned `python:3.13-slim` shipped — their **OS-layer CVEs clear on rebuild**.

### 2. Drop unused system libraries

The runtime stages installed `libxcb*` / `libx11-6` / `libgl1` / `libglib2.0-0` and (for the video images) `ffmpeg`. None are needed:

- **X11/GL libs** — openfilter uses `opencv-python-headless` (no GUI), and there's no `imshow`/GL use anywhere in the code, so these were leftovers from full opencv.
- **ffmpeg (apt)** — video I/O uses bundled ffmpeg, not the system package: `VideoIn` reads via `cv2.VideoCapture` (opencv's bundled ffmpeg) and `VideoOut` writes via PyAV (`import av`, bundled `libavcodec 62` / ffmpeg 8.x). Nothing shells out to the ffmpeg binary or links system `libav*`.

After this, all 8 runtime stages install **nothing** beyond the base — smaller images, smaller CVE surface.

## Verification

On the published `openfilter-base:py3.13` (which has none of these libs), a real `VideoIn -> VideoOut` pipeline runs end-to-end:

```
video open: file:///tmp/input.mp4  (10.0 fps)      # VideoIn via opencv (bundled ffmpeg)
video create: /tmp/output.mp4  (10.0 fps)          # VideoOut via PyAV (bundled ffmpeg)
video ended, exiting... / all children exited
run_multi exit codes: [0, 0]
output.mp4: 2543 bytes, 20 frames decoded
```

## When it takes effect

On the next release: `create-release`'s `publish-docker-images` builds each image from the currently published `plainsightai/openfilter-base:py3.13` (kept current by the weekly `build-base`). A small patch release is enough to roll the fresh OS out to the released images. A `## [Unreleased]` changelog entry is included.

No `needs:` wiring is required in `create-release`: the base is an independent, already-published image, so the release just pulls the latest base when it builds.
