### PR TITLE
chore: finish Python 3.14 rollout (release gate, images, examples)

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -33,10 +33,12 @@
           { "context": "run-unit-tests (3.11)" },
           { "context": "run-unit-tests (3.12)" },
           { "context": "run-unit-tests (3.13)" },
+          { "context": "run-unit-tests (3.14)" },
           { "context": "security-scan / grype (3.10)" },
           { "context": "security-scan / grype (3.11)" },
           { "context": "security-scan / grype (3.12)" },
           { "context": "security-scan / grype (3.13)" },
+          { "context": "security-scan / grype (3.14)" },
           { "context": "cascade-pr-checks" },
           { "context": "check-release-log" }
         ]

--- a/.github/workflows/cascade-on-tag.yaml
+++ b/.github/workflows/cascade-on-tag.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Python (for check_constraint.py)
         uses: actions/setup-python@v7
         with:
-          python-version: '3.11'
+          python-version: '3.14'
 
       - name: Install constraint-check deps
         run: pip install --quiet packaging
@@ -150,7 +150,7 @@ jobs:
       - name: Set up Python (for bump-strategy.sh)
         uses: actions/setup-python@v7
         with:
-          python-version: '3.11'
+          python-version: '3.14'
 
       - name: Install bump-strategy deps
         run: pip install --quiet packaging tomlkit mistletoe

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Verify README.pypi.md is in sync with README.md
         run: make check-pypi-readme
@@ -96,7 +96,7 @@ jobs:
         if: steps.filter.outputs.cascade == 'true'
         uses: actions/setup-python@v7
         with:
