### PR TITLE
feat(video-in): apply maxfps from the source timeline, not the wall clock

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ OpenFilter Library release notes
   a `file://` source the reader sleeps and an hour of recording costs an hour of wall clock
   however fast the machine is. The new `maxfps_by_index` config (env `FILTER_MAXFPS_BY_INDEX`
   / `VIDEO_IN_MAXFPS_BY_INDEX`, or `!maxfps_by_index` on a source string) keeps 1 frame in
-  every `round(fps / maxfps)` and reads as fast as the decoder allows. Off by default, and it
+  every `ceil(fps / maxfps)` and reads as fast as the decoder allows. Off by default, and it
   only engages for a file whose own rate is above `maxfps`, so existing behaviour is
   unchanged. Selecting from the source timeline is also exact, where selecting against the
   wall clock is not. On a detection chain running an hour of 30 fps video at 5 fps this is

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,9 @@ OpenFilter Library release notes
   preserved; it also no-ops on a container that reports no real rate (the >= 1000 fps VFR
   sentinel). Selecting from the source timeline is also exact, where selecting against the
   wall clock is not. On a detection chain running an hour of 30 fps video at 5 fps this is
-  the difference between about 60 minutes and 16 minutes, with the same frames analysed.
+  the difference between about 60 minutes and 16 minutes, with the same frames analysed. On a
+  directory source the gate runs per file, so members that report different rates each get
+  their own stride and their own selection starting at that file's index 0.
 - **`VideoIn` support for directory-based sequential video playback.**
   Users can now pass a directory of video files as a source (e.g. `file:///path/to/folder`).
   The video files inside are sorted alphabetically and played sequentially. Includes full

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,9 +11,11 @@ OpenFilter Library release notes
   a `file://` source the reader sleeps and an hour of recording costs an hour of wall clock
   however fast the machine is. The new `maxfps_by_index` config (env `FILTER_MAXFPS_BY_INDEX`
   / `VIDEO_IN_MAXFPS_BY_INDEX`, or `!maxfps_by_index` on a source string) keeps 1 frame in
-  every `ceil(fps / maxfps)` and reads as fast as the decoder allows. Off by default, and it
-  only engages for a file whose own rate is above `maxfps`, so existing behaviour is
-  unchanged. Selecting from the source timeline is also exact, where selecting against the
+  every `ceil(fps / maxfps)` and reads as fast as the decoder allows. Off by default, it is a
+  `sync=False` optimisation: it engages only for a `sync=False` file whose own rate is above
+  `maxfps`. Under `sync=True` it is a no-op, so that mode's documented no-skip guarantee is
+  preserved; it also no-ops on a container that reports no real rate (the >= 1000 fps VFR
+  sentinel). Selecting from the source timeline is also exact, where selecting against the
   wall clock is not. On a detection chain running an hour of 30 fps video at 5 fps this is
   the difference between about 60 minutes and 16 minutes, with the same frames analysed.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,19 @@ OpenFilter Library release notes
 
 ## [Unreleased]
 
+### Added
+
+- **`VideoIn`: `maxfps_by_index` to apply `maxfps` from the source timeline instead of the
+  wall clock.** `maxfps` limits how many frames are delivered per second of real time, so on
+  a `file://` source the reader sleeps and an hour of recording costs an hour of wall clock
+  however fast the machine is. The new `maxfps_by_index` config (env `FILTER_MAXFPS_BY_INDEX`
+  / `VIDEO_IN_MAXFPS_BY_INDEX`, or `!maxfps_by_index` on a source string) keeps 1 frame in
+  every `round(fps / maxfps)` and reads as fast as the decoder allows. Off by default, and it
+  only engages for a file whose own rate is above `maxfps`, so existing behaviour is
+  unchanged. Selecting from the source timeline is also exact, where selecting against the
+  wall clock is not. On a detection chain running an hour of 30 fps video at 5 fps this is
+  the difference between about 60 minutes and 16 minutes, with the same frames analysed.
+
 ## v1.3.0 - 2026-08-17
 
 ### Added

--- a/docs/video-in-filter.md
+++ b/docs/video-in-filter.md
@@ -73,6 +73,7 @@ export FILTER_BGR="true"
 export FILTER_SYNC="true"
 export FILTER_LOOP="true"
 export FILTER_MAXFPS="30"
