### PR TITLE
test: deflake test_topo_balance_step on Python 3.14

### DIFF
--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -394,8 +394,15 @@ class TestFilterOld(unittest.TestCase):
 
 
     def test_topo_balance_step(self):
+        # outputs_required makes the source block until all three workers are
+        # connected before it sends anything. Without it, outputs_balance rotates
+        # only over the channels connected so far, so a worker that connects late
+        # shifts the rotation and lands two consecutive frames on the same worker
+        # (the assertIsNot below). start_sleep=0.1 hid this under 'fork' (fast
+        # child startup), but Python 3.14 defaults multiprocessing to the slower
+        # 'forkserver' on Linux, which widened the race into a frequent flake.
         runner = Filter.Runner([
-            (FilterFromQueue, dict(id='src', outputs='tcp://*:5550, tcp://*:5552, tcp://*:5554', outputs_balance=True, queue=(qout := Queue()), start_sleep=0.1)),
+            (FilterFromQueue, dict(id='src', outputs='tcp://*:5550, tcp://*:5552, tcp://*:5554', outputs_balance=True, outputs_required='worker1, worker2, worker3', queue=(qout := Queue()), start_sleep=0.1)),
             (MyFilter,        dict(id='worker1', sources='tcp://localhost:5550', outputs='tcp://*:5560', queue=(qworker1 := Queue()))),
             (MyFilter,        dict(id='worker2', sources='tcp://localhost:5552', outputs='tcp://*:5562', queue=(qworker2 := Queue()))),
             (MyFilter,        dict(id='worker3', sources='tcp://localhost:5554', outputs='tcp://*:5564', queue=(qworker3 := Queue()))),


### PR DESCRIPTION
## Problem

`TestFilterOld::test_topo_balance_step` flakes on the `run-unit-tests (3.14)` leg (now a required check). It asserts strict round-robin balancing — each frame must land on a *different* worker than the previous one (`assertIsNot(qworker, last_qworker)`).

`outputs_balance` rotates only over the output channels that currently have a downstream connected. When a worker connects late, the rotation shifts and two consecutive frames land on the same worker → the assertion fails. The source's `start_sleep=0.1` masked this under `fork` (fast child startup), but **Python 3.14 defaults `multiprocessing` to the slower `forkserver` on Linux**, which widens the connection window and turns the latent race into a frequent flake.

## Fix

Add `outputs_required='worker1, worker2, worker3'` to the source. This is openfilter's own connection barrier (already used by `test_topo_tee`): the source blocks until all three named downstreams are connected before sending anything, so the balancing rotation starts from a fully-connected topology and is deterministic. One-line change (plus an explanatory comment); no product code touched.

## Validation (real Linux containers, not the flaky CI leg)

Reproduced faithfully in `python:3.14-slim` (Linux default = `forkserver`) and `python:3.13-slim` (`fork`):

| Environment | Before (start_sleep only) | After (outputs_required) |
|---|---|---|
| Linux 3.14 `forkserver` | 11/12 (~8% flake) | **60/60** |
| Linux 3.13 `fork` | green | **15/15** |

The macOS-only local `spawn`/`forkserver` repro was discarded as unfaithful (module re-import / root-permission artifacts); all numbers above are from real Linux containers matching CI.

## Scope

Test-only (`tests/test_filter.py`); the `check-release-log` gate is scoped to `openfilter/**`, so no RELEASE.md entry.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789075277&installation_model_id=20112&pr_number=148&repository=PlainsightAI%2Fopenfilter&return_to=https%3A%2F%2Fgithub.com%2FPlainsightAI%2Fopenfilter%2Fpull%2F148&signature=efe9e1736464f2d6dfb65874fbc9e2b98d990e66cb32c343cd2e941cc83b5bb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->