### PR TITLE
feat: FILTER_OVERRIDE_SOURCE_URI + ImageIn single-file extension-agnostic

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,24 @@ OpenFilter Library release notes
 
 ### Added
 
+- **`VideoIn` / `ImageIn`: `FILTER_OVERRIDE_SOURCE_URI` to preserve source-file identity.**
+  A new `override_source_uri` config (env `FILTER_OVERRIDE_SOURCE_URI`, or
+  `FILTER_OVERRIDE_SOURCE_URI_FILE` to read it from a file written at runtime) makes both
+  input filters report that value as each frame's `meta['src']` instead of the physical
+  input path. This lets an orchestrator keep per-file attribution when the media is
+  downloaded to a generic path (e.g. a batch claimer's `/ws/input`) — the identity travels
+  as metadata rather than in the filename. See PLAT-1498.
+
+### Fixed
+
+- **`ImageIn` now processes a single explicit file regardless of its extension.** The
+  image-extension gate (`jpg/png/…`) only ever needed to filter non-images out of
+  *directory* listings, but it was also applied to a single named file, so a file with a
+  non-image or missing extension (e.g. a batch claimer's `/ws/input`) was silently skipped
+  and produced no frames. Single explicit files are now accepted and validated by decoding
+  (`cv2.imread`), which also logs a warning on an undecodable file; directory and S3/GCS
+  listing keep the extension gate. See PLAT-1498.
+
 - **Python 3.14 support.** `requires-python` widens to `>=3.10,<3.15` and the unit-test
   matrix now includes 3.14, alongside the existing 3.10–3.13. numpy is the only dependency
   that needed a change: 2.2.x is the last line with Python 3.10 wheels, while cp314 wheels

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,7 @@ OpenFilter Library release notes
   input filters report that value as each frame's `meta['src']` instead of the physical
   input path. This lets an orchestrator keep per-file attribution when the media is
   downloaded to a generic path (e.g. a batch claimer's `/ws/input`) — the identity travels
-  as metadata rather than in the filename. See PLAT-1498.
+  as metadata rather than in the filename.
 
 ### Fixed
 
@@ -22,7 +22,7 @@ OpenFilter Library release notes
   non-image or missing extension (e.g. a batch claimer's `/ws/input`) was silently skipped
   and produced no frames. Single explicit files are now accepted and validated by decoding
   (`cv2.imread`), which also logs a warning on an undecodable file; directory and S3/GCS
-  listing keep the extension gate. See PLAT-1498.
+  listing keep the extension gate.
 
 - **Python 3.14 support.** `requires-python` widens to `>=3.10,<3.15` and the unit-test
   matrix now includes 3.14, alongside the existing 3.10–3.13. numpy is the only dependency

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,16 +14,6 @@ OpenFilter Library release notes
   downloaded to a generic path (e.g. a batch claimer's `/ws/input`) — the identity travels
   as metadata rather than in the filename.
 
-### Fixed
-
-- **`ImageIn` now processes a single explicit file regardless of its extension.** The
-  image-extension gate (`jpg/png/…`) only ever needed to filter non-images out of
-  *directory* listings, but it was also applied to a single named file, so a file with a
-  non-image or missing extension (e.g. a batch claimer's `/ws/input`) was silently skipped
-  and produced no frames. Single explicit files are now accepted and validated by decoding
-  (`cv2.imread`), which also logs a warning on an undecodable file; directory and S3/GCS
-  listing keep the extension gate.
-
 - **Python 3.14 support.** `requires-python` widens to `>=3.10,<3.15` and the unit-test
   matrix now includes 3.14, alongside the existing 3.10–3.13. numpy is the only dependency
   that needed a change: 2.2.x is the last line with Python 3.10 wheels, while cp314 wheels
@@ -46,6 +36,16 @@ OpenFilter Library release notes
   `src_frame` is unchanged, and the reader-level `VideoReader` / `extras` dict still carries the
   decoder value under `pts_s` (a codec term at that layer); only the emitted frame-meta field
   changed. Consumers reading `meta['pts_s']` must switch to `meta['src_seconds']`.
+
+### Fixed
+
+- **`ImageIn` now processes a single explicit file regardless of its extension.** The
+  image-extension gate (`jpg/png/…`) only ever needed to filter non-images out of
+  *directory* listings, but it was also applied to a single named file, so a file with a
+  non-image or missing extension (e.g. a batch claimer's `/ws/input`) was silently skipped
+  and produced no frames. Single explicit files are now accepted and validated by decoding
+  (`cv2.imread`), which also logs a warning on an undecodable file; directory and S3/GCS
+  listing keep the extension gate.
 
 ## v1.2.2 - 2026-08-10
 

--- a/openfilter/filter_runtime/filters/image_in.py
+++ b/openfilter/filter_runtime/filters/image_in.py
@@ -383,13 +383,30 @@ class ImageIn(Filter):
     def _list_images(self, source) -> List[str]:
         """List image files from the given source."""
         if source.source.startswith('file://'):
-            return self._list_local_images(source.source[7:], source.options)
+            images = self._list_local_images(source.source[7:], source.options)
         elif source.source.startswith('s3://'):
-            return self._list_s3_images(source.source, source.options)
+            images = self._list_s3_images(source.source, source.options)
         elif source.source.startswith('gs://'):
-            return self._list_gcs_images(source.source, source.options)
+            images = self._list_gcs_images(source.source, source.options)
         else:
             raise ValueError(f'Unsupported source scheme: {source.source}')
+
+        # _apply_override was decided statically from the config URI shape (so a watched directory
+        # that momentarily holds <=1 image can't slip the override onto later polls). If a listing
+        # pass ever resolves to MORE than one object, that static guess was wrong — a not-yet-
+        # existing path turned out to be a directory, or a cloud key turned out to be a shared
+        # prefix (e.g. s3://b/img also matching img-1.png) — and stamping every match with the same
+        # override URI would mislabel them. Disable the override (logged once, since the flag then
+        # stays False) rather than emit wrong attribution. This only ever DISABLES, so it cannot
+        # reintroduce the watched-directory race the static gate avoids.
+        if self._apply_override and len(images) > 1:
+            logger.warning(
+                f"override_source_uri is set for a single object, but source {source.source!r} "
+                f"resolved to {len(images)} images; disabling the override so they are not all "
+                "mislabeled with the same meta['src'].")
+            self._apply_override = False
+
+        return images
 
     def _list_local_images(self, path: str, options) -> List[str]:
         """List image files from local filesystem."""

--- a/openfilter/filter_runtime/filters/image_in.py
+++ b/openfilter/filter_runtime/filters/image_in.py
@@ -359,7 +359,7 @@ class ImageIn(Filter):
             # run. Mirrors the s3/gs shape check below: a trailing slash or an already-existing
             # directory is a listing; anything else is a single object. os.path.isdir is only True
             # when the path exists AND is a directory, so a not-yet-written file still qualifies.
-            return not path.endswith('/') and not os.path.isdir(path) and not any(c in path for c in glob_chars)
+            return bool(path) and not path.endswith('/') and not os.path.isdir(path) and not any(c in path for c in glob_chars)
         if uri.startswith('s3://') or uri.startswith('gs://'):
             # An exact object key (non-empty, no wildcard, no trailing slash) is a single object;
             # a bare bucket or a prefix is a directory-style listing. urlparse is correct here —

--- a/openfilter/filter_runtime/filters/image_in.py
+++ b/openfilter/filter_runtime/filters/image_in.py
@@ -386,7 +386,9 @@ class ImageIn(Filter):
                         # An exact key match (not a directory prefix) is a single explicit
                         # object; skip the image-extension gate for it, mirroring the local
                         # single-file case. Directory-prefix listings keep the gate.
-                        is_exact_object = key == prefix
+                        # `not endswith('/')` excludes the 0-byte directory-marker object
+                        # S3/GCS return for a prefix (named exactly `prefix/`); decoding it fails.
+                        is_exact_object = key == prefix and not key.endswith('/')
                         if (is_exact_object or is_image_file(key)) and matches_pattern(key, options.pattern or self.config.pattern):
                             images.append(f"s3://{bucket}/{key}")
 
@@ -413,7 +415,9 @@ class ImageIn(Filter):
             for blob in bucket.list_blobs(prefix=prefix):
                 # Exact key match = single explicit object; skip the extension gate for it
                 # (mirrors the local single-file case), keep it for directory prefixes.
-                if (blob.name == prefix or is_image_file(blob.name)) and matches_pattern(blob.name, options.pattern or self.config.pattern):
+                # `not endswith('/')` excludes the 0-byte directory-marker object.
+                is_exact_object = blob.name == prefix and not blob.name.endswith('/')
+                if (is_exact_object or is_image_file(blob.name)) and matches_pattern(blob.name, options.pattern or self.config.pattern):
                     images.append(f"gs://{bucket.name}/{blob.name}")
                             
             return sorted(images)
@@ -433,7 +437,10 @@ class ImageIn(Filter):
                 response = s3_client.get_object(Bucket=bucket, Key=key)
                 data = response['Body'].read()
                 arr = np.frombuffer(data, np.uint8)
-                return cv2.imdecode(arr, cv2.IMREAD_COLOR)
+                img = cv2.imdecode(arr, cv2.IMREAD_COLOR)
+                if img is None:
+                    logger.warning(f"Could not decode image {path} (unrecognized or corrupt format); skipping")
+                return img
             elif path.startswith("gs://"):
                 if not HAS_GCS:
                     logger.error("google-cloud-storage is required for GCS support")
@@ -447,7 +454,10 @@ class ImageIn(Filter):
                 blob = bucket.blob(key)
                 data = blob.download_as_bytes()
                 arr = np.frombuffer(data, np.uint8)
-                return cv2.imdecode(arr, cv2.IMREAD_COLOR)
+                img = cv2.imdecode(arr, cv2.IMREAD_COLOR)
+                if img is None:
+                    logger.warning(f"Could not decode image {path} (unrecognized or corrupt format); skipping")
+                return img
             else:
                 img = cv2.imread(path)
                 if img is None:

--- a/openfilter/filter_runtime/filters/image_in.py
+++ b/openfilter/filter_runtime/filters/image_in.py
@@ -313,9 +313,6 @@ class ImageIn(Filter):
             if isinstance(loop_val, int) and loop_val is not True and loop_val is not False and loop_val > 0:
                 self._finite_loop_topics.add(topic)
 
-        # Load initial images
-        self._load_initial_images()
-
         # The override identifies a SINGLE logical object (the orchestrator's batch claimer
         # downloads one file to a generic path and records its real URI). Applying one override
         # to every frame would mislabel each image of a directory/glob/multi-source input with the
@@ -334,6 +331,12 @@ class ImageIn(Filter):
         # Insertion-ordered dict (path -> True) so the bounded-size eviction in _warn_decode_failure
         # is FIFO (oldest first), not arbitrary.
         self._decode_warned = {}
+
+        # Load initial images LAST: _load_initial_images() reaches _list_images / _load_image, which
+        # read self._apply_override and self._decode_warned — so those must be initialized above
+        # first, or the initial load raises AttributeError, gets swallowed by _load_initial_images'
+        # own try/except (logging a spurious error), and is silently skipped until the first poll.
+        self._load_initial_images()
 
         # Start polling thread
         self.poll_thread = Thread(target=self._poll_loop, daemon=True)

--- a/openfilter/filter_runtime/filters/image_in.py
+++ b/openfilter/filter_runtime/filters/image_in.py
@@ -331,7 +331,9 @@ class ImageIn(Filter):
 
         # Paths already warned about failing to decode, so a mis-pointed single explicit file under
         # a loop (re-queued every frame) logs once instead of flooding at the send-callback rate.
-        self._decode_warned = set()
+        # Insertion-ordered dict (path -> True) so the bounded-size eviction in _warn_decode_failure
+        # is FIFO (oldest first), not arbitrary.
+        self._decode_warned = {}
 
         # Start polling thread
         self.poll_thread = Thread(target=self._poll_loop, daemon=True)
@@ -511,12 +513,12 @@ class ImageIn(Filter):
 
         Bounded to DECODE_WARNED_MAX distinct paths so a long-running directory poll over an
         unbounded stream of different corrupt/unreadable files can't grow the dedup set without
-        limit. On overflow an arbitrary path is evicted; the worst case is that path warning once
-        more later, which is harmless."""
+        limit. `_decode_warned` is an insertion-ordered dict so overflow evicts the OLDEST path
+        (FIFO), keeping recently-warned paths deduped; an evicted path may warn once more, harmless."""
         if path not in self._decode_warned:
             if len(self._decode_warned) >= DECODE_WARNED_MAX:
-                self._decode_warned.pop()
-            self._decode_warned.add(path)
+                del self._decode_warned[next(iter(self._decode_warned))]  # FIFO: evict oldest-inserted
+            self._decode_warned[path] = True
             logger.warning(message)
 
     def _load_image(self, path: str) -> Optional[np.ndarray]:

--- a/openfilter/filter_runtime/filters/image_in.py
+++ b/openfilter/filter_runtime/filters/image_in.py
@@ -24,7 +24,7 @@ except ImportError:
     HAS_GCS = False
 
 from openfilter.filter_runtime.filter import Filter, Frame, FilterConfig
-from openfilter.filter_runtime.utils import json_getval, split_commas_maybe, dict_without, adict
+from openfilter.filter_runtime.utils import json_getval, split_commas_maybe, dict_without, resolve_override_source_uri, adict
 
 __all__ = ['ImageInConfig', 'ImageIn']
 
@@ -118,6 +118,12 @@ class ImageInConfig(FilterConfig):
     pattern: str | None
     poll_interval: float | None
     maxfps: float | None
+
+    # Logical source URI to report as meta['src'] instead of the physical path (set by an
+    # orchestrator; see resolve_override_source_uri). FILTER_OVERRIDE_SOURCE_URI is the
+    # direct value, FILTER_OVERRIDE_SOURCE_URI_FILE a file to read it from.
+    override_source_uri: str | None
+    override_source_uri_file: str | None
     
 
 class ImageIn(Filter):
@@ -200,6 +206,10 @@ class ImageIn(Filter):
         FILTER_RECURSIVE      / IMAGE_IN_RECURSIVE
         FILTER_POLL_INTERVAL  / IMAGE_IN_POLL_INTERVAL
         FILTER_MAXFPS         / IMAGE_IN_MAXFPS
+        FILTER_OVERRIDE_SOURCE_URI       - logical source URI reported as each frame's meta['src']
+                                           (see `override_source_uri`).
+        FILTER_OVERRIDE_SOURCE_URI_FILE  - path to a file whose contents are that URI (used when
+                                           the value is only known at runtime by an orchestrator).
 
     S3 Configuration:
         For s3:// sources, AWS credentials are required. Set these environment variables:
@@ -259,6 +269,7 @@ class ImageIn(Filter):
     def setup(self, config):
         """Initialize the filter with sources and start polling thread."""
         self.config = config
+        self.override_source_uri = resolve_override_source_uri(config)
         self.frame_id = -1
         self.queues = {}                # topic -> list[path]
         self.processed = {}             # topic -> set[path]
@@ -338,7 +349,13 @@ class ImageIn(Filter):
 
         images = []
         if os.path.isfile(path):
-            if is_image_file(path) and matches_pattern(path, options.pattern or self.config.pattern):
+            # A single explicit file was named by the caller — there is nothing to filter,
+            # so skip the image-extension gate (which exists only to keep non-images out of
+            # directory listings) and let _load_image validate by decoding. This lets a
+            # generic/extensionless path (e.g. a batch claimer's /ws/input) be processed;
+            # the override_source_uri carries the real name. Directory/S3/GCS listing below
+            # keeps the extension gate.
+            if matches_pattern(path, options.pattern or self.config.pattern):
                 images.append(path)
         else:
             # Directory
@@ -426,7 +443,10 @@ class ImageIn(Filter):
                 arr = np.frombuffer(data, np.uint8)
                 return cv2.imdecode(arr, cv2.IMREAD_COLOR)
             else:
-                return cv2.imread(path)
+                img = cv2.imread(path)
+                if img is None:
+                    logger.warning(f"Could not decode image {path} (unrecognized or corrupt format); skipping")
+                return img
         except Exception as e:
             logger.error(f"Failed to load image {path}: {e}")
             return None
@@ -507,7 +527,7 @@ class ImageIn(Filter):
                     self.frame_id += 1
                     meta = {
                         'id': self.frame_id,
-                        'src': path,
+                        'src': self.override_source_uri or path,
                         'ts': time()
                     }
                     out[topic] = Frame(img, {'meta': meta}, format='BGR')

--- a/openfilter/filter_runtime/filters/image_in.py
+++ b/openfilter/filter_runtime/filters/image_in.py
@@ -311,7 +311,19 @@ class ImageIn(Filter):
 
         # Load initial images
         self._load_initial_images()
-        
+
+        # The override identifies a SINGLE logical object (the orchestrator's batch claimer
+        # downloads one file to a generic path and records its real URI). Applying one override
+        # to every frame would mislabel each image of a directory/glob/multi-source input with
+        # the same meta['src'], so only honor it when at most one image resolved; otherwise fall
+        # back to the real per-image path and warn once about the misconfiguration.
+        total_images = sum(len(q) for q in self.queues.values())
+        self._apply_override = bool(self.override_source_uri) and total_images <= 1
+        if self.override_source_uri and not self._apply_override:
+            logger.warning(
+                f"FILTER_OVERRIDE_SOURCE_URI[_FILE] is set but this ImageIn resolved {total_images} images; "
+                "the override identifies a single object, so meta['src'] will report each image's real path instead")
+
         # Start polling thread
         self.poll_thread = Thread(target=self._poll_loop, daemon=True)
         self.poll_thread.start()
@@ -461,7 +473,10 @@ class ImageIn(Filter):
             else:
                 img = cv2.imread(path)
                 if img is None:
-                    logger.warning(f"Could not decode image {path} (unrecognized or corrupt format); skipping")
+                    # imread returns None both for an unreadable/corrupt file and for one that
+                    # no longer exists (e.g. deleted/renamed between listing and load), so the
+                    # message covers all three rather than asserting a corrupt format.
+                    logger.warning(f"Could not read image {path} (missing, unrecognized, or corrupt format); skipping")
                 return img
         except Exception as e:
             logger.error(f"Failed to load image {path}: {e}")
@@ -543,7 +558,7 @@ class ImageIn(Filter):
                     self.frame_id += 1
                     meta = {
                         'id': self.frame_id,
-                        'src': self.override_source_uri or path,
+                        'src': self.override_source_uri if self._apply_override else path,
                         'ts': time()
                     }
                     out[topic] = Frame(img, {'meta': meta}, format='BGR')

--- a/openfilter/filter_runtime/filters/image_in.py
+++ b/openfilter/filter_runtime/filters/image_in.py
@@ -342,16 +342,15 @@ class ImageIn(Filter):
         source = config.sources[0]
         if source.options.recursive or config.recursive:
             return False
-        uri = source.source
+        parsed = urlparse(source.source)
         glob_chars = ('*', '?', '[')
-        if uri.startswith('file://'):
-            path = uri[7:]
+        if parsed.scheme == 'file':
+            path = parsed.path
             return os.path.isfile(path) and not any(c in path for c in glob_chars)
-        if uri.startswith('s3://') or uri.startswith('gs://'):
+        if parsed.scheme in ('s3', 'gs'):
             # An exact object key (non-empty, no wildcard, no trailing slash) is a single object;
             # a bare bucket or a prefix is a directory-style listing.
-            rest = uri.split('://', 1)[1].split('/', 1)
-            key = rest[1] if len(rest) > 1 else ''
+            key = parsed.path.lstrip('/')
             return bool(key) and not key.endswith('/') and not any(c in key for c in glob_chars)
         return False
 

--- a/openfilter/filter_runtime/filters/image_in.py
+++ b/openfilter/filter_runtime/filters/image_in.py
@@ -325,6 +325,10 @@ class ImageIn(Filter):
                 "(directory, glob, or multiple sources); the override identifies one object, so meta['src'] will "
                 "report each image's real path instead")
 
+        # Paths already warned about failing to decode, so a mis-pointed single explicit file under
+        # a loop (re-queued every frame) logs once instead of flooding at the send-callback rate.
+        self._decode_warned = set()
+
         # Start polling thread
         self.poll_thread = Thread(target=self._poll_loop, daemon=True)
         self.poll_thread.start()
@@ -349,7 +353,13 @@ class ImageIn(Filter):
             # as netloc (file://rel/img.png -> path='/img.png'), and this must match how
             # _list_local_images extracts the path (source.source[7:]).
             path = uri[7:]
-            return os.path.isfile(path) and not any(c in path for c in glob_chars)
+            # Decide from the URI shape, not existence — ImageIn is a polling filter that tolerates
+            # a source arriving after setup() (the batch claimer downloads to it as an init step),
+            # so requiring the file to exist here would silently disable the override for the whole
+            # run. Mirrors the s3/gs shape check below: a trailing slash or an already-existing
+            # directory is a listing; anything else is a single object. os.path.isdir is only True
+            # when the path exists AND is a directory, so a not-yet-written file still qualifies.
+            return not path.endswith('/') and not os.path.isdir(path) and not any(c in path for c in glob_chars)
         if uri.startswith('s3://') or uri.startswith('gs://'):
             # An exact object key (non-empty, no wildcard, no trailing slash) is a single object;
             # a bare bucket or a prefix is a directory-style listing. urlparse is correct here —
@@ -465,6 +475,12 @@ class ImageIn(Filter):
             logger.error(f"Failed to list GCS images from {gs_uri}: {e}")
             return []
 
+    def _warn_decode_failure(self, path: str, message: str) -> None:
+        """Log a decode failure once per path, so a looping mis-pointed source can't flood the log."""
+        if path not in self._decode_warned:
+            self._decode_warned.add(path)
+            logger.warning(message)
+
     def _load_image(self, path: str) -> Optional[np.ndarray]:
         """Load image from path (local or cloud)."""
         try:
@@ -479,7 +495,7 @@ class ImageIn(Filter):
                 arr = np.frombuffer(data, np.uint8)
                 img = cv2.imdecode(arr, cv2.IMREAD_COLOR)
                 if img is None:
-                    logger.warning(f"Could not decode image {path} (unrecognized or corrupt format); skipping")
+                    self._warn_decode_failure(path, f"Could not decode image {path} (unrecognized or corrupt format); skipping")
                 return img
             elif path.startswith("gs://"):
                 if not HAS_GCS:
@@ -496,7 +512,7 @@ class ImageIn(Filter):
                 arr = np.frombuffer(data, np.uint8)
                 img = cv2.imdecode(arr, cv2.IMREAD_COLOR)
                 if img is None:
-                    logger.warning(f"Could not decode image {path} (unrecognized or corrupt format); skipping")
+                    self._warn_decode_failure(path, f"Could not decode image {path} (unrecognized or corrupt format); skipping")
                 return img
             else:
                 img = cv2.imread(path)
@@ -504,7 +520,7 @@ class ImageIn(Filter):
                     # imread returns None both for an unreadable/corrupt file and for one that
                     # no longer exists (e.g. deleted/renamed between listing and load), so the
                     # message covers all three rather than asserting a corrupt format.
-                    logger.warning(f"Could not read image {path} (missing, unrecognized, or corrupt format); skipping")
+                    self._warn_decode_failure(path, f"Could not read image {path} (missing, unrecognized, or corrupt format); skipping")
                 return img
         except Exception as e:
             logger.error(f"Failed to load image {path}: {e}")

--- a/openfilter/filter_runtime/filters/image_in.py
+++ b/openfilter/filter_runtime/filters/image_in.py
@@ -342,15 +342,19 @@ class ImageIn(Filter):
         source = config.sources[0]
         if source.options.recursive or config.recursive:
             return False
-        parsed = urlparse(source.source)
+        uri = source.source
         glob_chars = ('*', '?', '[')
-        if parsed.scheme == 'file':
-            path = parsed.path
+        if uri.startswith('file://'):
+            # Slice rather than urlparse: urlparse treats a relative file:// path's first segment
+            # as netloc (file://rel/img.png -> path='/img.png'), and this must match how
+            # _list_local_images extracts the path (source.source[7:]).
+            path = uri[7:]
             return os.path.isfile(path) and not any(c in path for c in glob_chars)
-        if parsed.scheme in ('s3', 'gs'):
+        if uri.startswith('s3://') or uri.startswith('gs://'):
             # An exact object key (non-empty, no wildcard, no trailing slash) is a single object;
-            # a bare bucket or a prefix is a directory-style listing.
-            key = parsed.path.lstrip('/')
+            # a bare bucket or a prefix is a directory-style listing. urlparse is correct here —
+            # the bucket is the netloc and the key the path (mirrors parse_s3_uri/parse_gcs_uri).
+            key = urlparse(uri).path.lstrip('/')
             return bool(key) and not key.endswith('/') and not any(c in key for c in glob_chars)
         return False
 

--- a/openfilter/filter_runtime/filters/image_in.py
+++ b/openfilter/filter_runtime/filters/image_in.py
@@ -383,7 +383,11 @@ class ImageIn(Filter):
                 if 'Contents' in page:
                     for obj in page['Contents']:
                         key = obj['Key']
-                        if is_image_file(key) and matches_pattern(key, options.pattern or self.config.pattern):
+                        # An exact key match (not a directory prefix) is a single explicit
+                        # object; skip the image-extension gate for it, mirroring the local
+                        # single-file case. Directory-prefix listings keep the gate.
+                        is_exact_object = key == prefix
+                        if (is_exact_object or is_image_file(key)) and matches_pattern(key, options.pattern or self.config.pattern):
                             images.append(f"s3://{bucket}/{key}")
 
             return sorted(images)
@@ -407,7 +411,9 @@ class ImageIn(Filter):
             
             images = []
             for blob in bucket.list_blobs(prefix=prefix):
-                if is_image_file(blob.name) and matches_pattern(blob.name, options.pattern or self.config.pattern):
+                # Exact key match = single explicit object; skip the extension gate for it
+                # (mirrors the local single-file case), keep it for directory prefixes.
+                if (blob.name == prefix or is_image_file(blob.name)) and matches_pattern(blob.name, options.pattern or self.config.pattern):
                     images.append(f"gs://{bucket.name}/{blob.name}")
                             
             return sorted(images)

--- a/openfilter/filter_runtime/filters/image_in.py
+++ b/openfilter/filter_runtime/filters/image_in.py
@@ -39,6 +39,10 @@ IMAGE_IN_MAXFPS = None if (_ := json_getval((os.getenv('IMAGE_IN_MAXFPS') or os.
 # Image file extensions
 IMAGE_EXTENSIONS = {'jpg', 'jpeg', 'png', 'bmp', 'tif', 'tiff', 'gif', 'webp'}
 
+# Upper bound on the per-path decode-failure dedup set, so a long-running poll over an unbounded
+# stream of distinct corrupt files can't grow it without limit (see ImageIn._warn_decode_failure).
+DECODE_WARNED_MAX = 10000
+
 def is_image_file(path: str) -> bool:
     """Check if file is an image based on extension."""
     ext = path.lower().rsplit(".", 1)[-1]
@@ -340,7 +344,14 @@ class ImageIn(Filter):
         file or an exact S3/GCS object, not a directory, glob, or multiple sources. Gates
         _apply_override off the CONFIG rather than a dynamic image count, so a watched
         directory that happens to start with <=1 image can't slip the override onto later polled
-        images."""
+        images.
+
+        Because the decision is made from the URI shape (not existence, so a not-yet-written source
+        still qualifies), a directory that does NOT exist at setup and lacks a trailing slash is
+        classified as a single object here. A directory source that may not exist at setup should
+        therefore carry a trailing slash (or set recursive) so it is correctly treated as a listing.
+        As a backstop, _list_images disables the override at runtime once a source resolves to an
+        existing directory or to more than one object, so a mis-shaped path self-corrects."""
         if len(config.sources) != 1:
             return False
         source = config.sources[0]
@@ -392,18 +403,21 @@ class ImageIn(Filter):
             raise ValueError(f'Unsupported source scheme: {source.source}')
 
         # _apply_override was decided statically from the config URI shape (so a watched directory
-        # that momentarily holds <=1 image can't slip the override onto later polls). If a listing
-        # pass ever resolves to MORE than one object, that static guess was wrong — a not-yet-
-        # existing path turned out to be a directory, or a cloud key turned out to be a shared
-        # prefix (e.g. s3://b/img also matching img-1.png) — and stamping every match with the same
-        # override URI would mislabel them. Disable the override (logged once, since the flag then
-        # stays False) rather than emit wrong attribution. This only ever DISABLES, so it cannot
+        # that momentarily holds <=1 image can't slip the override onto later polls). Re-check it
+        # against what the listing actually resolved to, and disable if the static guess was wrong:
+        #   - more than one object — a shared cloud prefix (e.g. s3://b/img also matching img-1.png)
+        #     or a directory — so stamping every match with the same override URI would mislabel them; or
+        #   - a local file:// path that is now an EXISTING DIRECTORY, even one holding a single file:
+        #     a not-yet-existing path later created as a directory would otherwise stamp its first
+        #     frame with the override before a second file trips the >1 check.
+        # Disabling is logged once (the flag then stays False). This only ever DISABLES, so it can't
         # reintroduce the watched-directory race the static gate avoids.
-        if self._apply_override and len(images) > 1:
+        local_dir = source.source.startswith('file://') and os.path.isdir(source.source[7:])
+        if self._apply_override and (len(images) > 1 or local_dir):
             logger.warning(
                 f"override_source_uri is set for a single object, but source {source.source!r} "
-                f"resolved to {len(images)} images; disabling the override so they are not all "
-                "mislabeled with the same meta['src'].")
+                f"resolved to a directory or multiple images ({len(images)}); disabling the override "
+                "so frames are not mislabeled with the same meta['src'].")
             self._apply_override = False
 
         return images
@@ -493,8 +507,15 @@ class ImageIn(Filter):
             return []
 
     def _warn_decode_failure(self, path: str, message: str) -> None:
-        """Log a decode failure once per path, so a looping mis-pointed source can't flood the log."""
+        """Log a decode failure once per path, so a looping mis-pointed source can't flood the log.
+
+        Bounded to DECODE_WARNED_MAX distinct paths so a long-running directory poll over an
+        unbounded stream of different corrupt/unreadable files can't grow the dedup set without
+        limit. On overflow an arbitrary path is evicted; the worst case is that path warning once
+        more later, which is harmless."""
         if path not in self._decode_warned:
+            if len(self._decode_warned) >= DECODE_WARNED_MAX:
+                self._decode_warned.pop()
             self._decode_warned.add(path)
             logger.warning(message)
 

--- a/openfilter/filter_runtime/filters/image_in.py
+++ b/openfilter/filter_runtime/filters/image_in.py
@@ -314,21 +314,46 @@ class ImageIn(Filter):
 
         # The override identifies a SINGLE logical object (the orchestrator's batch claimer
         # downloads one file to a generic path and records its real URI). Applying one override
-        # to every frame would mislabel each image of a directory/glob/multi-source input with
-        # the same meta['src'], so only honor it when at most one image resolved; otherwise fall
-        # back to the real per-image path and warn once about the misconfiguration.
-        total_images = sum(len(q) for q in self.queues.values())
-        self._apply_override = bool(self.override_source_uri) and total_images <= 1
+        # to every frame would mislabel each image of a directory/glob/multi-source input with the
+        # same meta['src'], so only honor it when the config resolves to a single explicit object.
+        # This is decided from the CONFIG, not a dynamic image count — a watched directory that
+        # merely starts with <=1 image would otherwise slip the override onto later polled images.
+        self._apply_override = bool(self.override_source_uri) and self._override_source_is_single_object(config)
         if self.override_source_uri and not self._apply_override:
             logger.warning(
-                f"FILTER_OVERRIDE_SOURCE_URI[_FILE] is set but this ImageIn resolved {total_images} images; "
-                "the override identifies a single object, so meta['src'] will report each image's real path instead")
+                "FILTER_OVERRIDE_SOURCE_URI[_FILE] is set but this ImageIn source is not a single explicit object "
+                "(directory, glob, or multiple sources); the override identifies one object, so meta['src'] will "
+                "report each image's real path instead")
 
         # Start polling thread
         self.poll_thread = Thread(target=self._poll_loop, daemon=True)
         self.poll_thread.start()
         
         logger.info(f"ImageIn initialized with {len(config.sources)} sources")
+
+    def _override_source_is_single_object(self, config) -> bool:
+        """True only when the config resolves to exactly one explicit object — a single local
+        file or an exact S3/GCS object, not a directory, glob, or multiple sources. Gates
+        _apply_override (PLAT-1498) off the CONFIG rather than a dynamic image count, so a watched
+        directory that happens to start with <=1 image can't slip the override onto later polled
+        images."""
+        if len(config.sources) != 1:
+            return False
+        source = config.sources[0]
+        if source.options.recursive or config.recursive:
+            return False
+        uri = source.source
+        glob_chars = ('*', '?', '[')
+        if uri.startswith('file://'):
+            path = uri[7:]
+            return os.path.isfile(path) and not any(c in path for c in glob_chars)
+        if uri.startswith('s3://') or uri.startswith('gs://'):
+            # An exact object key (non-empty, no wildcard, no trailing slash) is a single object;
+            # a bare bucket or a prefix is a directory-style listing.
+            rest = uri.split('://', 1)[1].split('/', 1)
+            key = rest[1] if len(rest) > 1 else ''
+            return bool(key) and not key.endswith('/') and not any(c in key for c in glob_chars)
+        return False
 
     def _load_initial_images(self):
         """Load initial images from all sources into queues."""

--- a/openfilter/filter_runtime/filters/image_in.py
+++ b/openfilter/filter_runtime/filters/image_in.py
@@ -334,7 +334,7 @@ class ImageIn(Filter):
     def _override_source_is_single_object(self, config) -> bool:
         """True only when the config resolves to exactly one explicit object — a single local
         file or an exact S3/GCS object, not a directory, glob, or multiple sources. Gates
-        _apply_override (PLAT-1498) off the CONFIG rather than a dynamic image count, so a watched
+        _apply_override off the CONFIG rather than a dynamic image count, so a watched
         directory that happens to start with <=1 image can't slip the override onto later polled
         images."""
         if len(config.sources) != 1:

--- a/openfilter/filter_runtime/filters/video_in.py
+++ b/openfilter/filter_runtime/filters/video_in.py
@@ -827,6 +827,17 @@ class VideoIn(Filter):
         self._camera_connected = 0
         self.override_source_uri = resolve_override_source_uri(config)
 
+        # The override identifies a SINGLE logical source (an orchestrator's batch claimer
+        # downloads one file and records its real URI). With multiple videos, applying one
+        # override to every frame would mislabel each with the same meta['src'], so only honor
+        # it for a single source; otherwise fall back to each video's real source and warn once.
+        # Mirrors the ImageIn guard (PLAT-1498).
+        self._apply_override = bool(self.override_source_uri) and len(self.mvreader.videos) <= 1
+        if self.override_source_uri and not self._apply_override:
+            logger.warning(
+                f"FILTER_OVERRIDE_SOURCE_URI[_FILE] is set but this VideoIn has {len(self.mvreader.videos)} sources; "
+                "the override identifies a single source, so meta['src'] will report each video's real source instead")
+
         self.mvreader.start()
 
     def shutdown(self):
@@ -842,7 +853,7 @@ class VideoIn(Filter):
             self.id = id = self.id + 1
 
             def meta(vid, tfrm, extras):
-                meta = {'id': id, 'ts': tfrm / 1_000_000_000, 'src': self.override_source_uri or vid.source, 'src_fps': vid.fps}
+                meta = {'id': id, 'ts': tfrm / 1_000_000_000, 'src': self.override_source_uri if self._apply_override else vid.source, 'src_fps': vid.fps}
 
                 if extras:  # file sources: decoder position of this frame = the video offset jump-to-frame needs
                     meta['src_frame'] = extras['frame_n']

--- a/openfilter/filter_runtime/filters/video_in.py
+++ b/openfilter/filter_runtime/filters/video_in.py
@@ -831,7 +831,7 @@ class VideoIn(Filter):
         # downloads one file and records its real URI). With multiple videos, applying one
         # override to every frame would mislabel each with the same meta['src'], so only honor
         # it for a single source; otherwise fall back to each video's real source and warn once.
-        # Mirrors the ImageIn guard (PLAT-1498).
+        # Mirrors the ImageIn guard.
         self._apply_override = bool(self.override_source_uri) and len(self.mvreader.videos) <= 1
         if self.override_source_uri and not self._apply_override:
             logger.warning(

--- a/openfilter/filter_runtime/filters/video_in.py
+++ b/openfilter/filter_runtime/filters/video_in.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
-from openfilter.filter_runtime.utils import json_getval, dict_without, split_commas_maybe, hide_uri_users_and_pwds, Deque
+from openfilter.filter_runtime.utils import json_getval, dict_without, split_commas_maybe, hide_uri_users_and_pwds, resolve_override_source_uri, Deque
 
 __all__ = ['is_video', 'is_video_file', 'is_video_webcam', 'is_video_stream', 'VideoReader', 'MultiVideoReader']
 
@@ -623,6 +623,12 @@ class VideoInConfig(FilterConfig):
     maxsize: str | None
     resize:  str | None
 
+    # Logical source URI to report as meta['src'] instead of the physical source
+    # (set by an orchestrator; see resolve_override_source_uri). FILTER_OVERRIDE_SOURCE_URI
+    # is the direct value, FILTER_OVERRIDE_SOURCE_URI_FILE a file to read it from.
+    override_source_uri:      str | None
+    override_source_uri_file: str | None
+
 
 class VideoIn(Filter):
     """Single or multiple video input filter. Videos are assigned to topics via the ';' mapping character in `sources`.
@@ -713,6 +719,12 @@ class VideoIn(Filter):
             Same as `maxsize` but is always applied unconditionally regardless of input size.Can not be specified
             together with `maxsize`, it is one or the other. Set here to apply to all sources or can be set individually
             per source. Global env var default FILTER_RESIZE / VIDEO_IN_RESIZE.
+
+        override_source_uri:
+            Logical source URI to report as each frame's meta['src'] instead of the physical source opened by the
+            reader. Lets an orchestrator preserve per-file identity when the physical path is generic (e.g. a batch
+            claimer downloads every object to /ws/input). Env var FILTER_OVERRIDE_SOURCE_URI, or
+            FILTER_OVERRIDE_SOURCE_URI_FILE to read it from a file.
 
     Emitted frame meta:
         Every frame carries meta['id'] (delivery counter, rate depends on the consuming chain), meta['ts'] (wall-clock
@@ -813,6 +825,7 @@ class VideoIn(Filter):
         self.tops_n_vids     = tuple(zip(topics, self.mvreader.videos))
         self.id              = -1  # frame id
         self._camera_connected = 0
+        self.override_source_uri = resolve_override_source_uri(config)
 
         self.mvreader.start()
 
@@ -829,7 +842,7 @@ class VideoIn(Filter):
             self.id = id = self.id + 1
 
             def meta(vid, tfrm, extras):
-                meta = {'id': id, 'ts': tfrm / 1_000_000_000, 'src': vid.source, 'src_fps': vid.fps}
+                meta = {'id': id, 'ts': tfrm / 1_000_000_000, 'src': self.override_source_uri or vid.source, 'src_fps': vid.fps}
 
                 if extras:  # file sources: decoder position of this frame = the video offset jump-to-frame needs
                     meta['src_frame'] = extras['frame_n']

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -59,19 +59,23 @@ def resolve_override_source_uri(config) -> str | None:
         return str(uri)
 
     if (path := _get('override_source_uri_file')):
+        path = str(path)  # a non-str value (e.g. an int from config parsing) must not crash setup
         # Defense-in-depth on the orchestrator-provided path: reject traversal and require an
         # absolute path, so a misconfigured env can't turn this into an arbitrary-file read
-        # whose contents would ride downstream in meta['src'].
+        # whose contents would ride downstream in meta['src']. openfilter is a general framework
+        # and can't assume a specific sandbox root — the orchestrator that sets this env var owns
+        # the sandbox (e.g. the batch controller constrains it under /ws/, PLAT-1499).
         if '..' in path or not path.startswith('/'):
             logging.getLogger(__name__).warning(
                 f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} rejected: must be an absolute path without ".."')
             return None
         try:
-            # A source URI is small (well under 1KB); cap the read so a misconfigured
-            # or unbounded file/device stream can't exhaust memory. encoding is explicit
-            # to avoid locale-dependent decode failures across environments.
+            # A source URI is small (well under 1KB) and lives on the first line; read only that
+            # line, capped, so trailing lines/garbage can't ride along and an unbounded
+            # file/device stream can't exhaust memory. encoding is explicit to avoid
+            # locale-dependent decode failures across environments.
             with open(path, encoding='utf-8') as f:
-                return f.read(4096).strip() or None
+                return f.readline(4096).strip() or None
         # ValueError catches UnicodeDecodeError (invalid UTF-8 in the file) alongside
         # OSError, so a bad override file degrades to None instead of crashing setup.
         except (OSError, ValueError) as exc:

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -71,7 +71,7 @@ def resolve_override_source_uri(config: Any) -> str | None:
         # absolute path, so a misconfigured env can't turn this into an arbitrary-file read
         # whose contents would ride downstream in meta['src']. openfilter is a general framework
         # and can't assume a specific sandbox root — the orchestrator that sets this env var owns
-        # the sandbox (e.g. the batch controller constrains it under /ws/, PLAT-1499).
+        # the sandbox (e.g. an orchestrator constrains it under a known sandbox root).
         #
         # TRUST BOUNDARY (multi-tenant LFI): this library only guarantees "absolute path, no
         # traversal". An absolute path here (e.g. /etc/passwd) IS read and surfaced in meta['src'],
@@ -80,6 +80,13 @@ def resolve_override_source_uri(config: Any) -> str | None:
         if '..' in path or not os.path.isabs(path):
             logging.getLogger(__name__).warning(
                 f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} rejected: must be an absolute path without ".."')
+            return None
+        if not os.path.isfile(path):
+            # Require a regular file: opening a FIFO/named pipe or a special device (e.g.
+            # /dev/stdin) would block the setup thread indefinitely. os.path.isfile is False for
+            # those (and for a missing file), so we reject rather than risk hanging.
+            logging.getLogger(__name__).warning(
+                f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} rejected: not a regular file')
             return None
         try:
             # A source URI is small (well under 1KB) and lives on the first line; read only that

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -48,6 +48,13 @@ def resolve_override_source_uri(config: Any) -> str | None:
     ``FILTER_OVERRIDE_SOURCE_URI`` (direct value); otherwise reads the file named by
     ``FILTER_OVERRIDE_SOURCE_URI_FILE`` — used when the value is only known at claim
     time and is written into the shared volume for the filter to pick up.
+
+    SECURITY — trust boundary: ``FILTER_OVERRIDE_SOURCE_URI_FILE`` is read from disk and its
+    contents are surfaced downstream in ``meta['src']``. This helper only guarantees the path is
+    absolute and traversal-free; it does NOT restrict which absolute file may be read. Any
+    deployment that lets untrusted tenants set this env var MUST enforce its own sandbox root
+    (e.g. the batch controller constrains it under ``/ws/``), or an absolute path such as
+    ``/etc/passwd`` would be read and leaked.
     """
     if config is None:
         return None

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -65,7 +65,7 @@ def resolve_override_source_uri(config) -> str | None:
         # whose contents would ride downstream in meta['src']. openfilter is a general framework
         # and can't assume a specific sandbox root — the orchestrator that sets this env var owns
         # the sandbox (e.g. the batch controller constrains it under /ws/, PLAT-1499).
-        if '..' in path or not path.startswith('/'):
+        if '..' in path or not os.path.isabs(path):
             logging.getLogger(__name__).warning(
                 f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} rejected: must be an absolute path without ".."')
             return None

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -101,10 +101,10 @@ def resolve_override_source_uri(config: Any) -> str | None:
             # the first newline); the claimer writes exactly the URI + newline. encoding is explicit
             # to avoid locale-dependent decode failures across environments.
             with open(path, encoding='utf-8') as f:
-                line = f.readline(4097)  # cap + 1 so an over-length first line is detectable
+                line = f.readline(4097)  # text mode: reads at most 4097 characters (cap + 1, so an over-length first line is detectable)
             if len(line) > 4096:
                 logging.getLogger(__name__).warning(
-                    f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} rejected: first line exceeds 4096 bytes')
+                    f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} rejected: first line exceeds 4096 characters')
                 return None
             # Strip embedded NULs too: a NUL survives UTF-8 decoding, so a corrupt/binary sidecar
             # could otherwise ride \x00 into meta['src'] and glitch downstream consumers.

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -81,20 +81,32 @@ def resolve_override_source_uri(config: Any) -> str | None:
             logging.getLogger(__name__).warning(
                 f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} rejected: must be an absolute path without ".."')
             return None
+        if not os.path.exists(path):
+            # Missing: a wrong path, or the orchestrator hasn't written it yet (the documented
+            # "value only known at claim time" case). Degrade to None rather than crash setup.
+            logging.getLogger(__name__).warning(
+                f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} does not exist (not written yet?); skipping override')
+            return None
         if not os.path.isfile(path):
-            # Require a regular file: opening a FIFO/named pipe or a special device (e.g.
-            # /dev/stdin) would block the setup thread indefinitely. os.path.isfile is False for
-            # those (and for a missing file), so we reject rather than risk hanging.
+            # Exists but is not a regular file: opening a FIFO/named pipe or a special device
+            # (e.g. /dev/stdin) would block the setup thread indefinitely, so reject it.
             logging.getLogger(__name__).warning(
                 f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} rejected: not a regular file')
             return None
         try:
-            # A source URI is small (well under 1KB) and lives on the first line; read only that
-            # line, capped, so trailing lines/garbage can't ride along and an unbounded
-            # file/device stream can't exhaust memory. encoding is explicit to avoid
-            # locale-dependent decode failures across environments.
+            # A source URI is small (well under 1KB) and lives on the first line; read that line
+            # capped so an unbounded file/device stream can't exhaust memory. A first line over the
+            # cap is treated as corrupt and rejected (fail loudly) rather than silently truncated —
+            # a wrong meta['src'] is worse than none. Trailing LINES are ignored (readline stops at
+            # the first newline); the claimer writes exactly the URI + newline. encoding is explicit
+            # to avoid locale-dependent decode failures across environments.
             with open(path, encoding='utf-8') as f:
-                return f.readline(4096).strip() or None
+                line = f.readline(4097)  # cap + 1 so an over-length first line is detectable
+            if len(line) > 4096:
+                logging.getLogger(__name__).warning(
+                    f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} rejected: first line exceeds 4096 bytes')
+                return None
+            return line.strip() or None
         # ValueError catches UnicodeDecodeError (invalid UTF-8 in the file) alongside
         # OSError, so a bad override file degrades to None instead of crashing setup.
         except (OSError, ValueError) as exc:

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -17,7 +17,7 @@ from typing import Any, Callable
 from numpy import generic as np_generic, ndarray as np_ndarray
 
 __all__ = [
-    'JSONLiteral', 'JSONType', 'json_getval', 'json_sanitize',
+    'JSONLiteral', 'JSONType', 'json_getval', 'json_sanitize', 'resolve_override_source_uri',
     'sanitize_filename', 'sanitize_pathname', 'simpledeepcopy', 'dict_without',
     'split_commas_maybe', 'rndstr', 'sizestr', 'secstr', 'timestr',
     'parse_time_interval', 'parse_date_and_or_time',
@@ -38,6 +38,29 @@ def json_getval(val: str) -> JSONType:
         return json_loads(val)
     except Exception:
         return val
+
+
+def resolve_override_source_uri(config) -> str | None:
+    """Logical source URI an input filter should report as ``meta['src']``, or None.
+
+    Set by an orchestrator to preserve per-file identity when the physical input path
+    is generic (e.g. a batch claimer downloads every object to ``/ws/input``). Prefers
+    ``FILTER_OVERRIDE_SOURCE_URI`` (direct value); otherwise reads the file named by
+    ``FILTER_OVERRIDE_SOURCE_URI_FILE`` — used when the value is only known at claim
+    time and is written into the shared volume for the filter to pick up.
+    """
+    if (uri := config.override_source_uri):
+        return str(uri)
+
+    if (path := config.override_source_uri_file):
+        try:
+            with open(path) as f:
+                return f.read().strip() or None
+        except OSError as exc:
+            logging.getLogger(__name__).warning(
+                f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} could not be read: {exc}')
+
+    return None
 
 def json_sanitize(val: Any, loose=False) -> JSONType:
     """Sanitize for json.dumps() compatible, two levels, `loose` will convert datetime to iso text and dataclasses for

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -106,7 +106,9 @@ def resolve_override_source_uri(config: Any) -> str | None:
                 logging.getLogger(__name__).warning(
                     f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} rejected: first line exceeds 4096 bytes')
                 return None
-            return line.strip() or None
+            # Strip embedded NULs too: a NUL survives UTF-8 decoding, so a corrupt/binary sidecar
+            # could otherwise ride \x00 into meta['src'] and glitch downstream consumers.
+            return line.strip().replace('\x00', '') or None
         # ValueError catches UnicodeDecodeError (invalid UTF-8 in the file) alongside
         # OSError, so a bad override file degrades to None instead of crashing setup.
         except (OSError, ValueError) as exc:

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -63,7 +63,10 @@ def resolve_override_source_uri(config: Any) -> str | None:
         return config.get(key) if hasattr(config, 'get') else getattr(config, key, None)
 
     if (uri := _get('override_source_uri')):
-        return str(uri)
+        # Clean the direct value the same way as the file-read path: strip surrounding
+        # whitespace/newline and drop embedded NULs, so a malformed env/config value can't
+        # contaminate meta['src']. Empty after cleaning degrades to None.
+        return str(uri).strip().replace('\x00', '') or None
 
     if (path := _get('override_source_uri_file')):
         path = str(path)  # a non-str value (e.g. an int from config parsing) must not crash setup
@@ -99,8 +102,10 @@ def resolve_override_source_uri(config: Any) -> str | None:
             # cap is treated as corrupt and rejected (fail loudly) rather than silently truncated —
             # a wrong meta['src'] is worse than none. Trailing LINES are ignored (readline stops at
             # the first newline); the claimer writes exactly the URI + newline. encoding is explicit
-            # to avoid locale-dependent decode failures across environments.
-            with open(path, encoding='utf-8') as f:
+            # to avoid locale-dependent decode failures across environments. utf-8-sig strips a
+            # leading BOM if the writer added one (﻿ isn't ASCII whitespace, so .strip() below
+            # wouldn't remove it and it would ride into meta['src']); it is a no-op when absent.
+            with open(path, encoding='utf-8-sig') as f:
                 # Text mode counts characters, not bytes. Read the 4096-char cap + up to 2 for a
                 # trailing CR/LF, so a full-length first line is detectable AND a 4096-char URI
                 # that happens to end with a newline isn't spuriously rejected for the newline.

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -65,7 +65,9 @@ def resolve_override_source_uri(config) -> str | None:
             # to avoid locale-dependent decode failures across environments.
             with open(path, encoding='utf-8') as f:
                 return f.read(4096).strip() or None
-        except OSError as exc:
+        # ValueError catches UnicodeDecodeError (invalid UTF-8 in the file) alongside
+        # OSError, so a bad override file degrades to None instead of crashing setup.
+        except (OSError, ValueError) as exc:
             logging.getLogger(__name__).warning(
                 f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} could not be read: {exc}')
 

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -101,14 +101,19 @@ def resolve_override_source_uri(config: Any) -> str | None:
             # the first newline); the claimer writes exactly the URI + newline. encoding is explicit
             # to avoid locale-dependent decode failures across environments.
             with open(path, encoding='utf-8') as f:
-                line = f.readline(4097)  # text mode: reads at most 4097 characters (cap + 1, so an over-length first line is detectable)
-            if len(line) > 4096:
+                # Text mode counts characters, not bytes. Read the 4096-char cap + up to 2 for a
+                # trailing CR/LF, so a full-length first line is detectable AND a 4096-char URI
+                # that happens to end with a newline isn't spuriously rejected for the newline.
+                line = f.readline(4098)
+            # Strip surrounding whitespace/newline and embedded NULs (a NUL survives UTF-8 decoding,
+            # so a corrupt/binary sidecar could otherwise ride \x00 into meta['src']) BEFORE the
+            # length check, so the cap applies to the URI payload regardless of a trailing newline.
+            uri = line.strip().replace('\x00', '')
+            if len(uri) > 4096:
                 logging.getLogger(__name__).warning(
                     f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} rejected: first line exceeds 4096 characters')
                 return None
-            # Strip embedded NULs too: a NUL survives UTF-8 decoding, so a corrupt/binary sidecar
-            # could otherwise ride \x00 into meta['src'] and glitch downstream consumers.
-            return line.strip().replace('\x00', '') or None
+            return uri or None
         # ValueError catches UnicodeDecodeError (invalid UTF-8 in the file) alongside
         # OSError, so a bad override file degrades to None instead of crashing setup.
         except (OSError, ValueError) as exc:

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -49,13 +49,22 @@ def resolve_override_source_uri(config) -> str | None:
     ``FILTER_OVERRIDE_SOURCE_URI_FILE`` — used when the value is only known at claim
     time and is written into the shared volume for the filter to pick up.
     """
-    if (uri := config.override_source_uri):
+    if config is None:
+        return None
+
+    def _get(key):  # robust for adict, a plain dict, or an arbitrary config object
+        return config.get(key) if hasattr(config, 'get') else getattr(config, key, None)
+
+    if (uri := _get('override_source_uri')):
         return str(uri)
 
-    if (path := config.override_source_uri_file):
+    if (path := _get('override_source_uri_file')):
         try:
-            with open(path) as f:
-                return f.read().strip() or None
+            # A source URI is small (well under 1KB); cap the read so a misconfigured
+            # or unbounded file/device stream can't exhaust memory. encoding is explicit
+            # to avoid locale-dependent decode failures across environments.
+            with open(path, encoding='utf-8') as f:
+                return f.read(4096).strip() or None
         except OSError as exc:
             logging.getLogger(__name__).warning(
                 f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} could not be read: {exc}')

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -59,6 +59,13 @@ def resolve_override_source_uri(config) -> str | None:
         return str(uri)
 
     if (path := _get('override_source_uri_file')):
+        # Defense-in-depth on the orchestrator-provided path: reject traversal and require an
+        # absolute path, so a misconfigured env can't turn this into an arbitrary-file read
+        # whose contents would ride downstream in meta['src'].
+        if '..' in path or not path.startswith('/'):
+            logging.getLogger(__name__).warning(
+                f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} rejected: must be an absolute path without ".."')
+            return None
         try:
             # A source URI is small (well under 1KB); cap the read so a misconfigured
             # or unbounded file/device stream can't exhaust memory. encoding is explicit

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -40,7 +40,7 @@ def json_getval(val: str) -> JSONType:
         return val
 
 
-def resolve_override_source_uri(config) -> str | None:
+def resolve_override_source_uri(config: Any) -> str | None:
     """Logical source URI an input filter should report as ``meta['src']``, or None.
 
     Set by an orchestrator to preserve per-file identity when the physical input path
@@ -65,6 +65,11 @@ def resolve_override_source_uri(config) -> str | None:
         # whose contents would ride downstream in meta['src']. openfilter is a general framework
         # and can't assume a specific sandbox root — the orchestrator that sets this env var owns
         # the sandbox (e.g. the batch controller constrains it under /ws/, PLAT-1499).
+        #
+        # TRUST BOUNDARY (multi-tenant LFI): this library only guarantees "absolute path, no
+        # traversal". An absolute path here (e.g. /etc/passwd) IS read and surfaced in meta['src'],
+        # so any deployment that lets untrusted tenants set FILTER_OVERRIDE_SOURCE_URI_FILE MUST
+        # enforce its own sandbox root — do not weaken this check assuming the caller is trusted.
         if '..' in path or not os.path.isabs(path):
             logging.getLogger(__name__).warning(
                 f'FILTER_OVERRIDE_SOURCE_URI_FILE {path!r} rejected: must be an absolute path without ".."')

--- a/openfilter/filter_runtime/utils.py
+++ b/openfilter/filter_runtime/utils.py
@@ -103,7 +103,7 @@ def resolve_override_source_uri(config: Any) -> str | None:
             # a wrong meta['src'] is worse than none. Trailing LINES are ignored (readline stops at
             # the first newline); the claimer writes exactly the URI + newline. encoding is explicit
             # to avoid locale-dependent decode failures across environments. utf-8-sig strips a
-            # leading BOM if the writer added one (﻿ isn't ASCII whitespace, so .strip() below
+            # leading BOM if the writer added one (U+FEFF isn't ASCII whitespace, so .strip() below
             # wouldn't remove it and it would ride into meta['src']); it is a no-op when absent.
             with open(path, encoding='utf-8-sig') as f:
                 # Text mode counts characters, not bytes. Read the 4096-char cap + up to 2 for a

--- a/tests/test_filter_image_in.py
+++ b/tests/test_filter_image_in.py
@@ -348,6 +348,7 @@ class TestImageIn(unittest.TestCase):
         self.assertFalse(detect(cfg('file:///nonexistent/dir/')), "a trailing-slash path is a directory listing")
         self.assertFalse(detect(cfg('file:///nonexistent/*.png')), "a glob is not a single object")
         self.assertFalse(detect(cfg(f'file://{self.test_dir}')), "an existing directory is not a single object")
+        self.assertFalse(detect(cfg('file://')), "an empty file:// path is not a single object")
 
     def test_list_images_disables_override_when_local_resolves_to_multiple(self):
         """Safety net: _apply_override is decided from the config URI shape at setup, but if a

--- a/tests/test_filter_image_in.py
+++ b/tests/test_filter_image_in.py
@@ -400,6 +400,36 @@ class TestImageIn(unittest.TestCase):
         self.assertEqual(len(images), 3)
         self.assertFalse(filt._apply_override, "override must be disabled when a cloud prefix matches multiple objects")
 
+    def test_list_images_disables_override_when_local_resolves_to_single_file_directory(self):
+        """A file:// source that resolves to an existing directory disables the override even with a
+        single image, so a not-yet-existing path later created as a directory can't stamp its first
+        frame with the override before a second file trips the >1 check."""
+        one_dir = tempfile.mkdtemp(prefix="test_image_in_onedir_")
+        self.addCleanup(shutil.rmtree, one_dir, ignore_errors=True)
+        create_test_images(one_dir, 1)  # a directory holding exactly one image
+
+        filt = ImageIn.__new__(ImageIn)
+        filt._apply_override = True  # statically assumed a single object (path didn't exist at setup)
+        filt.config = ImageIn.normalize_config(dict(id='x', sources=f'file://{one_dir}', outputs='ipc://x'))
+
+        images = filt._list_images(filt.config.sources[0])
+
+        self.assertEqual(len(images), 1)
+        self.assertFalse(filt._apply_override, "an existing directory (even with one image) must disable the override")
+
+    def test_decode_warned_set_is_bounded(self):
+        """The per-path decode-failure dedup set must stay bounded so a long-running poll over an
+        unbounded stream of distinct corrupt files can't leak memory."""
+        from openfilter.filter_runtime.filters.image_in import DECODE_WARNED_MAX
+
+        filt = ImageIn.__new__(ImageIn)
+        filt._decode_warned = set()
+        for i in range(DECODE_WARNED_MAX + 500):
+            filt._warn_decode_failure(f"/tmp/corrupt_{i}.png", "decode failed")
+
+        self.assertLessEqual(len(filt._decode_warned), DECODE_WARNED_MAX,
+                             "the decode-warning dedup set must stay bounded")
+
     def test_loop(self):
         """Test looping functionality."""
         runner = Filter.Runner([

--- a/tests/test_filter_image_in.py
+++ b/tests/test_filter_image_in.py
@@ -221,7 +221,7 @@ class TestImageIn(unittest.TestCase):
 
     def test_override_source_uri_meta(self):
         """FILTER_OVERRIDE_SOURCE_URI replaces meta['src'] with the logical source URI, so
-        downstream (event-sink -> BigQuery) can attribute the record to its real source file
+        downstream event storage can attribute the record to its real source file
         even though ImageIn read a generic local path."""
         generic_path = self._write_bytes_image('input_ovr', color=(0, 255, 0), text="Ovr")
         override = 's3://my-bucket/nested/path/original-image.png'

--- a/tests/test_filter_image_in.py
+++ b/tests/test_filter_image_in.py
@@ -247,6 +247,41 @@ class TestImageIn(unittest.TestCase):
             runner.stop()
             queue.close()
 
+    def test_override_ignored_for_multiple_images(self):
+        """A global override identifies ONE object; when ImageIn resolves multiple images
+        (a directory), the override must be ignored so each frame keeps its real per-image
+        path in meta['src'] — otherwise every image would be mislabeled with the same src."""
+        override = 's3://my-bucket/should-not-be-used.png'
+
+        runner = Filter.Runner([
+            (ImageIn, dict(
+                sources=f'file://{self.test_dir}',
+                outputs='ipc://test-ImageIn-ovr-multi',
+                override_source_uri=override,
+            )),
+            (FiltersToQueue, dict(
+                sources='ipc://test-ImageIn-ovr-multi',
+                queue=(queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=5)
+
+        try:
+            seen = []
+            for _ in range(3):
+                result = queue.get()
+                if result is False:
+                    break
+                seen.append(result['main'].data['meta']['src'])
+            self.assertEqual(len(seen), 3, "expected three frames for the three-image directory")
+            for src in seen:
+                self.assertNotEqual(src, override, "override must not be applied to a multi-image source")
+                self.assertTrue(os.path.isfile(src), f"meta['src'] should be a real image path, got {src!r}")
+            # Each frame must carry its own distinct real file, not one repeated override.
+            self.assertEqual(len(set(seen)), 3)
+        finally:
+            runner.stop()
+            queue.close()
+
     def test_loop(self):
         """Test looping functionality."""
         runner = Filter.Runner([

--- a/tests/test_filter_image_in.py
+++ b/tests/test_filter_image_in.py
@@ -282,6 +282,38 @@ class TestImageIn(unittest.TestCase):
             runner.stop()
             queue.close()
 
+    def test_override_ignored_for_single_image_directory(self):
+        """The override applies only when the *config* names a single explicit object, not by a
+        dynamic image count: a directory holding exactly one image is still a directory (it can
+        grow via polling), so the override must be ignored and meta['src'] keeps the real path."""
+        one_dir = tempfile.mkdtemp(prefix="test_image_in_one_")
+        self.addCleanup(shutil.rmtree, one_dir, ignore_errors=True)
+        create_test_images(one_dir, 1)  # a directory with a single image
+        override = 's3://my-bucket/should-not-be-used.png'
+
+        runner = Filter.Runner([
+            (ImageIn, dict(
+                sources=f'file://{one_dir}',
+                outputs='ipc://test-ImageIn-ovr-onedir',
+                override_source_uri=override,
+            )),
+            (FiltersToQueue, dict(
+                sources='ipc://test-ImageIn-ovr-onedir',
+                queue=(queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=5)
+
+        try:
+            result = queue.get()
+            if result is False:
+                self.fail("ImageIn produced no frame for the single-image directory")
+            src = result['main'].data['meta']['src']
+            self.assertNotEqual(src, override, "override must not be applied to a directory source, even with one image")
+            self.assertTrue(os.path.isfile(src), f"meta['src'] should be the real image path, got {src!r}")
+        finally:
+            runner.stop()
+            queue.close()
+
     def test_loop(self):
         """Test looping functionality."""
         runner = Filter.Runner([

--- a/tests/test_filter_image_in.py
+++ b/tests/test_filter_image_in.py
@@ -417,18 +417,24 @@ class TestImageIn(unittest.TestCase):
         self.assertEqual(len(images), 1)
         self.assertFalse(filt._apply_override, "an existing directory (even with one image) must disable the override")
 
-    def test_decode_warned_set_is_bounded(self):
-        """The per-path decode-failure dedup set must stay bounded so a long-running poll over an
-        unbounded stream of distinct corrupt files can't leak memory."""
+    def test_decode_warned_set_is_bounded_fifo(self):
+        """The per-path decode-failure dedup set stays bounded (so a long-running poll over an
+        unbounded stream of distinct corrupt files can't leak memory) and evicts FIFO: the oldest
+        paths go first, so recently-warned paths stay deduped."""
         from openfilter.filter_runtime.filters.image_in import DECODE_WARNED_MAX
 
         filt = ImageIn.__new__(ImageIn)
-        filt._decode_warned = set()
-        for i in range(DECODE_WARNED_MAX + 500):
+        filt._decode_warned = {}
+        overflow = 500
+        for i in range(DECODE_WARNED_MAX + overflow):
             filt._warn_decode_failure(f"/tmp/corrupt_{i}.png", "decode failed")
 
         self.assertLessEqual(len(filt._decode_warned), DECODE_WARNED_MAX,
                              "the decode-warning dedup set must stay bounded")
+        # FIFO: the first `overflow` paths were evicted; the most recent one is retained.
+        self.assertNotIn("/tmp/corrupt_0.png", filt._decode_warned, "oldest path must be evicted first")
+        self.assertIn(f"/tmp/corrupt_{DECODE_WARNED_MAX + overflow - 1}.png", filt._decode_warned,
+                      "the most recently warned path must be retained")
 
     def test_loop(self):
         """Test looping functionality."""

--- a/tests/test_filter_image_in.py
+++ b/tests/test_filter_image_in.py
@@ -335,6 +335,20 @@ class TestImageIn(unittest.TestCase):
         self.assertTrue(detect(cfg('file://sub/input')), "a relative file:// to a real file is a single object")
         self.assertFalse(detect(cfg('file://sub')), "a relative directory is not a single object")
 
+    def test_single_object_detection_nonexistent_file(self):
+        """Regression: ImageIn is a polling filter, so a single file:// source that doesn't exist
+        yet (the claimer downloads it as an init step) must still be treated as a single object —
+        deciding from URI shape, not existence, so the override isn't silently disabled for the run."""
+        detect = ImageIn.__new__(ImageIn)._override_source_is_single_object
+
+        def cfg(src):
+            return ImageIn.normalize_config(dict(id='x', sources=src, outputs='ipc://x'))
+
+        self.assertTrue(detect(cfg('file:///nonexistent/ws/input')), "a not-yet-written single file is a single object")
+        self.assertFalse(detect(cfg('file:///nonexistent/dir/')), "a trailing-slash path is a directory listing")
+        self.assertFalse(detect(cfg('file:///nonexistent/*.png')), "a glob is not a single object")
+        self.assertFalse(detect(cfg(f'file://{self.test_dir}')), "an existing directory is not a single object")
+
     def test_loop(self):
         """Test looping functionality."""
         runner = Filter.Runner([

--- a/tests/test_filter_image_in.py
+++ b/tests/test_filter_image_in.py
@@ -436,6 +436,31 @@ class TestImageIn(unittest.TestCase):
         self.assertIn(f"/tmp/corrupt_{DECODE_WARNED_MAX + overflow - 1}.png", filt._decode_warned,
                       "the most recently warned path must be retained")
 
+    def test_setup_loads_initial_images_without_attribute_error(self):
+        """Regression (init ordering): setup() must initialize self._apply_override and
+        self._decode_warned BEFORE calling _load_initial_images(), which reaches _list_images /
+        _load_image and reads both. Otherwise the initial load raises AttributeError, which
+        _load_initial_images' own try/except swallows (logging a spurious error), and the queue
+        stays empty until the first poll."""
+        class _InertPollImageIn(ImageIn):
+            def _poll_loop(self):  # keep the poll thread inert so the test only exercises setup()
+                self.stop_event.wait()
+
+        filt = _InertPollImageIn.__new__(_InertPollImageIn)
+        cfg = ImageIn.normalize_config(dict(id='x', sources=f'file://{self.test_dir}', outputs='ipc://x'))
+        try:
+            filt.setup(cfg)
+            # self.test_dir holds several images; the initial load must have queued them. On the
+            # ordering bug _load_initial_images AttributeErrors and skips, leaving the queue empty.
+            self.assertGreater(len(filt.queues.get('main', [])), 0,
+                               "setup() must load initial images (empty queue => _load_initial_images was skipped)")
+            self.assertTrue(hasattr(filt, '_apply_override'))
+            self.assertTrue(hasattr(filt, '_decode_warned'))
+        finally:
+            filt.stop_event.set()
+            if getattr(filt, 'poll_thread', None):
+                filt.poll_thread.join(timeout=2)
+
     def test_loop(self):
         """Test looping functionality."""
         runner = Filter.Runner([

--- a/tests/test_filter_image_in.py
+++ b/tests/test_filter_image_in.py
@@ -181,6 +181,72 @@ class TestImageIn(unittest.TestCase):
             runner.stop()
             queue.close()
 
+    def _write_bytes_image(self, name, color, text):
+        """Write a PNG-encoded image to a file whose name has no image extension."""
+        ok, buf = cv2.imencode('.png', create_test_image(color=color, text=text))
+        self.assertTrue(ok)
+        path = os.path.join(self.test_dir, name)
+        with open(path, 'wb') as f:
+            f.write(buf.tobytes())
+        return path
+
+    def test_single_file_no_extension(self):
+        """A single explicit file with a non-image / missing extension must still be
+        processed. The extension gate applies only to directory listings; for a single
+        named file the caller chose it. This is the batch-claimer case where the media is
+        downloaded to a generic /ws/input path."""
+        generic_path = self._write_bytes_image('input', color=(0, 0, 255), text="NoExt")  # no extension
+
+        runner = Filter.Runner([
+            (ImageIn, dict(
+                sources=f'file://{generic_path}',
+                outputs='ipc://test-ImageIn-noext',
+            )),
+            (FiltersToQueue, dict(
+                sources='ipc://test-ImageIn-noext',
+                queue=(queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=5)
+
+        try:
+            result = queue.get()
+            if result is False:
+                self.fail("ImageIn produced no frame for a single extensionless file")
+            frame = result['main']
+            self.assertIsNotNone(frame.image)
+            self.assertEqual(frame.data['meta']['src'], generic_path)  # no override -> physical path
+        finally:
+            runner.stop()
+            queue.close()
+
+    def test_override_source_uri_meta(self):
+        """FILTER_OVERRIDE_SOURCE_URI replaces meta['src'] with the logical source URI, so
+        downstream (event-sink -> BigQuery) can attribute the record to its real source file
+        even though ImageIn read a generic local path."""
+        generic_path = self._write_bytes_image('input_ovr', color=(0, 255, 0), text="Ovr")
+        override = 's3://my-bucket/nested/path/original-image.png'
+
+        runner = Filter.Runner([
+            (ImageIn, dict(
+                sources=f'file://{generic_path}',
+                outputs='ipc://test-ImageIn-ovr',
+                override_source_uri=override,
+            )),
+            (FiltersToQueue, dict(
+                sources='ipc://test-ImageIn-ovr',
+                queue=(queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=5)
+
+        try:
+            result = queue.get()
+            if result is False:
+                self.fail("ImageIn produced no frame")
+            self.assertEqual(result['main'].data['meta']['src'], override)
+        finally:
+            runner.stop()
+            queue.close()
+
     def test_loop(self):
         """Test looping functionality."""
         runner = Filter.Runner([

--- a/tests/test_filter_image_in.py
+++ b/tests/test_filter_image_in.py
@@ -349,6 +349,56 @@ class TestImageIn(unittest.TestCase):
         self.assertFalse(detect(cfg('file:///nonexistent/*.png')), "a glob is not a single object")
         self.assertFalse(detect(cfg(f'file://{self.test_dir}')), "an existing directory is not a single object")
 
+    def test_list_images_disables_override_when_local_resolves_to_multiple(self):
+        """Safety net: _apply_override is decided from the config URI shape at setup, but if a
+        listing pass later resolves to >1 object (a path that turned out to be a directory),
+        stamping every match with the same override URI would mislabel them — so _list_images
+        disables the override. Only ever disables, so it can't reintroduce the watched-dir race."""
+        multi_dir = tempfile.mkdtemp(prefix="test_image_in_multi_")
+        self.addCleanup(shutil.rmtree, multi_dir, ignore_errors=True)
+        create_test_images(multi_dir, 2)
+
+        filt = ImageIn.__new__(ImageIn)
+        filt._apply_override = True  # statically assumed a single object
+        filt.config = ImageIn.normalize_config(dict(id='x', sources=f'file://{multi_dir}', outputs='ipc://x'))
+
+        images = filt._list_images(filt.config.sources[0])
+
+        self.assertEqual(len(images), 2)
+        self.assertFalse(filt._apply_override, "override must be disabled once the source resolves to >1 object")
+
+    def test_list_images_keeps_override_for_single_object(self):
+        """The safety net only ever disables on >1 object: a genuine single file keeps the
+        override enabled (guards against over-eager disabling)."""
+        one = self._write_bytes_image('input_single_guard', color=(0, 0, 255), text="One")
+
+        filt = ImageIn.__new__(ImageIn)
+        filt._apply_override = True
+        filt.config = ImageIn.normalize_config(dict(id='x', sources=f'file://{one}', outputs='ipc://x'))
+
+        images = filt._list_images(filt.config.sources[0])
+
+        self.assertEqual(len(images), 1)
+        self.assertTrue(filt._apply_override, "a single-object source must keep the override enabled")
+
+    def test_list_images_disables_override_when_cloud_prefix_matches_multiple(self):
+        """A cloud key with no trailing slash/glob is classified single, but S3/GCS listing is
+        prefix-based, so a shared prefix (s3://bucket/img also matching img-1.png) resolves to
+        multiple objects. The disable dispatch fires for the cloud scheme too (the lister is
+        stubbed here to isolate the safety net from boto3)."""
+        from unittest import mock
+
+        filt = ImageIn.__new__(ImageIn)
+        filt._apply_override = True
+        filt.config = ImageIn.normalize_config(dict(id='x', sources='s3://bucket/img', outputs='ipc://x'))
+
+        with mock.patch.object(filt, '_list_s3_images',
+                               return_value=['s3://bucket/img', 's3://bucket/img-1.png', 's3://bucket/img-2.png']):
+            images = filt._list_images(filt.config.sources[0])
+
+        self.assertEqual(len(images), 3)
+        self.assertFalse(filt._apply_override, "override must be disabled when a cloud prefix matches multiple objects")
+
     def test_loop(self):
         """Test looping functionality."""
         runner = Filter.Runner([

--- a/tests/test_filter_image_in.py
+++ b/tests/test_filter_image_in.py
@@ -314,6 +314,27 @@ class TestImageIn(unittest.TestCase):
             runner.stop()
             queue.close()
 
+    def test_single_object_detection_relative_file(self):
+        """Regression: a relative file:// path must be recognized as a single object. urlparse
+        would misparse its first path segment as the netloc (file://sub/x -> path='/x'); the
+        single-object check slices 'file://' off directly, matching how _list_local_images
+        extracts the path. Exercised in-process (no subprocess) to isolate the config-shape logic."""
+        prev_cwd = os.getcwd()
+        tmp = tempfile.mkdtemp(prefix="test_image_in_rel_")
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        self.addCleanup(os.chdir, prev_cwd)
+        os.chdir(tmp)
+        os.makedirs('sub')
+        open(os.path.join('sub', 'input'), 'wb').close()  # a real file at a relative path
+
+        detect = ImageIn.__new__(ImageIn)._override_source_is_single_object
+
+        def cfg(src):
+            return ImageIn.normalize_config(dict(id='x', sources=src, outputs='ipc://x'))
+
+        self.assertTrue(detect(cfg('file://sub/input')), "a relative file:// to a real file is a single object")
+        self.assertFalse(detect(cfg('file://sub')), "a relative directory is not a single object")
+
     def test_loop(self):
         """Test looping functionality."""
         runner = Filter.Runner([

--- a/tests/test_filter_video_in.py
+++ b/tests/test_filter_video_in.py
@@ -150,6 +150,30 @@ class TestVideoIn(unittest.TestCase):
             queue.close()
 
 
+    def test_override_source_uri_meta(self):
+        """FILTER_OVERRIDE_SOURCE_URI replaces meta['src'] with the logical source URI while
+        VideoIn still opens the physical file (VideoIn is already extension-agnostic)."""
+        override = 's3://my-bucket/nested/original-video.mp4'
+        runner = Filter.Runner([
+            (VideoIn, dict(
+                sources = f'file://{TEST_VIDEO_FNM}!sync',
+                outputs = 'ipc://test-VideoIn-ovr',
+                override_source_uri = override,
+            )),
+            (FiltersToQueue, dict(
+                sources = 'ipc://test-VideoIn-ovr',
+                queue   = (queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=3)
+
+        try:
+            frame = queue.get()['main']
+            self.assertEqual(frame.data['meta']['src'], override)
+        finally:
+            runner.stop()
+            queue.close()
+
+
     def test_pts(self):
         """File sources stamp the source position in seconds (src_seconds) and the
         0-based source frame index (src_frame) into each frame's meta, so

--- a/tests/test_filter_video_in.py
+++ b/tests/test_filter_video_in.py
@@ -207,6 +207,41 @@ class TestVideoIn(unittest.TestCase):
             queue.close()
 
 
+    def test_extensionless_file_decodes(self):
+        """The batch claimer downloads to a generic extension-less path (/ws/input), so VideoIn
+        must decode a file with no extension: is_video_file keys on the file:// scheme (not the
+        extension) and cv2.VideoCapture/FFmpeg probes the container from the bytes. This proves
+        the /ws/input default is safe for VideoIn, not just image-in (PLAT-1499)."""
+        noext = 'test_video_noext'  # deliberately no extension
+        with open(noext, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+
+        runner = Filter.Runner([
+            (VideoIn, dict(
+                sources = f'file://{noext}!sync',
+                outputs = 'ipc://test-VideoIn-noext',
+            )),
+            (FiltersToQueue, dict(
+                sources = 'ipc://test-VideoIn-noext',
+                queue   = (queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=3)
+
+        try:
+            result = queue.get()
+            if not result:
+                self.fail("VideoIn produced no frame for an extension-less file")
+            frame = result['main']
+            self.assertIsNotNone(frame.image, "VideoIn must decode the extension-less file by content")
+        finally:
+            runner.stop()
+            queue.close()
+            try:
+                os.unlink(noext)
+            except Exception:
+                pass
+
+
     def test_pts(self):
         """File sources stamp the source position in seconds (src_seconds) and the
         0-based source frame index (src_frame) into each frame's meta, so

--- a/tests/test_filter_video_in.py
+++ b/tests/test_filter_video_in.py
@@ -174,6 +174,39 @@ class TestVideoIn(unittest.TestCase):
             queue.close()
 
 
+    def test_override_ignored_for_multiple_sources(self):
+        """A global override identifies ONE source; with multiple VideoIn sources it must be
+        ignored so each frame keeps its real per-source meta['src'] — otherwise every source
+        would be mislabeled with the same URI (mirrors the ImageIn guard, PLAT-1498)."""
+        override = 's3://my-bucket/should-not-be-used.mp4'
+        runner = Filter.Runner([
+            (VideoIn, dict(
+                sources = f'file://{TEST_VIDEO_FNM}!sync;main, file://{TEST_VIDEO_FNM}!sync;other',
+                outputs = 'ipc://test-VideoIn-ovr-multi',
+                override_source_uri = override,
+            )),
+            (FiltersToQueue, dict(
+                sources = 'ipc://test-VideoIn-ovr-multi',
+                queue   = (queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=3)
+
+        try:
+            srcs = []
+            for _ in range(6):
+                result = queue.get()
+                if not result:
+                    break
+                for frame in result.values():
+                    srcs.append(frame.data['meta']['src'])
+            self.assertTrue(srcs, "expected at least one frame")
+            for src in srcs:
+                self.assertNotEqual(src, override, "override must not be applied to a multi-source VideoIn")
+        finally:
+            runner.stop()
+            queue.close()
+
+
     def test_pts(self):
         """File sources stamp the source position in seconds (src_seconds) and the
         0-based source frame index (src_frame) into each frame's meta, so

--- a/tests/test_filter_video_in.py
+++ b/tests/test_filter_video_in.py
@@ -177,7 +177,7 @@ class TestVideoIn(unittest.TestCase):
     def test_override_ignored_for_multiple_sources(self):
         """A global override identifies ONE source; with multiple VideoIn sources it must be
         ignored so each frame keeps its real per-source meta['src'] — otherwise every source
-        would be mislabeled with the same URI (mirrors the ImageIn guard, PLAT-1498)."""
+        would be mislabeled with the same URI (mirrors the ImageIn guard)."""
         override = 's3://my-bucket/should-not-be-used.mp4'
         runner = Filter.Runner([
             (VideoIn, dict(
@@ -211,7 +211,7 @@ class TestVideoIn(unittest.TestCase):
         """The batch claimer downloads to a generic extension-less path (/ws/input), so VideoIn
         must decode a file with no extension: is_video_file keys on the file:// scheme (not the
         extension) and cv2.VideoCapture/FFmpeg probes the container from the bytes. This proves
-        the /ws/input default is safe for VideoIn, not just image-in (PLAT-1499)."""
+        the /ws/input default is safe for VideoIn, not just image-in."""
         noext = 'test_video_noext'  # deliberately no extension
         with open(noext, 'wb') as f:
             f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)

--- a/tests/test_filter_video_in.py
+++ b/tests/test_filter_video_in.py
@@ -215,6 +215,7 @@ class TestVideoIn(unittest.TestCase):
         noext = 'test_video_noext'  # deliberately no extension
         with open(noext, 'wb') as f:
             f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+        self.addCleanup(os.unlink, noext)  # resilient even if Filter.Runner construction raises
 
         runner = Filter.Runner([
             (VideoIn, dict(
@@ -236,10 +237,6 @@ class TestVideoIn(unittest.TestCase):
         finally:
             runner.stop()
             queue.close()
-            try:
-                os.unlink(noext)
-            except Exception:
-                pass
 
 
     def test_pts(self):

--- a/tests/test_override_source_uri.py
+++ b/tests/test_override_source_uri.py
@@ -44,6 +44,16 @@ class TestResolveOverrideSourceURI(unittest.TestCase):
             cfg = adict(override_source_uri_file=path)
             self.assertIsNone(resolve_override_source_uri(cfg))
 
+    @unittest.skipUnless(hasattr(os, 'mkfifo'), 'requires os.mkfifo (POSIX)')
+    def test_fifo_rejected(self):
+        # A FIFO/named pipe must be rejected without being opened — reading it would block the
+        # setup thread indefinitely. It is absolute and has no '..', so only the regular-file
+        # check can reject it.
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'pipe.source_uri')
+            os.mkfifo(path)
+            self.assertIsNone(resolve_override_source_uri(adict(override_source_uri_file=path)))
+
     def test_path_traversal_rejected(self):
         self.assertIsNone(resolve_override_source_uri(adict(override_source_uri_file='/ws/../etc/passwd')))
 

--- a/tests/test_override_source_uri.py
+++ b/tests/test_override_source_uri.py
@@ -44,6 +44,16 @@ class TestResolveOverrideSourceURI(unittest.TestCase):
             cfg = adict(override_source_uri_file=path)
             self.assertIsNone(resolve_override_source_uri(cfg))
 
+    def test_invalid_utf8_file_returns_none(self):
+        # A file with invalid UTF-8 must degrade to None (UnicodeDecodeError is a
+        # ValueError), not crash the filter's setup.
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'bad.source_uri')
+            with open(path, 'wb') as f:
+                f.write(b'\xff\xfe not valid utf-8 \x80\x81')
+            cfg = adict(override_source_uri_file=path)
+            self.assertIsNone(resolve_override_source_uri(cfg))
+
     def test_plain_dict_config(self):
         # Must work for a plain dict, not only adict (no AttributeError).
         self.assertEqual(

--- a/tests/test_override_source_uri.py
+++ b/tests/test_override_source_uri.py
@@ -116,6 +116,17 @@ class TestResolveOverrideSourceURI(unittest.TestCase):
                 f.write('x' * (1 << 20))  # 1 MiB of junk after the URI on the same line
             self.assertIsNone(resolve_override_source_uri(adict(override_source_uri_file=path)))
 
+    def test_multibyte_first_line_under_char_cap_accepted(self):
+        # The cap is 4096 CHARACTERS, not bytes: a first line of multi-byte characters that is
+        # under the char cap but over 4096 bytes must still be accepted (guards the
+        # characters-vs-bytes distinction in the cap check and its message).
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'multibyte.source_uri')
+            value = 'é' * 3000  # 3000 chars (< 4096) but 6000 bytes (> 4096) in UTF-8
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(value + '\n')
+            self.assertEqual(resolve_override_source_uri(adict(override_source_uri_file=path)), value)
+
     def test_trailing_lines_ignored(self):
         # Only the first line is read; junk on later lines never rides into meta['src'].
         with tempfile.TemporaryDirectory() as d:

--- a/tests/test_override_source_uri.py
+++ b/tests/test_override_source_uri.py
@@ -87,17 +87,24 @@ class TestResolveOverrideSourceURI(unittest.TestCase):
             override_source_uri = 's3://bucket/from-attr.png'
         self.assertEqual(resolve_override_source_uri(Cfg()), 's3://bucket/from-attr.png')
 
-    def test_bounded_read_ignores_trailing_garbage(self):
-        # A pathological huge file: only the capped prefix is read; the URI (short,
-        # first token) is still returned and the read is bounded.
+    def test_over_length_first_line_rejected(self):
+        # A pathological first line (URI + 1 MiB of junk on the same line) exceeds the cap and is
+        # rejected outright — a truncated/contaminated URI must not ride into meta['src'].
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, 'big.source_uri')
             with open(path, 'w', encoding='utf-8') as f:
                 f.write('s3://bucket/real.mp4')
                 f.write('x' * (1 << 20))  # 1 MiB of junk after the URI on the same line
-            got = resolve_override_source_uri(adict(override_source_uri_file=path))
-            self.assertTrue(got.startswith('s3://bucket/real.mp4'))
-            self.assertLessEqual(len(got), 4096)
+            self.assertIsNone(resolve_override_source_uri(adict(override_source_uri_file=path)))
+
+    def test_trailing_lines_ignored(self):
+        # Only the first line is read; junk on later lines never rides into meta['src'].
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'multi.source_uri')
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write('s3://bucket/real.mp4\nignored second line\nmore junk\n')
+            self.assertEqual(
+                resolve_override_source_uri(adict(override_source_uri_file=path)), 's3://bucket/real.mp4')
 
 
 if __name__ == '__main__':

--- a/tests/test_override_source_uri.py
+++ b/tests/test_override_source_uri.py
@@ -20,7 +20,7 @@ class TestResolveOverrideSourceURI(unittest.TestCase):
     def test_file_value(self):
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, 'input.source_uri')
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding='utf-8') as f:
                 f.write('s3://bucket/path/from-file.mp4\n')  # trailing newline must be stripped
             cfg = adict(override_source_uri_file=path)
             self.assertEqual(resolve_override_source_uri(cfg), 's3://bucket/path/from-file.mp4')
@@ -28,7 +28,7 @@ class TestResolveOverrideSourceURI(unittest.TestCase):
     def test_direct_value_wins_over_file(self):
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, 'input.source_uri')
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding='utf-8') as f:
                 f.write('s3://bucket/from-file')
             cfg = adict(override_source_uri='s3://bucket/direct', override_source_uri_file=path)
             self.assertEqual(resolve_override_source_uri(cfg), 's3://bucket/direct')
@@ -40,7 +40,7 @@ class TestResolveOverrideSourceURI(unittest.TestCase):
     def test_empty_file_returns_none(self):
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, 'empty')
-            open(path, 'w').close()
+            open(path, 'w', encoding='utf-8').close()
             cfg = adict(override_source_uri_file=path)
             self.assertIsNone(resolve_override_source_uri(cfg))
 
@@ -82,7 +82,7 @@ class TestResolveOverrideSourceURI(unittest.TestCase):
         # first token) is still returned and the read is bounded.
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, 'big.source_uri')
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding='utf-8') as f:
                 f.write('s3://bucket/real.mp4')
                 f.write('x' * (1 << 20))  # 1 MiB of junk after the URI on the same line
             got = resolve_override_source_uri(adict(override_source_uri_file=path))

--- a/tests/test_override_source_uri.py
+++ b/tests/test_override_source_uri.py
@@ -147,6 +147,26 @@ class TestResolveOverrideSourceURI(unittest.TestCase):
                 f.write('a' * 4097 + '\n')
             self.assertIsNone(resolve_override_source_uri(adict(override_source_uri_file=path)))
 
+    def test_bom_stripped_from_file(self):
+        # A UTF-8 BOM prefix (some writers/editors/OSes add one) must be stripped, not ride into
+        # meta['src'] as an invisible ﻿. utf-8-sig handles it at decode time; str.strip() would
+        # not, since ﻿ is not ASCII whitespace.
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'bom.source_uri')
+            with open(path, 'wb') as f:
+                f.write('﻿s3://bucket/real.mp4\n'.encode('utf-8'))  # UTF-8 BOM + URI
+            self.assertEqual(
+                resolve_override_source_uri(adict(override_source_uri_file=path)), 's3://bucket/real.mp4')
+
+    def test_direct_value_stripped_and_cleaned(self):
+        # The direct value gets the same cleaning as the file path: surrounding whitespace/newline
+        # and embedded NULs removed; empty after cleaning degrades to None.
+        self.assertEqual(
+            resolve_override_source_uri(adict(override_source_uri='  s3://bucket/x.png\n  ')), 's3://bucket/x.png')
+        self.assertEqual(
+            resolve_override_source_uri(adict(override_source_uri='s3://b/\x00na\x00me.png')), 's3://b/name.png')
+        self.assertIsNone(resolve_override_source_uri(adict(override_source_uri='   ')))
+
     def test_trailing_lines_ignored(self):
         # Only the first line is read; junk on later lines never rides into meta['src'].
         with tempfile.TemporaryDirectory() as d:

--- a/tests/test_override_source_uri.py
+++ b/tests/test_override_source_uri.py
@@ -44,6 +44,35 @@ class TestResolveOverrideSourceURI(unittest.TestCase):
             cfg = adict(override_source_uri_file=path)
             self.assertIsNone(resolve_override_source_uri(cfg))
 
+    def test_plain_dict_config(self):
+        # Must work for a plain dict, not only adict (no AttributeError).
+        self.assertEqual(
+            resolve_override_source_uri({'override_source_uri': 's3://bucket/x.png'}),
+            's3://bucket/x.png',
+        )
+        self.assertIsNone(resolve_override_source_uri({}))
+
+    def test_none_config(self):
+        self.assertIsNone(resolve_override_source_uri(None))
+
+    def test_object_config_without_get(self):
+        # Arbitrary config object exposing attributes but no .get().
+        class Cfg:
+            override_source_uri = 's3://bucket/from-attr.png'
+        self.assertEqual(resolve_override_source_uri(Cfg()), 's3://bucket/from-attr.png')
+
+    def test_bounded_read_ignores_trailing_garbage(self):
+        # A pathological huge file: only the capped prefix is read; the URI (short,
+        # first token) is still returned and the read is bounded.
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'big.source_uri')
+            with open(path, 'w') as f:
+                f.write('s3://bucket/real.mp4')
+                f.write('x' * (1 << 20))  # 1 MiB of junk after the URI on the same line
+            got = resolve_override_source_uri(adict(override_source_uri_file=path))
+            self.assertTrue(got.startswith('s3://bucket/real.mp4'))
+            self.assertLessEqual(len(got), 4096)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_override_source_uri.py
+++ b/tests/test_override_source_uri.py
@@ -70,6 +70,25 @@ class TestResolveOverrideSourceURI(unittest.TestCase):
             cfg = adict(override_source_uri_file=path)
             self.assertIsNone(resolve_override_source_uri(cfg))
 
+    def test_null_bytes_stripped(self):
+        # A NUL byte is valid UTF-8 and survives decoding, so a corrupt/binary sidecar could
+        # otherwise carry \x00 into meta['src']. Embedded NULs must be stripped out.
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'nul.source_uri')
+            with open(path, 'wb') as f:
+                f.write(b's3://bucket/\x00na\x00me.png\n')
+            cfg = adict(override_source_uri_file=path)
+            self.assertEqual(resolve_override_source_uri(cfg), 's3://bucket/name.png')
+
+    def test_all_null_bytes_returns_none(self):
+        # A first line that is only NULs strips to empty -> None, not ''.
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'nuls.source_uri')
+            with open(path, 'wb') as f:
+                f.write(b'\x00\x00\x00')
+            cfg = adict(override_source_uri_file=path)
+            self.assertIsNone(resolve_override_source_uri(cfg))
+
     def test_plain_dict_config(self):
         # Must work for a plain dict, not only adict (no AttributeError).
         self.assertEqual(

--- a/tests/test_override_source_uri.py
+++ b/tests/test_override_source_uri.py
@@ -44,6 +44,12 @@ class TestResolveOverrideSourceURI(unittest.TestCase):
             cfg = adict(override_source_uri_file=path)
             self.assertIsNone(resolve_override_source_uri(cfg))
 
+    def test_path_traversal_rejected(self):
+        self.assertIsNone(resolve_override_source_uri(adict(override_source_uri_file='/ws/../etc/passwd')))
+
+    def test_relative_path_rejected(self):
+        self.assertIsNone(resolve_override_source_uri(adict(override_source_uri_file='relative/input.source_uri')))
+
     def test_invalid_utf8_file_returns_none(self):
         # A file with invalid UTF-8 must degrade to None (UnicodeDecodeError is a
         # ValueError), not crash the filter's setup.

--- a/tests/test_override_source_uri.py
+++ b/tests/test_override_source_uri.py
@@ -149,12 +149,12 @@ class TestResolveOverrideSourceURI(unittest.TestCase):
 
     def test_bom_stripped_from_file(self):
         # A UTF-8 BOM prefix (some writers/editors/OSes add one) must be stripped, not ride into
-        # meta['src'] as an invisible ﻿. utf-8-sig handles it at decode time; str.strip() would
-        # not, since ﻿ is not ASCII whitespace.
+        # meta['src'] as an invisible U+FEFF. utf-8-sig handles it at decode time; str.strip() would
+        # not, since U+FEFF is not ASCII whitespace.
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, 'bom.source_uri')
             with open(path, 'wb') as f:
-                f.write('﻿s3://bucket/real.mp4\n'.encode('utf-8'))  # UTF-8 BOM + URI
+                f.write('s3://bucket/real.mp4\n'.encode('utf-8-sig'))  # utf-8-sig prepends the BOM bytes
             self.assertEqual(
                 resolve_override_source_uri(adict(override_source_uri_file=path)), 's3://bucket/real.mp4')
 

--- a/tests/test_override_source_uri.py
+++ b/tests/test_override_source_uri.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+import os
+import tempfile
+import unittest
+
+from openfilter.filter_runtime.utils import adict, resolve_override_source_uri
+
+
+class TestResolveOverrideSourceURI(unittest.TestCase):
+    """Unit tests for the FILTER_OVERRIDE_SOURCE_URI[_FILE] resolution helper."""
+
+    def test_none_when_unset(self):
+        self.assertIsNone(resolve_override_source_uri(adict()))
+
+    def test_direct_value(self):
+        cfg = adict(override_source_uri='s3://bucket/path/original.png')
+        self.assertEqual(resolve_override_source_uri(cfg), 's3://bucket/path/original.png')
+
+    def test_file_value(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'input.source_uri')
+            with open(path, 'w') as f:
+                f.write('s3://bucket/path/from-file.mp4\n')  # trailing newline must be stripped
+            cfg = adict(override_source_uri_file=path)
+            self.assertEqual(resolve_override_source_uri(cfg), 's3://bucket/path/from-file.mp4')
+
+    def test_direct_value_wins_over_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'input.source_uri')
+            with open(path, 'w') as f:
+                f.write('s3://bucket/from-file')
+            cfg = adict(override_source_uri='s3://bucket/direct', override_source_uri_file=path)
+            self.assertEqual(resolve_override_source_uri(cfg), 's3://bucket/direct')
+
+    def test_missing_file_returns_none(self):
+        cfg = adict(override_source_uri_file='/no/such/file.source_uri')
+        self.assertIsNone(resolve_override_source_uri(cfg))
+
+    def test_empty_file_returns_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'empty')
+            open(path, 'w').close()
+            cfg = adict(override_source_uri_file=path)
+            self.assertIsNone(resolve_override_source_uri(cfg))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_override_source_uri.py
+++ b/tests/test_override_source_uri.py
@@ -127,6 +127,26 @@ class TestResolveOverrideSourceURI(unittest.TestCase):
                 f.write(value + '\n')
             self.assertEqual(resolve_override_source_uri(adict(override_source_uri_file=path)), value)
 
+    def test_exactly_max_length_with_newline_accepted(self):
+        # A 4096-character URI followed by a trailing newline must be accepted: the cap applies to
+        # the payload, not the newline (regression for an off-by-one where readline's char count
+        # included the '\n' and rejected a full-length URI only because it ended with a newline).
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'maxlen.source_uri')
+            value = 's3://bucket/' + 'a' * (4096 - len('s3://bucket/'))  # exactly 4096 chars
+            self.assertEqual(len(value), 4096)
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(value + '\n')
+            self.assertEqual(resolve_override_source_uri(adict(override_source_uri_file=path)), value)
+
+    def test_over_max_length_rejected(self):
+        # 4097 characters of payload is over the cap -> rejected.
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'over.source_uri')
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write('a' * 4097 + '\n')
+            self.assertIsNone(resolve_override_source_uri(adict(override_source_uri_file=path)))
+
     def test_trailing_lines_ignored(self):
         # Only the first line is read; junk on later lines never rides into meta['src'].
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
## What

Two changes to the entry filters so a batch pipeline can attribute each record to its source file, and so `ImageIn` works in the batch queue path at all.

### 1. `FILTER_OVERRIDE_SOURCE_URI` → `meta['src']` (VideoIn + ImageIn)
New `override_source_uri` config — env `FILTER_OVERRIDE_SOURCE_URI` (direct value) or `FILTER_OVERRIDE_SOURCE_URI_FILE` (a file to read it from, for when the value is only known at runtime). When set, the filter stamps that **logical** URI as each frame's `meta['src']` instead of the physical input path. This lets an orchestrator preserve per-file identity even when the media is downloaded to a generic path (e.g. a batch claimer's `/ws/input`) — identity travels as metadata, not in the filename. Resolution is a shared `utils.resolve_override_source_uri` helper (absolute + traversal-safe, first-line bounded read, rejects non-regular files).

### 2. ImageIn: single explicit file is extension-agnostic (bug fix)
`ImageIn`'s image-extension gate (`jpg/png/…`) only ever needed to filter non-images out of **directory** listings, but it was also applied to a **single explicit file** — so a file with a non-image or missing extension (e.g. a generic `/ws/input.mp4` or `/ws/input`) was **silently skipped, producing zero frames**. Now a single named file is accepted and validated by decoding (`cv2.imread`, which also logs a warning on an undecodable file). Directory and S3/GCS listings keep the extension gate. `VideoIn` was already extension-agnostic (scheme-classified, content-decoded), so it only needed change #1.

The global override is applied only when the source config resolves to a single explicit object (not a directory/glob/multi-source), so a multi-image input keeps each frame's real per-file path.

## Tests
- `tests/test_override_source_uri.py` — the resolver: direct value, file, precedence, missing/empty/non-regular file (FIFO), traversal/relative rejection, unset.
- `tests/test_filter_image_in.py` — single extensionless file; `meta['src']` override; single-object detection (incl. the relative `file://` case) and the multi-image / single-image-directory guards.
- `tests/test_filter_video_in.py` — `meta['src']` override; multi-source guard; extension-less decode.