+export FILTER_MAXFPS_BY_INDEX="false"
 export FILTER_MAXSIZE="1920x1080"
 export FILTER_RESIZE="800x600"
 ```
@@ -742,5 +743,6 @@ class VideoIn(Filter):
 - `FILTER_SYNC`: Enable synchronization
 - `FILTER_LOOP`: Enable video looping
 - `FILTER_MAXFPS`: Maximum frame rate
+- `FILTER_MAXFPS_BY_INDEX`: Apply `maxfps` from the source timeline instead of the wall clock (`sync=False` files only; reads as fast as the decoder allows). Off by default
 - `FILTER_MAXSIZE`: Maximum image size
 - `FILTER_RESIZE`: Image resize dimensions

--- a/docs/video-in-filter.md
+++ b/docs/video-in-filter.md
@@ -773,7 +773,7 @@ class VideoIn(Filter):
 - `FILTER_SYNC`: Enable synchronization
 - `FILTER_LOOP`: Enable video looping
 - `FILTER_MAXFPS`: Maximum frame rate
-- `FILTER_MAXFPS_BY_INDEX`: Apply `maxfps` from the source timeline instead of the wall clock (`sync=False` files only; reads as fast as the decoder allows). Off by default
+- `FILTER_MAXFPS_BY_INDEX`: Apply `maxfps` from the source timeline instead of the wall clock (`sync=False` files only; reads as fast as the decoder allows). On a directory source it is gated per file, so members with different frame rates each get their own stride. Off by default
 - `FILTER_MAXSIZE`: Maximum image size
 - `FILTER_RESIZE`: Image resize dimensions
 - `FILTER_PATTERN`: Glob/wildcard pattern for directory video files

--- a/openfilter/filter_runtime/filters/video_in.py
+++ b/openfilter/filter_runtime/filters/video_in.py
@@ -312,12 +312,17 @@ class VideoReader:
         # _cap_read rejects as bogus): a stride derived from it would drop nearly every frame.
         by_index = VIDEO_IN_MAXFPS_BY_INDEX if maxfps_by_index is None else maxfps_by_index
 
-        if by_index and is_file and not sync and maxfps and fps and fps < FPS_SANE_CEILING and fps > maxfps:
+        # Kept so the gate can run again per file: a directory source opens members with
+        # their own rates, and each has to be gated on its own fps (see _open_dir_file).
+        self._by_index = by_index
+        self._sync     = bool(sync)
+
+        if self._by_index_stride_for(fps) is not None:
             # ceil, not round: round picks the nearest stride and banker's-rounds 2.5 -> 2,
             # which lets the by-index rate exceed maxfps (e.g. 25 fps / maxfps 10 -> stride 2
             # -> 12.5 fps). ceil keeps the effective rate at or below the cap for every ratio,
             # matching the wall-clock path (fps > maxfps here already guarantees stride >= 2).
-            self.index_stride  = math.ceil(fps / maxfps)
+            self.index_stride  = self._by_index_stride_for(fps)
             self.ns_per_fps    = None
             self.ns_per_maxfps = None
 
@@ -434,6 +439,20 @@ class VideoReader:
 
         return ret, image
 
+    def _by_index_stride_for(self, fps):
+        """The by-index stride for a file reporting ``fps``, or None if the gate declines it.
+
+        Shared by __init__ and _open_dir_file so that every member of a directory source is
+        gated exactly the way a lone file is: the stride is derived from THAT file's rate.
+        """
+        maxfps = self.maxfps
+
+        if (self._by_index and self.is_file and not self._sync and maxfps and fps
+                and fps < FPS_SANE_CEILING and fps > maxfps):
+            return math.ceil(fps / maxfps)
+
+        return None
+
     def _open_dir_file(self, index: int):
         self.dir_index = index
         active_source = self.dir_files[index]
@@ -450,6 +469,45 @@ class VideoReader:
         if self.maxfps is not None and fps is not None and fps > self.maxfps:
             if not self.is_file or not self.sync_evt:
                 self.fps = self.maxfps
+
+        # A directory's members can each report their own rate, so re-run the by-index gate
+        # for this file instead of carrying dir_files[0]'s decision for the whole directory:
+        # the stride is ceil(fps / maxfps) of THIS file, and a file the gate declines falls
+        # back to the wall-clock pacing it would have had on its own. Without this a 30 fps
+        # file followed by a 60 fps one keeps stride 6 throughout and the second file is
+        # delivered at 10 fps under maxfps=5.
+        #
+        # The sync_evt handshake, once created, is never torn down: the consumer side holds a
+        # reference to it, so swapping it back to None mid-stream would strand a reader waiting
+        # on the old event. Leaving it in place only adds back-pressure, which is harmless on
+        # the files the gate declines.
+        if (stride := self._by_index_stride_for(fps)) is not None:
+            if stride != self.index_stride:
+                logger.info(f'maxfps by index: keeping 1 frame in every {stride} of '
+                            f'{fps:.1f} fps -> {fps / stride:.2f} fps effective ({active_source})')
+
+            self.index_stride  = stride
+            self.ns_per_fps    = None
+            self.ns_per_maxfps = None
+
+            if self.sync_evt is None:  # by-index needs the handshake, see the __init__ gate
+                self.sync_evt = Event()
+
+                self.sync_evt.set()
+
+        else:
+            if self.index_stride is not None:
+                logger.info(f'maxfps by index not engaged for {active_source} '
+                            f'({"no fixed rate" if fps is None else f"{fps:.1f} fps"}); '
+                            f'maxfps applied on the wall clock instead')
+
+            self.index_stride  = None
+            self.ns_per_maxfps = None if self.maxfps is None else 1_000_000_000 // self.maxfps
+
+        # by-index counts source frames, so restart the count with every file: each member of
+        # a directory selects from its own index 0, on the first pass and on every loop pass.
+        # Same reason as the reset next to the VideoCapture reopen in read_one.
+        self.frame_i = 0
 
         if not self.sync_evt:
             self.ns_per_fps = 1_000_000_000 // (self.native_fps or 15)

--- a/openfilter/filter_runtime/filters/video_in.py
+++ b/openfilter/filter_runtime/filters/video_in.py
@@ -241,8 +241,9 @@ class VideoReader:
         # path untouched rather than silently subsampling it. It also no-ops when fps is the
         # >= FPS_SANE_CEILING sentinel a VFR container reports for no real rate (the value
         # _cap_read rejects as bogus): a stride derived from it would drop nearly every frame.
-        if (VIDEO_IN_MAXFPS_BY_INDEX if maxfps_by_index is None else maxfps_by_index) \
-                and is_file and not sync and maxfps and fps and fps < FPS_SANE_CEILING and fps > maxfps:
+        by_index = VIDEO_IN_MAXFPS_BY_INDEX if maxfps_by_index is None else maxfps_by_index
+
+        if by_index and is_file and not sync and maxfps and fps and fps < FPS_SANE_CEILING and fps > maxfps:
             # ceil, not round: round picks the nearest stride and banker's-rounds 2.5 -> 2,
             # which lets the by-index rate exceed maxfps (e.g. 25 fps / maxfps 10 -> stride 2
             # -> 12.5 fps). ceil keeps the effective rate at or below the cap for every ratio,
@@ -261,6 +262,18 @@ class VideoReader:
 
             logger.info(f'maxfps by index: keeping 1 frame in every {self.index_stride} '
                         f'of {fps:.1f} fps -> {fps / self.index_stride:.2f} fps effective')
+
+        # The two no-op paths that would otherwise be silent: by-index was asked for on a file
+        # whose rate is above maxfps (so it would have engaged), but sync is on or the reported
+        # rate is the >= FPS_SANE_CEILING sentinel. An operator setting FILTER_MAXFPS_BY_INDEX
+        # fleet-wide gets no speedup on those pipelines, so say why. NOT logged for fps <= maxfps,
+        # which is a legitimate, frequent no-op and would just be noise.
+        elif by_index and is_file and maxfps and fps and fps > maxfps and (sync or fps >= FPS_SANE_CEILING):
+            reason = ('sync is on, its no-skip guarantee is preserved' if sync else
+                      f'the source reports no real frame rate ({fps:.0f} fps sentinel)')
+
+            logger.info(f'maxfps by index requested but not engaged ({reason}); '
+                        f'maxfps {maxfps:.1f} applied on the wall clock instead')
 
         if fps is None:
             logger.warning(f'video does not have fixed framerate {self.source!r}{"" if maxfps is None else ", maxfps ignored"}')

--- a/openfilter/filter_runtime/filters/video_in.py
+++ b/openfilter/filter_runtime/filters/video_in.py
@@ -25,6 +25,7 @@ VIDEO_IN_BGR      = bool(json_getval((os.getenv('VIDEO_IN_BGR') or os.getenv('FI
 VIDEO_IN_SYNC     = bool(json_getval((os.getenv('VIDEO_IN_SYNC') or os.getenv('FILTER_SYNC') or 'false').lower()))
 VIDEO_IN_LOOP     = _ if isinstance(_ := json_getval((os.getenv('VIDEO_IN_LOOP') or os.getenv('FILTER_LOOP') or 'false').lower()), bool) else int(_)
 VIDEO_IN_MAXFPS   = None if (_ := json_getval((os.getenv('VIDEO_IN_MAXFPS') or os.getenv('FILTER_MAXFPS') or 'null').lower())) is None else float(_)
+VIDEO_IN_MAXFPS_BY_INDEX = bool(json_getval((os.getenv('VIDEO_IN_MAXFPS_BY_INDEX') or os.getenv('FILTER_MAXFPS_BY_INDEX') or 'false').lower()))
 VIDEO_IN_MAXSIZE  = os.getenv('VIDEO_IN_MAXSIZE') or os.getenv('FILTER_MAXSIZE') or None
 VIDEO_IN_RESIZE   = os.getenv('VIDEO_IN_RESIZE') or os.getenv('FILTER_RESIZE') or None
 
@@ -130,6 +131,7 @@ class VideoReader:
         sync:    bool | None = None,
         loop:    bool | int = False,
         maxfps:  float | None = None,
+        maxfps_by_index: bool | None = None,
         maxsize: str | None = None,
         resize:  str | None = None,
         region:  str | None = None,
@@ -173,6 +175,8 @@ class VideoReader:
         self.sync_evt      = None  # this is set only for file fideo with 'sync' option True
         self.ns_per_fps    = None  # this is set only for file video with 'sync' option False
         self.ns_per_maxfps = None if maxfps is None else 1_000_000_000 // maxfps
+        self.index_stride  = None  # set only for file video when maxfps is applied by source index
+        self.frame_i       = 0
         self.is_file       = is_file = is_video_file(source) or is_video_s3(source)
         self.as_bgr        = bool(VIDEO_IN_BGR if bgr is None else bgr)  # only validated after first frame is read (set to False if frames are grayscale)
 
@@ -222,6 +226,22 @@ class VideoReader:
             self.ns_per_fps = 1_000_000_000 // (fps or 15)  # cv2 reads files as fast as possible, this is to keep it realtime, default to 15 if video doesn't provide fixed framerate
 
         self.fps = fps
+
+        # maxfps normally means "N frames per second of WALL CLOCK": the reader either
+        # sleeps (sync) or paces to the container rate (no-sync), so an hour of file costs
+        # an hour however fast the machine is. For offline processing what is wanted is the
+        # same selection taken from the source timeline and read as fast as the box allows.
+        # Opt in with maxfps_by_index: the reader keeps 1 frame in every round(fps/maxfps)
+        # and both clock paths are switched off. Which frames are selected is unchanged in
+        # steady state, they are just no longer spread over real time.
+        if (VIDEO_IN_MAXFPS_BY_INDEX if maxfps_by_index is None else maxfps_by_index) \
+                and is_file and maxfps and fps and fps > maxfps:
+            self.index_stride  = max(1, round(fps / maxfps))
+            self.ns_per_fps    = None
+            self.ns_per_maxfps = None
+
+            logger.info(f'maxfps by index: keeping 1 frame in every {self.index_stride} '
+                        f'of {fps:.1f} fps -> {fps / self.index_stride:.2f} fps effective')
 
         if fps is None:
             logger.warning(f'video does not have fixed framerate {self.source!r}{"" if maxfps is None else ", maxfps ignored"}')
@@ -316,6 +336,18 @@ class VideoReader:
     def read_one(self):
         def wait() -> bool:  # returns if should return frame or keep looping
             t = time_ns()
+
+            if (stride := self.index_stride) is not None:
+                self.frame_i += 1
+
+                if (self.frame_i - 1) % stride:  # dropped: no back-pressure wait, no sleep
+                    return False
+
+                if (sync_evt := self.sync_evt) is not None:
+                    sync_evt.wait()
+                    sync_evt.clear()
+
+                return True
 
             if self.is_file:
                 if (sync_evt := self.sync_evt) is not None:
@@ -604,6 +636,7 @@ class VideoInConfig(FilterConfig):
             sync:       bool | None
             loop:       bool | int | None
             maxfps:     float | None
+            maxfps_by_index: bool | None
             maxsize:    str | None
             resize:     str | None
             region:     str | None
@@ -620,6 +653,7 @@ class VideoInConfig(FilterConfig):
     sync:    bool | None
     loop:    bool | int | None
     maxfps:  float | None
+    maxfps_by_index: bool | None
     maxsize: str | None
     resize:  str | None
 
@@ -669,6 +703,9 @@ class VideoIn(Filter):
                 '!maxfps=10':
                     Set `maxfps` option for this source.
 
+                '!maxfps_by_index', '!no-maxfps_by_index':
+                    Set `maxfps_by_index` option for this source.
+
                 '!maxsize=1280x720', '!maxsize=1280+720C':
                     Set `maxsize` option for this source.
 
@@ -707,6 +744,13 @@ class VideoIn(Filter):
             Restrict video to this FPS. Works for all types of video and if playing a file:// video in `sync` mode then
             will present the individual frames at this frame rate but will not skip any frames. Set here to apply to
             all sources or can be set individually per source. Global env var default FILTER_MAXFPS / VIDEO_IN_MAXFPS.
+
+        maxfps_by_index:
+            Only has meaning for file:// sources with `maxfps` set below the file's own rate. Off by default, in which
+            case `maxfps` behaves as it always has: a limit on frames delivered per second of WALL CLOCK, so an hour of
+            file takes an hour of wall clock however fast the machine is. Turned on, the same selection is taken from
+            the source timeline instead, keeping 1 frame in every round(fps / maxfps) and reading as fast as the box
+            allows. Use it for offline processing of a recording; leave it off for anything that has to track real time.
 
         maxsize:
             Maximum image size to allow, above this will be resized down. Valid codes are 'WxH' which will
@@ -748,6 +792,7 @@ class VideoIn(Filter):
         FILTER_SYNC     / VIDEO_IN_SYNC
         FILTER_LOOP     / VIDEO_IN_LOOP
         FILTER_MAXFPS   / VIDEO_IN_MAXFPS
+        FILTER_MAXFPS_BY_INDEX / VIDEO_IN_MAXFPS_BY_INDEX
         FILTER_MAXSIZE  / VIDEO_IN_MAXSIZE
         FILTER_RESIZE   / VIDEO_IN_RESIZE
 
@@ -796,7 +841,7 @@ class VideoIn(Filter):
                 source.topic = 'main'
             if not isinstance(options := source.options, VideoInConfig.Source.Options):
                 source.options = options = VideoInConfig.Source.Options() if options is None else VideoInConfig.Source.Options(options)
-            if any((option := o) not in ('bgr', 'sync', 'loop', 'maxfps', 'maxsize', 'resize', 'region', 'expiration') for o in options):
+            if any((option := o) not in ('bgr', 'sync', 'loop', 'maxfps', 'maxfps_by_index', 'maxsize', 'resize', 'region', 'expiration') for o in options):
                 raise ValueError(f'unknown option {option!r} in {source!r}')
 
         if len(set(source.topic for source in sources)) != len(sources):
@@ -820,7 +865,7 @@ class VideoIn(Filter):
             optionss.append(source.options or {})
 
         default_options      = {'bgr': config.bgr, 'sync': config.sync, 'loop': config.loop, 'maxfps': config.maxfps,
-            'maxsize': config.maxsize, 'resize': config.resize}
+            'maxfps_by_index': config.maxfps_by_index, 'maxsize': config.maxsize, 'resize': config.resize}
         self.mvreader        = MultiVideoReader(vsources, [{**default_options, **options} for options in optionss])
         self.tops_n_vids     = tuple(zip(topics, self.mvreader.videos))
         self.id              = -1  # frame id

--- a/openfilter/filter_runtime/filters/video_in.py
+++ b/openfilter/filter_runtime/filters/video_in.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import os
 import re
 from threading import Condition, Event, Thread
@@ -231,14 +232,26 @@ class VideoReader:
         # sleeps (sync) or paces to the container rate (no-sync), so an hour of file costs
         # an hour however fast the machine is. For offline processing what is wanted is the
         # same selection taken from the source timeline and read as fast as the box allows.
-        # Opt in with maxfps_by_index: the reader keeps 1 frame in every round(fps/maxfps)
+        # Opt in with maxfps_by_index: the reader keeps 1 frame in every ceil(fps/maxfps)
         # and both clock paths are switched off. Which frames are selected is unchanged in
         # steady state, they are just no longer spread over real time.
         if (VIDEO_IN_MAXFPS_BY_INDEX if maxfps_by_index is None else maxfps_by_index) \
                 and is_file and maxfps and fps and fps > maxfps:
-            self.index_stride  = max(1, round(fps / maxfps))
+            # ceil, not round: round picks the nearest stride and banker's-rounds 2.5 -> 2,
+            # which lets the by-index rate exceed maxfps (e.g. 25 fps / maxfps 10 -> stride 2
+            # -> 12.5 fps). ceil keeps the effective rate at or below the cap for every ratio,
+            # matching the wall-clock path (fps > maxfps here already guarantees stride >= 2).
+            self.index_stride  = math.ceil(fps / maxfps)
             self.ns_per_fps    = None
             self.ns_per_maxfps = None
+
+            # By-index switches off both clock paths, which are also the only back-pressure
+            # against the reader outrunning the consumer. Without the sync_evt handshake the
+            # reader decodes flat out into the 1-slot deque and overwrites selected frames
+            # before they are popped, so create it here even when sync is off.
+            if self.sync_evt is None:
+                self.sync_evt = Event()
+                self.sync_evt.set()
 
             logger.info(f'maxfps by index: keeping 1 frame in every {self.index_stride} '
                         f'of {fps:.1f} fps -> {fps / self.index_stride:.2f} fps effective')
@@ -334,14 +347,20 @@ class VideoReader:
         return ret, image
 
     def read_one(self):
-        def wait() -> bool:  # returns if should return frame or keep looping
+        def wait(is_eof=False) -> bool:  # returns if should return frame or keep looping
             t = time_ns()
 
             if (stride := self.index_stride) is not None:
-                self.frame_i += 1
+                # At EOF the caller wants the last real frame held for the consumer, not a
+                # by-index decision. Skip the stride test (the phantom EOF index is off-stride
+                # (stride-1)/stride of the time) and go straight to the handshake, otherwise the
+                # (None, ...) sentinel evicts the last frame from the 1-slot deque before it is
+                # popped.
+                if not is_eof:
+                    self.frame_i += 1
 
-                if (self.frame_i - 1) % stride:  # dropped: no back-pressure wait, no sleep
-                    return False
+                    if (self.frame_i - 1) % stride:  # dropped: no back-pressure wait, no sleep
+                        return False
 
                 if (sync_evt := self.sync_evt) is not None:
                     sync_evt.wait()
@@ -396,7 +415,7 @@ class VideoReader:
                     self.loop = loop - 1
 
                     if not self.loop:
-                        wait()
+                        wait(is_eof=True)
 
                         return None
 
@@ -409,7 +428,7 @@ class VideoReader:
                         raise RuntimeError(f'failed to reopen video source: {self.source!r}')
 
                 except Exception:
-                    wait()
+                    wait(is_eof=True)
 
                     return None
 
@@ -749,7 +768,7 @@ class VideoIn(Filter):
             Only has meaning for file:// sources with `maxfps` set below the file's own rate. Off by default, in which
             case `maxfps` behaves as it always has: a limit on frames delivered per second of WALL CLOCK, so an hour of
             file takes an hour of wall clock however fast the machine is. Turned on, the same selection is taken from
-            the source timeline instead, keeping 1 frame in every round(fps / maxfps) and reading as fast as the box
+            the source timeline instead, keeping 1 frame in every ceil(fps / maxfps) and reading as fast as the box
             allows. Use it for offline processing of a recording; leave it off for anything that has to track real time.
 
         maxsize:

--- a/openfilter/filter_runtime/filters/video_in.py
+++ b/openfilter/filter_runtime/filters/video_in.py
@@ -173,7 +173,7 @@ class VideoReader:
         self.maxsize       = None if (s := VIDEO_IN_MAXSIZE if maxsize is None else maxsize) is None else parse_size(s)
         self.resize        = None if (s := VIDEO_IN_RESIZE if resize is None else resize) is None else parse_size(s)
         self.state         = 0     # 0 = before start, 1 = playing, 2 = stopped / done
-        self.sync_evt      = None  # file video only: set for 'sync' True, and also for 'sync' False when index_stride is set (by-index needs the back-pressure), so this being set does NOT imply sync is on
+        self.sync_evt      = None  # file video only: set for 'sync' True, and also for 'sync' False when maxfps_by_index engages (by-index needs the back-pressure), so this being set does NOT imply sync is on
         self.ns_per_fps    = None  # this is set only for file video with 'sync' option False
         self.ns_per_maxfps = None if maxfps is None else 1_000_000_000 // maxfps
         self.index_stride  = None  # set only for file video when maxfps is applied by source index
@@ -232,11 +232,17 @@ class VideoReader:
         # sleeps (sync) or paces to the container rate (no-sync), so an hour of file costs
         # an hour however fast the machine is. For offline processing what is wanted is the
         # same selection taken from the source timeline and read as fast as the box allows.
-        # Opt in with maxfps_by_index: the reader keeps 1 frame in every ceil(fps/maxfps)
-        # and both clock paths are switched off. Which frames are selected is unchanged in
-        # steady state, they are just no longer spread over real time.
+        # Opt in with maxfps_by_index: on a sync=False file the reader keeps 1 frame in every
+        # ceil(fps/maxfps) and reads flat out, both clock paths switched off. The selection is
+        # unchanged in steady state, it is just no longer spread over real time.
+        #
+        # It is deliberately a sync=False optimisation. sync=True documents a no-skip contract
+        # ("will not skip any frames"), so by-index no-ops under sync and leaves that paced
+        # path untouched rather than silently subsampling it. It also no-ops when fps is the
+        # >= FPS_SANE_CEILING sentinel a VFR container reports for no real rate (the value
+        # _cap_read rejects as bogus): a stride derived from it would drop nearly every frame.
         if (VIDEO_IN_MAXFPS_BY_INDEX if maxfps_by_index is None else maxfps_by_index) \
-                and is_file and maxfps and fps and fps > maxfps:
+                and is_file and not sync and maxfps and fps and fps < FPS_SANE_CEILING and fps > maxfps:
             # ceil, not round: round picks the nearest stride and banker's-rounds 2.5 -> 2,
             # which lets the by-index rate exceed maxfps (e.g. 25 fps / maxfps 10 -> stride 2
             # -> 12.5 fps). ceil keeps the effective rate at or below the cap for every ratio,
@@ -245,13 +251,13 @@ class VideoReader:
             self.ns_per_fps    = None
             self.ns_per_maxfps = None
 
-            # By-index switches off both clock paths, which are also the only back-pressure
-            # against the reader outrunning the consumer. Without the sync_evt handshake the
-            # reader decodes flat out into the 1-slot deque and overwrites selected frames
-            # before they are popped, so create it here even when sync is off.
-            if self.sync_evt is None:
-                self.sync_evt = Event()
-                self.sync_evt.set()
+            # We only get here under sync=False, which switches off both clock paths - and
+            # those were the only back-pressure against the reader outrunning the consumer.
+            # Without the sync_evt handshake the reader decodes flat out into the 1-slot deque
+            # and overwrites selected frames before they are popped, so give the by-index path
+            # the same handshake sync=True has (sync_evt is None here, never created above).
+            self.sync_evt = Event()
+            self.sync_evt.set()
 
             logger.info(f'maxfps by index: keeping 1 frame in every {self.index_stride} '
                         f'of {fps:.1f} fps -> {fps / self.index_stride:.2f} fps effective')
@@ -262,7 +268,7 @@ class VideoReader:
             fps_str = ''
 
         else:
-            if maxfps is None or fps <= maxfps:  # maxfps is not None implies (not is_file or not sync) because it would have errored otherwise
+            if maxfps is None or fps <= maxfps:
                 fps_str = f'  ({fps:.1f} fps)'
 
             else:
@@ -766,11 +772,14 @@ class VideoIn(Filter):
             all sources or can be set individually per source. Global env var default FILTER_MAXFPS / VIDEO_IN_MAXFPS.
 
         maxfps_by_index:
-            Only has meaning for file:// sources with `maxfps` set below the file's own rate. Off by default, in which
-            case `maxfps` behaves as it always has: a limit on frames delivered per second of WALL CLOCK, so an hour of
-            file takes an hour of wall clock however fast the machine is. Turned on, the same selection is taken from
-            the source timeline instead, keeping 1 frame in every ceil(fps / maxfps) and reading as fast as the box
-            allows. Use it for offline processing of a recording; leave it off for anything that has to track real time.
+            A `sync=False` optimisation, for file:// sources with `maxfps` set below the file's own rate. Off by
+            default, in which case `maxfps` behaves as it always has: a limit on frames delivered per second of WALL
+            CLOCK, so an hour of file takes an hour of wall clock however fast the machine is. Turned on, the same
+            selection is taken from the source timeline instead, keeping 1 frame in every ceil(fps / maxfps) and reading
+            as fast as the box allows. Use it for offline processing of a recording; leave it off for anything that has
+            to track real time. It only engages under `sync=False`: `sync=True` documents a no-skip guarantee ("will not
+            skip any frames"), so with `sync=True` this flag is a no-op and that paced, lossless path is preserved. It
+            is also a no-op on a container that reports no real frame rate (the >= 1000 fps VFR sentinel).
 
         maxsize:
             Maximum image size to allow, above this will be resized down. Valid codes are 'WxH' which will

--- a/openfilter/filter_runtime/filters/video_in.py
+++ b/openfilter/filter_runtime/filters/video_in.py
@@ -173,7 +173,7 @@ class VideoReader:
         self.maxsize       = None if (s := VIDEO_IN_MAXSIZE if maxsize is None else maxsize) is None else parse_size(s)
         self.resize        = None if (s := VIDEO_IN_RESIZE if resize is None else resize) is None else parse_size(s)
         self.state         = 0     # 0 = before start, 1 = playing, 2 = stopped / done
-        self.sync_evt      = None  # this is set only for file fideo with 'sync' option True
+        self.sync_evt      = None  # file video only: set for 'sync' True, and also for 'sync' False when index_stride is set (by-index needs the back-pressure), so this being set does NOT imply sync is on
         self.ns_per_fps    = None  # this is set only for file video with 'sync' option False
         self.ns_per_maxfps = None if maxfps is None else 1_000_000_000 // maxfps
         self.index_stride  = None  # set only for file video when maxfps is applied by source index
@@ -424,6 +424,7 @@ class VideoReader:
 
                     self.cap.release()
                     self.cap = cv2.VideoCapture(self.ssource)
+                    self.frame_i = 0  # by-index counts source frames; restart it with the cap so each pass selects from source index 0
                     if not self.cap.isOpened():
                         raise RuntimeError(f'failed to reopen video source: {self.source!r}')
 

--- a/tests/test_video_in_maxfps_by_index.py
+++ b/tests/test_video_in_maxfps_by_index.py
@@ -14,10 +14,12 @@ import subprocess
 import tempfile
 import unittest
 from time import sleep, time
+from unittest import mock
 
+import cv2
 import numpy as np
 
-from openfilter.filter_runtime.filters.video_in import VideoIn, VideoReader
+from openfilter.filter_runtime.filters.video_in import VideoIn, VideoReader, FPS_SANE_CEILING
 from openfilter.filter_runtime.utils import setLogLevelGlobal
 
 logger = logging.getLogger(__name__)
@@ -64,6 +66,20 @@ def _drain(**kwargs) -> tuple[int, float]:
             vid.stop()
 
 
+def _reader_reporting_fps(path: str, fps: float, **kwargs) -> VideoReader:
+    """Open a real fixture but make cap.get(CAP_PROP_FPS) report `fps` at construction.
+
+    Reproduces a container whose reported rate is the VFR sentinel without having to author
+    one; the patch only spans __init__ (which is where the by-index gate reads the rate)."""
+    real_get = cv2.VideoCapture.get
+
+    def fake_get(self, prop):
+        return fps if prop == cv2.CAP_PROP_FPS else real_get(self, prop)
+
+    with mock.patch.object(cv2.VideoCapture, 'get', fake_get):
+        return VideoReader(f'file://{path}', **kwargs)
+
+
 @unittest.skipUnless(
     subprocess.run(['which', 'ffmpeg'], capture_output=True).returncode == 0,
     'ffmpeg needed to author the fixture',
@@ -81,18 +97,18 @@ class TestMaxfpsByIndex(unittest.TestCase):
         self.assertGreater(elapsed, 2.0, 'default maxfps should still be bound to real time')
 
     def test_by_index_selects_the_same_frames_without_waiting(self):
-        n, elapsed = _drain(sync=True, maxfps=5, maxfps_by_index=True)
+        n, elapsed = _drain(sync=False, maxfps=5, maxfps_by_index=True)
 
         self.assertEqual(n, N_FRAMES // 6, 'by-index is exact: 1 in every 6 of 90')
         self.assertLess(elapsed, 1.5, 'by-index should read as fast as the decoder allows')
 
     def test_by_index_keeps_the_first_frame_and_then_every_stride(self):
-        """The selection is 1 in round(fps / maxfps), starting at the first frame."""
+        """The selection is 1 in ceil(fps / maxfps), starting at the first frame."""
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, 'v.mp4')
             _write_video(path)
 
-            vid = VideoReader(f'file://{path}', sync=True, maxfps=5, maxfps_by_index=True)
+            vid = VideoReader(f'file://{path}', sync=False, maxfps=5, maxfps_by_index=True)
             vid.start()
 
             try:
@@ -114,7 +130,7 @@ class TestMaxfpsByIndex(unittest.TestCase):
             path = os.path.join(d, 'v.mp4')
             _write_video(path)
 
-            vid = VideoReader(f'file://{path}', sync=True, maxfps=60, maxfps_by_index=True)
+            vid = VideoReader(f'file://{path}', sync=False, maxfps=60, maxfps_by_index=True)
 
             try:
                 self.assertIsNone(vid.index_stride)
@@ -161,7 +177,7 @@ class TestMaxfpsByIndex(unittest.TestCase):
             path = os.path.join(d, 'v.mp4')
             _write_video(path, n_frames=91)
 
-            vid = VideoReader(f'file://{path}', sync=True, maxfps=5, maxfps_by_index=True)
+            vid = VideoReader(f'file://{path}', sync=False, maxfps=5, maxfps_by_index=True)
             vid.start()
 
             try:
@@ -190,7 +206,7 @@ class TestMaxfpsByIndex(unittest.TestCase):
             path = os.path.join(d, 'v.mp4')
             _write_video(path, n_frames=92)
 
-            vid = VideoReader(f'file://{path}', sync=True, maxfps=5, maxfps_by_index=True, loop=2)
+            vid = VideoReader(f'file://{path}', sync=False, maxfps=5, maxfps_by_index=True, loop=2)
             vid.start()
 
             try:
@@ -206,6 +222,53 @@ class TestMaxfpsByIndex(unittest.TestCase):
 
         one_pass = list(range(0, 92, 6))  # 0, 6, ..., 90
         self.assertEqual(frame_ns, one_pass + one_pass)  # both passes select from source index 0
+
+    def test_by_index_no_ops_under_sync_preserving_the_no_skip_guarantee(self):
+        """sync=True is documented as "will not skip any frames"; by-index is a sync=False
+        optimisation and must no-op under sync=True. Locks in the reviewer's 181 -> 61 drop:
+        the by-index count must equal the stock sync=True count, never a subsample."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'v.mp4')
+            _write_video(path, n_frames=30)  # 1 s of source, paced at 15/s -> ~2 s per run
+
+            def count(**kwargs):
+                vid = VideoReader(f'file://{path}', **kwargs)
+                vid.start()
+
+                try:
+                    n = 0
+
+                    while vid.read() is not None:
+                        n += 1
+
+                    return n, vid.index_stride
+                finally:
+                    vid.stop()
+
+            stock_n, _         = count(sync=True, maxfps=15)
+            by_index_n, stride = count(sync=True, maxfps=15, maxfps_by_index=True)
+
+        self.assertIsNone(stride, 'by-index must not engage under sync=True')
+        self.assertEqual(by_index_n, stock_n, 'sync=True must never skip: by-index == stock')
+        self.assertEqual(by_index_n, 30, 'all frames delivered under sync=True')
+
+    def test_by_index_no_ops_on_the_fps_sentinel_container(self):
+        """A container reporting the >= FPS_SANE_CEILING VFR sentinel must not drive by-index.
+
+        _cap_read already rejects that rate as bogus; the gate must too, otherwise stride is
+        ceil(1000 / maxfps) = 200 and 99% of the frames are dropped. Guarding the gate makes
+        it fall back to the normal path (index_stride stays None) instead."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'v.mp4')
+            _write_video(path)
+
+            vid = _reader_reporting_fps(path, FPS_SANE_CEILING, sync=False, maxfps=5, maxfps_by_index=True)
+
+            try:
+                self.assertEqual(vid.native_fps, FPS_SANE_CEILING)  # the reported sentinel rate
+                self.assertIsNone(vid.index_stride)                 # by-index no-ops on it
+            finally:
+                vid.cap.release()
 
     def test_option_is_accepted_in_a_source_string(self):
         cfg = VideoIn.normalize_config({

--- a/tests/test_video_in_maxfps_by_index.py
+++ b/tests/test_video_in_maxfps_by_index.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+
+"""maxfps applied from the source timeline instead of from the wall clock.
+
+By default maxfps limits how many frames are delivered per second of real time, so an
+hour of file costs an hour of wall clock no matter how fast the machine is. That is right
+for anything tracking real time and wrong for offline processing of a recording, where
+the same selection should come off the source timeline and be read as fast as possible.
+"""
+
+import logging
+import os
+import subprocess
+import tempfile
+import unittest
+from time import time
+
+import numpy as np
+
+from openfilter.filter_runtime.filters.video_in import VideoIn, VideoReader
+from openfilter.filter_runtime.utils import setLogLevelGlobal
+
+logger = logging.getLogger(__name__)
+setLogLevelGlobal(int(getattr(logging, (os.getenv('LOG_LEVEL') or 'CRITICAL').upper())))
+
+FPS      = 30
+N_FRAMES = 90   # 3 s of source
+
+
+def _write_video(path: str) -> None:
+    """90 distinct frames at 30 fps, via ffmpeg so the container reports a fixed rate."""
+    proc = subprocess.Popen([
+        'ffmpeg', '-loglevel', 'error', '-y',
+        '-f', 'rawvideo', '-pix_fmt', 'bgr24', '-s', '64x64', '-r', str(FPS), '-i', '-',
+        '-c:v', 'libx264', '-pix_fmt', 'yuv420p', path,
+    ], stdin=subprocess.PIPE)
+
+    for i in range(N_FRAMES):
+        proc.stdin.write(np.full((64, 64, 3), i * 2 % 256, dtype=np.uint8).tobytes())
+
+    proc.stdin.close()
+    proc.wait()
+
+
+def _drain(**kwargs) -> tuple[int, float]:
+    """Read a video to exhaustion, returning how many frames came out and how long it took."""
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, 'v.mp4')
+        _write_video(path)
+
+        vid = VideoReader(f'file://{path}', **kwargs)
+        vid.start()
+
+        try:
+            t0 = time()
+            n  = 0
+
+            while vid.read() is not None:
+                n += 1
+
+            return n, time() - t0
+
+        finally:
+            vid.stop()
+
+
+@unittest.skipUnless(
+    subprocess.run(['which', 'ffmpeg'], capture_output=True).returncode == 0,
+    'ffmpeg needed to author the fixture',
+)
+class TestMaxfpsByIndex(unittest.TestCase):
+    def test_off_by_default_so_maxfps_still_paces_the_read(self):
+        """3 s of source capped to 5 fps: about 15 frames, spread over ~3 s of real time.
+
+        The count is approximate on purpose. Selecting against the wall clock cannot be
+        exact, which is the other half of what by-index fixes."""
+        n, elapsed = _drain(sync=False, maxfps=5)
+
+        self.assertGreaterEqual(n, 13)
+        self.assertLessEqual(n, 16)
+        self.assertGreater(elapsed, 2.0, 'default maxfps should still be bound to real time')
+
+    def test_by_index_selects_the_same_frames_without_waiting(self):
+        n, elapsed = _drain(sync=True, maxfps=5, maxfps_by_index=True)
+
+        self.assertEqual(n, N_FRAMES // 6, 'by-index is exact: 1 in every 6 of 90')
+        self.assertLess(elapsed, 1.5, 'by-index should read as fast as the decoder allows')
+
+    def test_by_index_keeps_the_first_frame_and_then_every_stride(self):
+        """The selection is 1 in round(fps / maxfps), starting at the first frame."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'v.mp4')
+            _write_video(path)
+
+            vid = VideoReader(f'file://{path}', sync=True, maxfps=5, maxfps_by_index=True)
+            vid.start()
+
+            try:
+                self.assertEqual(vid.index_stride, 6)
+
+                frame_ns = []
+
+                while (item := vid.read(with_tframe=True)) is not None:
+                    frame_ns.append(item[2]['frame_n'])
+
+            finally:
+                vid.stop()
+
+        self.assertEqual(frame_ns[:4], [0, 6, 12, 18])
+
+    def test_ignored_when_maxfps_is_not_below_the_source_rate(self):
+        """Nothing to drop, so the reader stays on its normal path."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'v.mp4')
+            _write_video(path)
+
+            vid = VideoReader(f'file://{path}', sync=True, maxfps=60, maxfps_by_index=True)
+
+            try:
+                self.assertIsNone(vid.index_stride)
+            finally:
+                vid.stop()
+
+    def test_option_is_accepted_in_a_source_string(self):
+        cfg = VideoIn.normalize_config({
+            'id': 'vidin',
+            'sources': 'file://x.mp4!sync!maxfps=5!maxfps_by_index',
+            'outputs': 'tcp://*',
+        })
+
+        self.assertIs(cfg.sources[0].options.maxfps_by_index, True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_video_in_maxfps_by_index.py
+++ b/tests/test_video_in_maxfps_by_index.py
@@ -179,6 +179,34 @@ class TestMaxfpsByIndex(unittest.TestCase):
 
         self.assertEqual(frame_ns, list(range(0, 91, 6)))  # 0, 6, ..., 90 - the last one kept
 
+    def test_by_index_restarts_at_source_zero_on_each_loop(self):
+        """Each loop pass must restart the by-index phase at source index 0.
+
+        The reopen resets self.cap but has to reset self.frame_i too, otherwise the stride
+        phase carries over and pass two selects from the wrong offset. 92 frames is not a
+        multiple of stride 6, so a carried-over phase shows (pass two would start at frame 4);
+        the 90-frame fixture hides it because 90 % 6 == 0."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'v.mp4')
+            _write_video(path, n_frames=92)
+
+            vid = VideoReader(f'file://{path}', sync=True, maxfps=5, maxfps_by_index=True, loop=2)
+            vid.start()
+
+            try:
+                self.assertEqual(vid.index_stride, 6)
+
+                frame_ns = []
+
+                while (item := vid.read(with_tframe=True)) is not None:
+                    if item[0] is not None:
+                        frame_ns.append(item[2]['frame_n'])
+            finally:
+                vid.stop()
+
+        one_pass = list(range(0, 92, 6))  # 0, 6, ..., 90
+        self.assertEqual(frame_ns, one_pass + one_pass)  # both passes select from source index 0
+
     def test_option_is_accepted_in_a_source_string(self):
         cfg = VideoIn.normalize_config({
             'id': 'vidin',

--- a/tests/test_video_in_maxfps_by_index.py
+++ b/tests/test_video_in_maxfps_by_index.py
@@ -29,11 +29,11 @@ FPS      = 30
 N_FRAMES = 90   # 3 s of source
 
 
-def _write_video(path: str, n_frames: int = N_FRAMES) -> None:
-    """n_frames distinct frames at 30 fps, via ffmpeg so the container reports a fixed rate."""
+def _write_video(path: str, n_frames: int = N_FRAMES, fps: int = FPS) -> None:
+    """n_frames distinct frames at `fps`, via ffmpeg so the container reports a fixed rate."""
     proc = subprocess.Popen([
         'ffmpeg', '-loglevel', 'error', '-y',
-        '-f', 'rawvideo', '-pix_fmt', 'bgr24', '-s', '64x64', '-r', str(FPS), '-i', '-',
+        '-f', 'rawvideo', '-pix_fmt', 'bgr24', '-s', '64x64', '-r', str(fps), '-i', '-',
         '-c:v', 'libx264', '-pix_fmt', 'yuv420p', path,
     ], stdin=subprocess.PIPE)
 
@@ -294,6 +294,79 @@ class TestMaxfpsByIndex(unittest.TestCase):
             with self.assertLogs(_LOGGER, level='INFO') as cm:
                 VideoReader(f'file://{path}', sync=False, maxfps=60, maxfps_by_index=True).cap.release()
             self.assertFalse(any('not engaged' in m for m in cm.output))
+
+    def test_by_index_regates_each_file_of_a_mixed_rate_directory(self):
+        """A directory's members can report different rates, so the stride is per file.
+
+        The gate runs once in __init__ against dir_files[0]; _open_dir_file re-runs it for
+        every subsequent member. Without that the stride of the first file is carried for the
+        whole directory and a faster file is delivered above maxfps: 30 fps then 60 fps at
+        maxfps=5 keeps stride 6 throughout, so the 60 fps file comes out at 10 fps."""
+        with tempfile.TemporaryDirectory() as d:
+            _write_video(os.path.join(d, 'a.mp4'), n_frames=30, fps=30)
+            _write_video(os.path.join(d, 'b.mp4'), n_frames=60, fps=60)
+
+            vid = VideoReader(f'file://{d}', sync=False, maxfps=5, maxfps_by_index=True)
+            vid.start()
+
+            try:
+                self.assertEqual(vid.index_stride, 6)  # from a.mp4, 30 fps
+
+                frame_ns = []
+
+                while (item := vid.read(with_tframe=True)) is not None:
+                    if item[0] is not None:
+                        frame_ns.append(item[2]['frame_n'])
+            finally:
+                vid.stop()
+
+        # a.mp4 at stride 6, then b.mp4 re-gated to stride 12: both land on 5 fps effective.
+        self.assertEqual(frame_ns, list(range(0, 30, 6)) + list(range(0, 60, 12)))
+
+    def test_by_index_restarts_at_source_zero_for_every_file_in_a_directory(self):
+        """The by-index phase must not carry across a directory's file boundaries.
+
+        This is the fe89efe loop-reopen fix on the directory path: _open_dir_file resets
+        frame_i so each member selects from its own index 0, both on the first pass and on
+        every loop pass. The file lengths are deliberately off-stride (10 and 12 against
+        stride 6) so a carried-over phase shows as a shifted start."""
+        with tempfile.TemporaryDirectory() as d:
+            _write_video(os.path.join(d, 'a.mp4'), n_frames=10)
+            _write_video(os.path.join(d, 'b.mp4'), n_frames=12)
+
+            vid = VideoReader(f'file://{d}', sync=False, maxfps=5, maxfps_by_index=True)
+            vid.start()
+
+            try:
+                frame_ns = []
+
+                while (item := vid.read(with_tframe=True)) is not None:
+                    if item[0] is not None:
+                        frame_ns.append(item[2]['frame_n'])
+            finally:
+                vid.stop()
+
+        self.assertEqual(frame_ns, [0, 6, 0, 6])  # b.mp4 starts at its own 0, not at 2
+
+    def test_by_index_restarts_at_source_zero_on_each_directory_loop_pass(self):
+        """Same reset, exercised through the directory loop-restart branch rather than the
+        file-to-file transition: a single-file directory looped twice."""
+        with tempfile.TemporaryDirectory() as d:
+            _write_video(os.path.join(d, 'a.mp4'), n_frames=10)
+
+            vid = VideoReader(f'file://{d}', sync=False, maxfps=5, maxfps_by_index=True, loop=2)
+            vid.start()
+
+            try:
+                frame_ns = []
+
+                while (item := vid.read(with_tframe=True)) is not None:
+                    if item[0] is not None:
+                        frame_ns.append(item[2]['frame_n'])
+            finally:
+                vid.stop()
+
+        self.assertEqual(frame_ns, [0, 6, 0, 6])  # pass two restarts the phase
 
     def test_option_is_accepted_in_a_source_string(self):
         cfg = VideoIn.normalize_config({

--- a/tests/test_video_in_maxfps_by_index.py
+++ b/tests/test_video_in_maxfps_by_index.py
@@ -13,7 +13,7 @@ import os
 import subprocess
 import tempfile
 import unittest
-from time import time
+from time import sleep, time
 
 import numpy as np
 
@@ -27,15 +27,15 @@ FPS      = 30
 N_FRAMES = 90   # 3 s of source
 
 
-def _write_video(path: str) -> None:
-    """90 distinct frames at 30 fps, via ffmpeg so the container reports a fixed rate."""
+def _write_video(path: str, n_frames: int = N_FRAMES) -> None:
+    """n_frames distinct frames at 30 fps, via ffmpeg so the container reports a fixed rate."""
     proc = subprocess.Popen([
         'ffmpeg', '-loglevel', 'error', '-y',
         '-f', 'rawvideo', '-pix_fmt', 'bgr24', '-s', '64x64', '-r', str(FPS), '-i', '-',
         '-c:v', 'libx264', '-pix_fmt', 'yuv420p', path,
     ], stdin=subprocess.PIPE)
 
-    for i in range(N_FRAMES):
+    for i in range(n_frames):
         proc.stdin.write(np.full((64, 64, 3), i * 2 % 256, dtype=np.uint8).tobytes())
 
     proc.stdin.close()
@@ -119,7 +119,65 @@ class TestMaxfpsByIndex(unittest.TestCase):
             try:
                 self.assertIsNone(vid.index_stride)
             finally:
+                vid.cap.release()  # stop() is a no-op without start(); release the cap directly
+
+    def test_by_index_delivers_the_full_selection_with_sync_off_the_default(self):
+        """sync=False (the default) + by-index must still deliver every selected frame.
+
+        By-index switches off both clock paths, which are also the only back-pressure on the
+        reader. Without the sync_evt handshake the reader outruns the 1-slot deque and drops
+        selected frames whenever the consumer is even slightly slow (the reviewer saw 3 of 50).
+        A per-frame sleep here makes that race deterministic."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'v.mp4')
+            _write_video(path)
+
+            vid = VideoReader(f'file://{path}', sync=False, maxfps=5, maxfps_by_index=True)
+            vid.start()
+
+            try:
+                self.assertEqual(vid.index_stride, 6)
+
+                frame_ns = []
+
+                while (item := vid.read(with_tframe=True)) is not None:
+                    if item[0] is not None:
+                        frame_ns.append(item[2]['frame_n'])
+
+                    sleep(0.02)  # a slow-ish consumer, to expose the reader outrunning the deque
+            finally:
                 vid.stop()
+
+        self.assertEqual(frame_ns, list(range(0, N_FRAMES, 6)))  # 0, 6, ..., 84 - none dropped
+
+    def test_by_index_holds_the_last_frame_when_the_eof_index_is_off_stride(self):
+        """The last selected frame must survive even when the phantom EOF index is off-stride.
+
+        read_one calls wait() at EOF to hold the last frame for the consumer; the by-index
+        branch used to return before the handshake when that phantom index was off-stride, so
+        the (None, ...) sentinel evicted the last frame. 91 frames at stride 6 puts the phantom
+        EOF index off-stride ((92 - 1) % 6 != 0), the case the 90-frame fixture hides."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'v.mp4')
+            _write_video(path, n_frames=91)
+
+            vid = VideoReader(f'file://{path}', sync=True, maxfps=5, maxfps_by_index=True)
+            vid.start()
+
+            try:
+                self.assertEqual(vid.index_stride, 6)
+
+                frame_ns = []
+
+                while (item := vid.read(with_tframe=True)) is not None:
+                    if item[0] is not None:
+                        frame_ns.append(item[2]['frame_n'])
+
+                    sleep(0.02)  # slow consumer so a missed handshake would drop the last frame
+            finally:
+                vid.stop()
+
+        self.assertEqual(frame_ns, list(range(0, 91, 6)))  # 0, 6, ..., 90 - the last one kept
 
     def test_option_is_accepted_in_a_source_string(self):
         cfg = VideoIn.normalize_config({

--- a/tests/test_video_in_maxfps_by_index.py
+++ b/tests/test_video_in_maxfps_by_index.py
@@ -270,6 +270,31 @@ class TestMaxfpsByIndex(unittest.TestCase):
             finally:
                 vid.cap.release()
 
+    def test_by_index_logs_the_two_requested_but_no_op_paths(self):
+        """The requested-but-no-op paths must not be silent: an operator who set the flag
+        fleet-wide needs to know why a pipeline got no speedup. Limited to sync=True and the
+        fps sentinel; the frequent, legitimate fps <= maxfps no-op stays quiet."""
+        _LOGGER = 'openfilter.filter_runtime.filters.video_in'
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'v.mp4')
+            _write_video(path)
+
+            # sync=True: requested, would have engaged, but no-skip is preserved
+            with self.assertLogs(_LOGGER, level='INFO') as cm:
+                VideoReader(f'file://{path}', sync=True, maxfps=5, maxfps_by_index=True).cap.release()
+            self.assertTrue(any('not engaged' in m and 'sync is on' in m for m in cm.output))
+
+            # fps sentinel: requested, sync off, but the reported rate is bogus
+            with self.assertLogs(_LOGGER, level='INFO') as cm:
+                _reader_reporting_fps(path, FPS_SANE_CEILING, sync=False, maxfps=5, maxfps_by_index=True).cap.release()
+            self.assertTrue(any('not engaged' in m and 'sentinel' in m for m in cm.output))
+
+            # fps <= maxfps: a legitimate no-op, must stay quiet about by-index
+            with self.assertLogs(_LOGGER, level='INFO') as cm:
+                VideoReader(f'file://{path}', sync=False, maxfps=60, maxfps_by_index=True).cap.release()
+            self.assertFalse(any('not engaged' in m for m in cm.output))
+
     def test_option_is_accepted_in_a_source_string(self):
         cfg = VideoIn.normalize_config({
             'id': 'vidin',


### PR DESCRIPTION
## What

`maxfps` limits how many frames are delivered per second of **wall clock**. On a `file://` source that means the reader sleeps, so an hour of recording costs an hour of wall clock however fast the machine is.

