### PR TITLE
ci: exclude the Lob detector from the TruffleHog secret scan (false positives)

### DIFF
--- a/.github/workflows/sast-secrets.yml
+++ b/.github/workflows/sast-secrets.yml
@@ -44,5 +44,10 @@ jobs:
       - name: TruffleHog (verified secrets only)
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
-          extra_args: --only-verified
+          # Exclude the Lob detector: it matches any `test_<word>` string (Lob test keys are
+          # `test_<hex>`) and "verifies" it against Lob's permissive test API, so Python test
+          # names in git history (e.g. `test_single_file_without_image_extension`) are reported as
+          # verified secrets. openfilter has no Lob (mail/address API) integration, so the detector
+          # is pure false-positive noise here.
+          extra_args: --only-verified --exclude-detectors=lob
           version: "3.95.9"


### PR DESCRIPTION
## Problem

The scheduled **SAST and Secret Scan** on `main` fails on "verified Lob result" findings ([example run](https://github.com/PlainsightAI/openfilter/actions/runs/32002403920)) — **false positives**, not a real leak.

TruffleHog's **Lob** detector matches any `test_<word>` string (real Lob test keys are `test_<hex>`) and "verifies" it against Lob's permissive test API, which validates almost any `test_*` value. The secret scan walks the full repo including `.git/` history, so Python **test names** in history get flagged as verified secrets, e.g.:
- `test_single_file_without_image_extension`
- `test_observability_client_build_exporter`

They are not present in the working tree (`git grep` finds nothing) — only in old objects/reflog — and they are not hex, so they are unambiguously test identifiers, not Lob keys.

## Fix

openfilter has no Lob (mail/address API) integration, so the Lob detector is pure false-positive noise. Exclude it:

```yaml
extra_args: --only-verified --exclude-detectors=lob
```

No other detector is affected; verified-secrets-only scanning is otherwise unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789592401&installation_model_id=20112&pr_number=156&repository=PlainsightAI%2Fopenfilter&return_to=https%3A%2F%2Fgithub.com%2FPlainsightAI%2Fopenfilter%2Fpull%2F156&signature=ec4c7eadcd1b788971db023db796b1ece8699150adced6193ed35345cc3f3223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->