-          python-version: '3.11'
+          python-version: '3.14'
 
       - name: Install cascade check and test deps
         if: steps.filter.outputs.cascade == 'true'

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -289,9 +289,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Wait for package availability on PyPI
+        # 3.14 is the newest supported interpreter, so the --dry-run resolve below
+        # doubles as a check that the just-published version installs on it.
         env:
           PACKAGE_NAME: ${{ needs.prepare-pypi-publish.outputs.package_name }}
           VERSION: ${{ needs.prepare-pypi-publish.outputs.package_version }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -142,7 +142,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.11"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: pip install build twine
@@ -229,7 +229,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.11"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: pip install twine

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,10 @@ OpenFilter Library release notes
   3.10–3.13 stay on `numpy~=2.2.6` (unchanged), and 3.14 pulls `numpy>=2.3.2,<3`. Every
   other compiled dependency already ships 3.14 wheels (opencv/av via stable-ABI `abi3`
   wheels, pyzmq, psutil, pydantic-core, grpcio, protobuf). The shared `openfilter-base`
-  image is now also published as `plainsightai/openfilter-base:py3.14`.
+  image is now also published as `plainsightai/openfilter-base:py3.14`, the release gate
+  (`create-release`) runs the suite on 3.14, and the built-in filter images
+  (video-in/out, image-in/out, mqtt-out, recorder, rest, webvis) now build on
+  `python:3.14-slim` / `openfilter-base:py3.14`. The example projects widen to `<3.15` too.
 
 ## v1.2.2 - 2026-08-10
 

--- a/docker/image_in.Dockerfile
+++ b/docker/image_in.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM python:3.13-slim AS builder
+FROM python:3.14-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential python3-dev && rm -rf /var/lib/apt/lists/*
@@ -8,7 +8,7 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[image_in]==${VERSION}"
 
-FROM plainsightai/openfilter-base:py3.13
+FROM plainsightai/openfilter-base:py3.14
 
 USER appuser
 

--- a/docker/image_out.Dockerfile
+++ b/docker/image_out.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM python:3.13-slim AS builder
+FROM python:3.14-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential python3-dev && rm -rf /var/lib/apt/lists/*
@@ -8,7 +8,7 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[image_out]==${VERSION}"
 
-FROM plainsightai/openfilter-base:py3.13
+FROM plainsightai/openfilter-base:py3.14
 
 USER appuser
 

--- a/docker/mqtt_out.Dockerfile
+++ b/docker/mqtt_out.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM python:3.13-slim AS builder
+FROM python:3.14-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential python3-dev && rm -rf /var/lib/apt/lists/*
@@ -8,7 +8,7 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[mqtt_out]==${VERSION}"
 
-FROM plainsightai/openfilter-base:py3.13
+FROM plainsightai/openfilter-base:py3.14
 
 USER appuser
 

--- a/docker/recorder.Dockerfile
+++ b/docker/recorder.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM python:3.13-slim AS builder
+FROM python:3.14-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential python3-dev && rm -rf /var/lib/apt/lists/*
@@ -8,7 +8,7 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[recorder]==${VERSION}"
 
-FROM plainsightai/openfilter-base:py3.13
+FROM plainsightai/openfilter-base:py3.14
 
 USER appuser
 

--- a/docker/rest.Dockerfile
+++ b/docker/rest.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM python:3.13-slim AS builder
+FROM python:3.14-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential python3-dev && rm -rf /var/lib/apt/lists/*
@@ -8,7 +8,7 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[rest]==${VERSION}"
 
-FROM plainsightai/openfilter-base:py3.13
+FROM plainsightai/openfilter-base:py3.14
 
 USER appuser
 

--- a/docker/video_in.Dockerfile
+++ b/docker/video_in.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM python:3.13-slim AS builder
+FROM python:3.14-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential python3-dev && rm -rf /var/lib/apt/lists/*
@@ -8,7 +8,7 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[video_in]==${VERSION}"
 
-FROM plainsightai/openfilter-base:py3.13
+FROM plainsightai/openfilter-base:py3.14
 
 USER appuser
 

--- a/docker/video_out.Dockerfile
+++ b/docker/video_out.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM python:3.13-slim AS builder
+FROM python:3.14-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential python3-dev && rm -rf /var/lib/apt/lists/*
@@ -8,7 +8,7 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[video_out]==${VERSION}"
 
-FROM plainsightai/openfilter-base:py3.13
+FROM plainsightai/openfilter-base:py3.14
 
 USER appuser
 

--- a/docker/webvis.Dockerfile
+++ b/docker/webvis.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM python:3.13-slim AS builder
+FROM python:3.14-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential python3-dev && rm -rf /var/lib/apt/lists/*
@@ -8,7 +8,7 @@ ARG VERSION
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "openfilter[webvis]==${VERSION}"
 
-FROM plainsightai/openfilter-base:py3.13
+FROM plainsightai/openfilter-base:py3.14
 
 USER appuser
 

--- a/examples/hello-ocr/pyproject.toml
+++ b/examples/hello-ocr/pyproject.toml
@@ -11,7 +11,7 @@ version = { file = "VERSION" }
 [project]
 name = "filter_hello_ocr"
 readme = "README.md"
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.10, <3.15"
 license = "Apache-2.0"
 
 classifiers = [

--- a/examples/hello-ocr/pyproject.toml
+++ b/examples/hello-ocr/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 
 dynamic = ["version"]

--- a/examples/hello-world/pyproject.toml
+++ b/examples/hello-world/pyproject.toml
@@ -11,7 +11,7 @@ version = { file = "VERSION" }
 [project]
 name = "filter_license_plate_pipeline_demo"
 readme = "README.md"
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.10, <3.15"
 license = "Apache-2.0"
 
 classifiers = [

--- a/examples/hello-world/pyproject.toml
+++ b/examples/hello-world/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 
 dynamic = ["version"]

--- a/examples/image_in/Dockerfile.dev
+++ b/examples/image_in/Dockerfile.dev
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 # Build openfilter from local source for development testing.
 # Build context must be the repo root.
-FROM python:3.13-slim AS builder
+FROM python:3.14-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential python3-dev && rm -rf /var/lib/apt/lists/*
@@ -10,7 +10,7 @@ COPY . /src
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "/src[all]"
 
-FROM python:3.13-slim
+FROM python:3.14-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 

--- a/examples/monitoring-demo/Dockerfile
+++ b/examples/monitoring-demo/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 # Build openfilter from local source for Docker-based pipeline testing.
 # Build context must be the repo root: docker build -f Dockerfile ../..
-FROM python:3.13-slim AS builder
+FROM python:3.14-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential python3-dev && rm -rf /var/lib/apt/lists/*
@@ -10,7 +10,7 @@ COPY . /src
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "/src[all]"
 
-FROM python:3.13-slim
+FROM python:3.14-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 

--- a/examples/text-generator-demo/pyproject.toml
+++ b/examples/text-generator-demo/pyproject.toml
@@ -11,7 +11,7 @@ version = { file = "VERSION" }
 [project]
 name = "filter_text_generator_demo"
 readme = "README.md"
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.10, <3.15"
 license = "Apache-2.0"
 
 classifiers = [

--- a/examples/text-generator-demo/pyproject.toml
+++ b/examples/text-generator-demo/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 
 dynamic = ["version"]

--- a/examples/video-pipeline-demo/pyproject.toml
+++ b/examples/video-pipeline-demo/pyproject.toml
@@ -11,7 +11,7 @@ version = { file = "VERSION" }
 [project]
 name = "video-pipeline-demo"
 readme = "README.md"
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.10, <3.15"
 license = "Apache-2.0"
 
 classifiers = [

--- a/examples/video-pipeline-demo/pyproject.toml
+++ b/examples/video-pipeline-demo/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
Follow-ups after #142 (which added Python 3.14 to the `openfilter` package). These close the remaining places that still assumed a 3.13 ceiling.

## 1. Release gate now runs on 3.14
`create-release.yaml`'s `run-unit-tests` matrix gated releases on 3.10–3.13 only, and `create-release` depends on it — so a release could be cut even if 3.14 broke. Added `3.14`.

## 2. Branch protection requires the 3.14 checks
`.github/rulesets/main.json` listed required status checks explicitly per version, only up to 3.13 — so `run-unit-tests (3.14)` and `grype (3.14)` were advisory and a PR could merge with 3.14 red. Added both. Both contexts exist on `main` once this PR lands (unit-tests via #142; `grype (3.14)` via item 4 here), so no deadlock — the old ruleset still gates this PR.

## 3. Built-in filter images build on 3.14
The 8 built-in images (video-in/out, image-in/out, mqtt-out, recorder, rest, webvis) now build on `python:3.14-slim` + `openfilter-base:py3.14` (base tag already published by `build-base` after #142 merged).

Safe by construction: `publish-docker-images` `needs: [prepare-pypi-publish, publish-to-pypi, wait-for-pypi]` and installs `openfilter[...]==<version>` **after** the release is on PyPI — so the builder always resolves the cp314 wheels that the same 3.14-supporting release ships. The Dockerfile bump and the numpy cp314 fix travel together in `main`, so they can never release out of step.

## 4. Security scan + PyPI poll on 3.14
- `security-scan.yaml`: `python_versions` override adds 3.14 so Grype scans the 3.14 dependency tree.
- `wait-for-pypi` (`create-release.yaml`): polls on 3.14 instead of 3.13 — the newest supported interpreter, so its `pip install --dry-run` doubles as an install check on 3.14.

## 5. Example projects widen to `<3.15`
The four `examples/*/pyproject.toml` were capped at `>=3.10,<3.13` (excluded even 3.13) → `>=3.10,<3.15`. `monitoring-demo/Dockerfile` and `image_in/Dockerfile.dev` bumped to `python:3.14-slim`. Standalone demo packages, independent of the shipped wheel.

## 6. Tooling steps standardized on 3.14
The build/publish, readme-sync check, and cascade steps were pinned to 3.11/3.12. They only install pure-Python tools with no `requires_python` upper cap (`build`, `twine`, `packaging`, `tomlkit`, `mistletoe`, `pytest`; `make_pypi_readme.py` is stdlib-only), so they run on 3.14. Standardized on 3.14 so the toolchain stays current the longest (3.11 ages out first) and every job uses one interpreter. The wheel stays a `py3-none-any` universal artifact regardless of build interpreter — this is consistency/future-proofing, not a build change.

## Scope / gate
Touches only `.github/**`, `docker/**`, `examples/**`, `RELEASE.md` — no `openfilter/**` source, so the release-log gate is a no-op; the RELEASE.md `[Unreleased]` entry from #142 is extended for completeness. `VERSION` bump stays for the separate release PR per convention.