This adds `maxfps_by_index`, off by default, a `sync=False` optimisation that applies the same limit from the **source timeline** instead: keep 1 frame in every `ceil(fps / maxfps)` and read as fast as the decoder allows.

## Why

Measured on a raw 180 s clip at 30 fps with `maxfps=5`, stock:

| mode | frames delivered | wall clock |
| --- | --- | --- |
| `!no-sync!maxfps=5` | 900 of 5400 | 190 s |
| `!sync!maxfps=5` | 310 in the first 60 s, still running | paced at 5/s |

The **selection is already correct**, 900 is exactly a 5 fps sampling of that clip. What is not right for offline work is that it is spread over real time. Neither mode lets you read a recording faster than it was recorded.

That is the correct behaviour for a source tracking real time. It is the wrong one for processing a recording, which is what our detection pipelines do.

With the flag on, the same probe drops from 190 s to 17 s.

End to end on a full RTX PRO 6000, one hour of 30 fps video (108000 frames) through video-in, frame-dedup, a detector, colour and captioning at 5 fps:

| | wall clock |
| --- | --- |
| stock | ~60 min, bound by the file clock |
| `maxfps_by_index` | **16.0 min**, bound by the chain |

Same 3104 frames survive dedup either way, so nothing about what gets analysed changes. Verified independently by doing the same sampling in the downstream filter instead, which produced the identical 3104 and took 24.9 min because the discarded frames still had to cross the process boundary.

