### PR TITLE
Rename VideoIn frame meta `pts_s` to `src_seconds`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,17 @@ OpenFilter Library release notes
   (video-in/out, image-in/out, mqtt-out, recorder, rest, webvis) now build on
   `python:3.14-slim` / `openfilter-base:py3.14`. The example projects widen to `<3.15` too.
 
+### Changed
+
+- **`VideoIn` frame meta: `pts_s` renamed to `src_seconds` (#128 follow-up).** The file-source
+  meta key introduced in v1.2.0 is renamed to name what it actually is: the frame's position
+  *within the source*, in seconds — a source offset, not the raw container PTS (in the CFR path it
+  is `src_frame / fps`, a nominal timeline) and not the wall-clock `meta['ts']`. This lands now
+  because v1.2.0 is days old and no consumer reads the key yet, so the honest name costs nothing.
+  `src_frame` is unchanged, and the reader-level `VideoReader` / `extras` dict still carries the
+  decoder value under `pts_s` (a codec term at that layer); only the emitted frame-meta field
+  changed. Consumers reading `meta['pts_s']` must switch to `meta['src_seconds']`.
+
 ## v1.2.2 - 2026-08-10
 
 ### Security

--- a/docs/design-video-in-pts.md
+++ b/docs/design-video-in-pts.md
@@ -45,10 +45,10 @@ Merge plan with `feat/video-in-seekable-replay`:
   `self.cap`, and its docstring marks it as such. #118's post-seek path currently calls raw
   `cap.read()` for forward-read compensation; whichever PR merges second must route that read
   through `_cap_read()` (compensation frames are discarded, so the cost is nil, and the first
-  *delivered* post-seek frame then carries correct `pts_s`/`src_frame`).
+  *delivered* post-seek frame then carries correct `src_seconds`/`src_frame`).
 - **Meta naming**: `src_frame` (this PR) and `frame_index` (#118) are the same value at meta
   level. One name must survive; this PR has no attachment to `src_frame` — if #118 lands first we
-  adopt `frame_index` and keep `pts_s`; if this lands first, #118 rebases its `frame_index` onto
+  adopt `frame_index` and keep `src_seconds`; if this lands first, #118 rebases its `frame_index` onto
   `src_frame` or renames ours. Either way the second-to-merge PR emits a single key.
 - **Landing order (agreed, per review)**: #118 merges first — it owns the extras-dict shape and
   its design doc, and this PR already adopted its shape and `frame_n` key. This PR then rebases
@@ -67,7 +67,7 @@ same frame, which is the contract's purpose. Switching such files to `POS_MSEC` 
 upgrade: `POS_MSEC` exhibits B-frame presentation reordering and reports 0 on several
 container/backend combos (both reproduced by the repo's own test clip), with no way to tell a
 true pts from a lie at runtime. `POS_MSEC` is therefore used only for containers reporting no
-frame rate at all, and only while it looks sane (nonzero past frame 0); otherwise `pts_s` is
+frame rate at all, and only while it looks sane (nonzero past frame 0); otherwise `src_seconds` is
 omitted rather than emitted wrong. Consumers needing true per-frame VFR timestamps should demux
 container pts out-of-band (e.g. PyAV); that is out of scope for `VideoIn`.
 

--- a/docs/design-video-in-pts.md
+++ b/docs/design-video-in-pts.md
@@ -1,8 +1,8 @@
-# Design Note: Decoder pts_s / src_frame in `VideoIn` Frame Meta
+# Design Note: `src_seconds` / `src_frame` in `VideoIn` Frame Meta
 
-Status: proposed with PR #128. Prior art: the CPD hybrid-RAG specs (internal-chicagopd PR 2,
-spec 01) establish that jump-to-frame requires a decoder-derived video offset; this note records
-how that need lands on openfilter core's public surface.
+Status: proposed with PR #128. Prior art established that jump-to-frame requires a
+decoder-derived video offset; this note records how that need lands on openfilter core's
+public surface.
 
 ## 1. The frame-meta contract
 
@@ -11,10 +11,15 @@ For **file sources** (`file://`, `s3://`) every emitted frame's `meta` gains:
 | Key | Type | Semantics |
 |---|---|---|
 | `src_frame` | `int` | 0-based source frame index of the delivered frame: `CAP_PROP_POS_FRAMES` sampled immediately **before** the successful `cap.read()`. Exact on every backend. |
-| `pts_s` | `float` | Presentation timestamp in seconds. Primary: `src_frame / container_fps` (nominal CFR timeline). Fallback: `CAP_PROP_POS_MSEC / 1000` only when the container reports no usable frame rate (none at all, or an implausible `>= FPS_SANE_CEILING` / non-finite sentinel — see §4). Omitted when neither is trustworthy (`src_frame` remains present and exact). |
+| `src_seconds` | `float` | The frame's position **within the source**, in seconds. Primary: `src_frame / container_fps` (nominal CFR timeline). Fallback: `CAP_PROP_POS_MSEC / 1000` only when the container reports no usable frame rate (none at all, or an implausible `>= FPS_SANE_CEILING` / non-finite sentinel — see §4). Omitted when neither is trustworthy (`src_frame` remains present and exact). This is a source offset — not the wall-clock `meta['ts']`, and not the raw container PTS (in the CFR path it is `src_frame / fps`, a nominal timeline). |
 
 Stream (`rtsp://` etc.) and webcam sources have no meaningful decoder position: both keys are
 **absent** and the rest of `meta` (`id`, `ts`, `src`, `src_fps`) is byte-for-byte unchanged.
+
+> **Layering note.** At the `VideoReader` / `extras` level this value is carried under the key
+> `pts_s` (the decoder-derived seconds, see §3–§4); the emitted **frame meta** field is
+> `src_seconds`. This mirrors the boundary rename `extras['frame_n']` → `meta['src_frame']`:
+> the reader uses codec terms, the public meta uses source-position terms.
 
 ## 2. Core vs. companion filter
 
@@ -75,9 +80,9 @@ through to the same guarded `POS_MSEC` branch as a no-rate container, keeping `s
 
 ## 4a. Looped sources
 
-With `loop`, the cap is reopened each pass, so `src_frame` / `pts_s` restart at 0 every loop —
+With `loop`, the cap is reopened each pass, so `src_frame` / `src_seconds` restart at 0 every loop —
 they are the position *within the file*, which is the correct semantics — while `meta['id']` keeps
-counting across passes. A looped timeline is thus non-monotonic in `src_frame`/`pts_s` but
+counting across passes. A looped timeline is thus non-monotonic in `src_frame`/`src_seconds` but
 monotonic in `id`; consumers indexing a looped source must key off `id`, not `src_frame`.
 
 ## 5. Back-compat position

--- a/openfilter/filter_runtime/filters/video_in.py
+++ b/openfilter/filter_runtime/filters/video_in.py
@@ -719,14 +719,15 @@ class VideoIn(Filter):
         seconds at read), meta['src'] and meta['src_fps']. File sources (file:// and s3://) additionally carry the
         decoder position of the delivered frame - the video offset that cannot be reconstructed downstream:
 
-            meta['src_frame'] - 0-based source frame index (CAP_PROP_POS_FRAMES sampled before the read, exact).
-            meta['pts_s']     - presentation timestamp in seconds: src_frame / container fps (nominal CFR timeline;
-                see VideoReader._cap_read for the VFR position), or CAP_PROP_POS_MSEC when the container reports no
-                frame rate. Omitted when neither is trustworthy - src_frame is then still present and exact.
+            meta['src_frame']   - 0-based source frame index (CAP_PROP_POS_FRAMES sampled before the read, exact).
+            meta['src_seconds'] - the frame's position WITHIN the source, in seconds: src_frame / container fps
+                (nominal CFR timeline; see VideoReader._cap_read for the VFR position), or CAP_PROP_POS_MSEC when the
+                container reports no frame rate. This is a source offset, not the wall-clock meta['ts'] nor the raw
+                container PTS. Omitted when neither is trustworthy - src_frame is then still present and exact.
 
-        With `loop`, the cap is reopened each pass, so src_frame and pts_s restart at 0 every loop (they are the
+        With `loop`, the cap is reopened each pass, so src_frame and src_seconds restart at 0 every loop (they are the
         position WITHIN the file) while meta['id'] keeps counting across passes: a looped timeline is non-monotonic
-        in src_frame/pts_s but monotonic in id, so consumers indexing a looped source must key off id, not src_frame.
+        in src_frame/src_seconds but monotonic in id, so consumers indexing a looped source must key off id, not src_frame.
 
         Stream and webcam sources have no meaningful decoder position: both keys are absent, all other meta unchanged.
 
@@ -834,7 +835,7 @@ class VideoIn(Filter):
                     meta['src_frame'] = extras['frame_n']
 
                     if (pts_s := extras.get('pts_s')) is not None:
-                        meta['pts_s'] = pts_s
+                        meta['src_seconds'] = pts_s
 
                 return meta
 

--- a/tests/test_filter_video_in.py
+++ b/tests/test_filter_video_in.py
@@ -151,7 +151,7 @@ class TestVideoIn(unittest.TestCase):
 
 
     def test_pts(self):
-        """File sources stamp the decoder presentation timestamp (pts_s) and the
+        """File sources stamp the source position in seconds (src_seconds) and the
         0-based source frame index (src_frame) into each frame's meta, so
         downstream consumers get the video offset without guessing it from the
         frame counter and an assumed frame rate (`ts` is wall-clock, not video
@@ -176,7 +176,7 @@ class TestVideoIn(unittest.TestCase):
             self.assertEqual(len(metas), 3)
             self.assertEqual([m['src_frame'] for m in metas], [0, 1, 2])
 
-            ptss = [m['pts_s'] for m in metas]
+            ptss = [m['src_seconds'] for m in metas]
 
             for pts in ptss:
                 self.assertIsInstance(pts, float)
@@ -278,7 +278,7 @@ class TestVideoIn(unittest.TestCase):
 
     def test_pts_non_file_unchanged(self):
         """Non-file sources: _cap_read() delegates to cap.read() untouched and extras
-        stays {} - the only source of pts_s / src_frame - so stream/webcam meta cannot
+        stays {} - the only source of src_seconds / src_frame - so stream/webcam meta cannot
         gain the keys."""
         vid = self._reader_with_fake_cap([0.0, 40.0])
 
@@ -386,7 +386,7 @@ class TestVideoIn(unittest.TestCase):
 
 
     def test_loop_pts_restarts_per_pass(self):
-        """With loop, the cap is reopened each pass so src_frame/pts_s restart at 0
+        """With loop, the cap is reopened each pass so src_frame/src_seconds restart at 0
         every loop (position WITHIN the file), while meta['id'] keeps counting: the
         looped timeline is non-monotonic in src_frame but monotonic in id."""
         runner = Filter.Runner([
@@ -413,7 +413,7 @@ class TestVideoIn(unittest.TestCase):
             self.assertEqual(ids, sorted(ids))  # monotonic across passes
             self.assertEqual(len(set(ids)), len(ids))  # strictly increasing, keeps counting
 
-            self.assertEqual([m['pts_s'] for m in metas], [m['pts_s'] for m in metas[:3]] * 2)  # pts restarts too
+            self.assertEqual([m['src_seconds'] for m in metas], [m['src_seconds'] for m in metas[:3]] * 2)  # src_seconds restarts too
 
         finally:
             runner.stop()


### PR DESCRIPTION
## What

Renames the `VideoIn` file-source frame-meta key `pts_s` → **`src_seconds`**.

## Why

The key introduced in v1.2.0 (#128) was named after the container PTS, but the value it
carries is the frame's **position within the source, in seconds** — `src_frame / fps` on the
CFR path (a nominal timeline), or `CAP_PROP_POS_MSEC / 1000` on the fallback. It is a *source
offset*: not the raw container PTS, and not the wall-clock `meta['ts']`. `src_seconds` names
what it is.

This lands now, on purpose: v1.2.0 is only days old and no consumer reads the key yet, so the
honest name costs nothing. A later window would make it a real breaking change.

## Scope

- Only the **emitted frame-meta field** is renamed. `meta['pts_s']` → `meta['src_seconds']`.
- **`src_frame` is unchanged.**
- The reader-level `VideoReader` / `extras` dict still carries the decoder value under `pts_s`
  (a codec term at that layer) — this mirrors the existing boundary rename
  `extras['frame_n']` → `meta['src_frame']`. A layering note was added to the design doc.
- Consumers reading `meta['pts_s']` must switch to `meta['src_seconds']` (documented under
  `### Changed`).

## Testing

`tests/test_filter_video_in.py` — 19 passed (+4 subtests). Meta-level assertions now read
`src_seconds`; reader-level `extras` assertions are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789342342&installation_model_id=20112&pr_number=154&repository=PlainsightAI%2Fopenfilter&return_to=https%3A%2F%2Fgithub.com%2FPlainsightAI%2Fopenfilter%2Fpull%2F154&signature=93719d9bb05754ece2076fab7b93dc0062d5c8eee9ba061692fc4c460f8b1ef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->