## What changes for existing users

Nothing unless they opt in. Default is off, and the flag is a `sync=False` optimisation: it engages only for a `sync=False` `file://` source whose own rate is above `maxfps`. Under `sync=True` it is a no-op, so that mode's documented no-skip guarantee is preserved. It also no-ops on a container that reports no real rate (the >= 1000 fps VFR sentinel, not VFR sources in general), falling back to normal behaviour. Both clock paths stay exactly as they are for anyone who does not opt in.

## Notes for review

- Selecting against the wall clock cannot be exact. The test shows the default path landing anywhere in 13 to 16 frames on a fixture where by-index always returns 15. That is a second, smaller reason to prefer it offline.
- The drop happens at the top of `wait()`, before the sync back-pressure and before any sleep, so a discarded frame costs one modulo.
- Settable globally, per source string (`!maxfps_by_index`), or by `FILTER_MAXFPS_BY_INDEX` / `VIDEO_IN_MAXFPS_BY_INDEX`.

## Tests

`tests/test_video_in_maxfps_by_index.py`: default still paced; by-index (`sync=False`) exact and fast; selected indices are `0, 6, 12, 18`; the full selection survives with `sync=False`; the last frame is held at an off-stride EOF; each loop pass restarts at source index 0; by-index no-ops under `sync=True` (same count as stock, no subsample) and on the fps sentinel (`index_stride` stays None); no-op when `maxfps` is not below the source rate; and the source-string option parses.

Full unit suite run on this branch and on `main`. Two failures on both, `test_zmq_roundtrip_report` consistently and one different flaky test each run, neither related to this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790438772&installation_model_id=20112&pr_number=158&repository=PlainsightAI%2Fopenfilter&return_to=https%3A%2F%2Fgithub.com%2FPlainsightAI%2Fopenfilter%2Fpull%2F158&signature=4b99b4c45196927320dc72c85504b8bb092f8d4d1c00979f1253ad8f5b8c0b1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
