### PR TITLE
feat: support directory-based video sources in VideoIn

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,6 @@ OpenFilter Library release notes
 
 ### Added
 
-
 - **`VideoIn` / `ImageIn`: `FILTER_OVERRIDE_SOURCE_URI` to preserve source-file identity.**
   A new `override_source_uri` config (env `FILTER_OVERRIDE_SOURCE_URI`, or
   `FILTER_OVERRIDE_SOURCE_URI_FILE` to read it from a file written at runtime) makes both

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,9 +4,18 @@ OpenFilter Library release notes
 
 ## [Unreleased]
 
+### Added
+
+- **`VideoIn` support for directory-based sequential video playback.**
+  Users can now pass a directory of video files as a source (e.g. `file:///path/to/folder`).
+  The video files inside are sorted alphabetically and played sequentially. Includes full
+  support for loop and sync, recursive subfolder scanning via `recursive`, and glob-based file
+  pattern filtering via `pattern`.
+
 ## v1.3.0 - 2026-08-17
 
 ### Added
+
 
 - **`VideoIn` / `ImageIn`: `FILTER_OVERRIDE_SOURCE_URI` to preserve source-file identity.**
   A new `override_source_uri` config (env `FILTER_OVERRIDE_SOURCE_URI`, or

--- a/docs/video-in-filter.md
+++ b/docs/video-in-filter.md
@@ -228,6 +228,34 @@ Filter.run_multi([
 ])
 ```
 
+### 6. Local Directory of Video Files
+
+The Video Source filter can sequentially read and play video files located inside a local directory in alphabetical order. 
+
+#### Directory Path Format
+```python
+sources='file:///path/to/directory'
+```
+
+#### Directory Playback Parameters
+When pointing `sources` to a folder, you can configure these optional parameters:
+- **`pattern`**: A glob/wildcard pattern (e.g. `*.mp4`) or regular expression to filter specific files.
+- **`recursive`**: If `True`, the filter scans subfolders recursively for matching videos.
+
+#### Directory Example
+```python
+# Process a folder of videos sequentially
+Filter.run_multi([
+    (VideoIn, dict(
+        sources='file:///home/user/videos_to_process',
+        outputs='tcp://*:5550',
+        pattern='*.mp4',    # Only read .mp4 files
+        recursive=True,     # Look inside subfolders
+        sync=True,          # Decode with sync
+    )),
+])
+```
+
 ## Video Processing Options
 
 ### Color Format (`bgr`)
@@ -714,6 +742,8 @@ class VideoInConfig(FilterConfig):
     fps: int | None
     maxsize: str | None
     resize: str | None
+    pattern: str | None
+    recursive: bool | None
 ```
 
 ### VideoIn
@@ -744,3 +774,5 @@ class VideoIn(Filter):
 - `FILTER_MAXFPS`: Maximum frame rate
 - `FILTER_MAXSIZE`: Maximum image size
 - `FILTER_RESIZE`: Image resize dimensions
+- `FILTER_PATTERN`: Glob/wildcard pattern for directory video files
+- `FILTER_RECURSIVE`: Scan directories recursively for matching videos

--- a/examples/directory-pipeline-demo/README.md
+++ b/examples/directory-pipeline-demo/README.md
@@ -1,0 +1,27 @@
+# Directory Pipeline Demo
+
+This example demonstrates how to use the directory traversal feature in `VideoIn` to process a directory of video files sequentially as if they were a single continuous stream.
+
+## Features Illustrated
+1. **Sequential Directory Traversal**: Reads all video files matching our video extension allowlist within a folder in alphabetical order.
+2. **Metadata Tracking**: Displays real-time metadata reporting the active physical video file, the current frame index (re-indexed on new files), and video-time offsets (presentation timestamps).
+3. **Pacing and MaxFPS**: Illustrates pacing frames across segment transitions without skipping or missing frames.
+4. **Frame Saving**: Uses `ImageOut` to save frames to disk inside the `output/` folder.
+
+## How to Run
+
+Install dependencies and run the script:
+```bash
+python examples/directory-pipeline-demo/main.py
+```
+
+### Options
+You can also supply your own directory of videos:
+```bash
+python examples/directory-pipeline-demo/main.py --directory /path/to/my/videos
+```
+
+For more options, run:
+```bash
+python examples/directory-pipeline-demo/main.py --help
+```

--- a/examples/directory-pipeline-demo/main.py
+++ b/examples/directory-pipeline-demo/main.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Directory Pipeline Demo
+
+This example demonstrates using the directory traversal feature in VideoIn to sequentialize
+a directory of video files and run them through a processing pipeline.
+"""
+
+import os
+import sys
+import shutil
+import tempfile
+import argparse
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from openfilter.filter_runtime.filter import Filter, FilterConfig
+from openfilter.filter_runtime.filters.video_in import VideoIn
+from openfilter.filter_runtime.filters.image_out import ImageOut
+
+
+class InfoPrinter(Filter):
+    """Prints frame metadata in real-time to show directory sequential playback."""
+    FILTER_TYPE = 'Processor'
+
+    def process(self, frames):
+        for topic, frame in frames.items():
+            meta = frame.data.get('meta', {})
+            src = meta.get('src', 'N/A')
+            frame_idx = meta.get('src_frame', 'N/A')
+            pts = meta.get('src_seconds', 'N/A')
+            
+            print(f"[InfoPrinter] Topic: {topic} | Active Source: {src} | Frame In Video: {frame_idx} | Offset Secs: {pts}")
+            
+        return frames
+
+
+def create_sample_video(p: str, color: str):
+    """Generate a lightweight 3-frame MP4 video of a solid color using cv2.VideoWriter."""
+    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+    out = cv2.VideoWriter(p, fourcc, 30.0, (100, 100))
+    img = np.zeros((100, 100, 3), dtype=np.uint8)
+    if color == 'red':
+        img[:, :, 2] = 255
+    elif color == 'green':
+        img[:, :, 1] = 255
+    elif color == 'blue':
+        img[:, :, 0] = 255
+    for _ in range(3):
+        out.write(img)
+    out.release()
+    print(f"Created sample video: {p}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run the directory pipeline demo.")
+    parser.add_argument("--directory", type=str, help="Directory of video files to read. If not provided, a temporary one with sample videos will be created.")
+    parser.add_argument("--loop", type=int, default=1, help="Number of times to loop (0 for infinite loop, 1 for once, etc.)")
+    args = parser.parse_args()
+
+    temp_dir = None
+    if not args.directory:
+        print("No directory provided. Creating a temporary directory with sample videos...")
+        temp_dir = tempfile.mkdtemp()
+        
+        # Create three separate video clips dynamically
+        vid_a = os.path.join(temp_dir, "01_autumn.mp4")
+        vid_b = os.path.join(temp_dir, "02_winter.mp4")
+        vid_c = os.path.join(temp_dir, "03_spring.mp4")
+        
+        create_sample_video(vid_a, 'red')
+        create_sample_video(vid_b, 'green')
+        create_sample_video(vid_c, 'blue')
+            
+        source_dir = temp_dir
+    else:
+        source_dir = os.path.abspath(args.directory)
+        if not os.path.isdir(source_dir):
+            print(f"Error: {source_dir} is not a valid directory.")
+            sys.exit(1)
+
+    output_dir = Path(__file__).parent / "output"
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print("\nDirectory Pipeline Demo")
+    print("=" * 60)
+    print(f"Source Directory: {source_dir}")
+    print(f"Output Frames:    {output_dir}")
+    print("=" * 60)
+    print("Starting pipeline: VideoIn -> InfoPrinter -> ImageOut")
+    print("Press Ctrl+C to exit.")
+    print("-" * 60)
+
+    try:
+        Filter.run_multi([
+            # 1. VideoIn: reads the folder
+            (VideoIn, FilterConfig({
+                'id': 'video-input',
+                'sources': f'file://{source_dir}!sync!maxfps=1',
+                'outputs': 'tcp://127.0.0.1:5570',
+            })),
+            
+            # 2. InfoPrinter: custom live printing filter
+            (InfoPrinter, FilterConfig({
+                'id': 'info-printer',
+                'sources': 'tcp://127.0.0.1:5570',
+                'outputs': 'tcp://127.0.0.1:5572',
+            })),
+            
+            # 3. ImageOut: saves the frames to disk
+            (ImageOut, FilterConfig({
+                'id': 'image-output',
+                'sources': 'tcp://127.0.0.1:5572',
+                'outputs': [
+                    f'file://{output_dir}/frame_%Y%m%d_%H%M%S_%d.png!format=png'
+                ],
+                'bgr': True,
+            }))
+        ])
+        
+        print("-" * 60)
+        print("Pipeline execution finished successfully.")
+        print(f"Output frames saved in: {output_dir}")
+        print("List of generated files:")
+        for entry in sorted(output_dir.iterdir()):
+            print(f"  - {entry.name}")
+
+    except KeyboardInterrupt:
+        print("\nPipeline interrupted by user.")
+    except Exception as e:
+        print(f"\nPipeline execution failed: {e}")
+        sys.exit(1)
+    finally:
+        if temp_dir and os.path.exists(temp_dir):
+            shutil.rmtree(temp_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/openfilter/filter_runtime/filters/video_in.py
+++ b/openfilter/filter_runtime/filters/video_in.py
@@ -29,6 +29,8 @@ VIDEO_IN_LOOP     = _ if isinstance(_ := json_getval((os.getenv('VIDEO_IN_LOOP')
 VIDEO_IN_MAXFPS   = None if (_ := json_getval((os.getenv('VIDEO_IN_MAXFPS') or os.getenv('FILTER_MAXFPS') or 'null').lower())) is None else float(_)
 VIDEO_IN_MAXSIZE  = os.getenv('VIDEO_IN_MAXSIZE') or os.getenv('FILTER_MAXSIZE') or None
 VIDEO_IN_RESIZE   = os.getenv('VIDEO_IN_RESIZE') or os.getenv('FILTER_RESIZE') or None
+VIDEO_IN_PATTERN  = os.getenv('VIDEO_IN_PATTERN') or os.getenv('FILTER_PATTERN') or None
+VIDEO_IN_RECURSIVE = bool(json_getval((os.getenv('VIDEO_IN_RECURSIVE') or os.getenv('FILTER_RECURSIVE') or 'false').lower()))
 
 # OpenCV's ffmpeg backend reports a sentinel ~1000 fps (the 1 ms MKV/webm container
 # timebase, not a real rate) for some VFR files. Any CAP_PROP_FPS at or above this
@@ -199,9 +201,9 @@ class VideoReader:
 
             expiration: Presigned URL expiration in seconds (optional).
 
-            pattern: Filter string or glob pattern (e.g., `*.mp4`) to select specific video files from directories.
+            pattern: Filter string or glob pattern (e.g., `*.mp4`) to select specific video files from directories. Has env var default.
 
-            recursive: If True, subfolders in directories are recursively scanned for video files.
+            recursive: If True, subfolders in directories are recursively scanned for video files. Has env var default.
         """
 
         if not isinstance((loop := VIDEO_IN_LOOP if loop is None else loop), (bool, int)) or loop < 0:
@@ -213,6 +215,8 @@ class VideoReader:
         self.maxfps        = maxfps = VIDEO_IN_MAXFPS if maxfps is None else maxfps
         self.maxsize       = None if (s := VIDEO_IN_MAXSIZE if maxsize is None else maxsize) is None else parse_size(s)
         self.resize        = None if (s := VIDEO_IN_RESIZE if resize is None else resize) is None else parse_size(s)
+        pattern            = VIDEO_IN_PATTERN if pattern is None else pattern
+        recursive          = VIDEO_IN_RECURSIVE if recursive is None else recursive
         self.state         = 0     # 0 = before start, 1 = playing, 2 = stopped / done
         self.sync_evt      = None  # this is set only for file fideo with 'sync' option True
         self.ns_per_fps    = None  # this is set only for file video with 'sync' option False
@@ -793,22 +797,23 @@ class VideoIn(Filter):
 
     config:
         sources:
-            The source(s) of the video(s), comma delimited, can be file://, rtsp:// stream, s3:// bucket object, 
-            or a webcam:// index.
+            The source(s) of the video(s), comma delimited, can be file://, rtsp:// stream, s3:// bucket object,
+            a webcam:// index, or a file:// directory path for sequential playback of the video files within it.
 
             Examples:
-                'file://a.mp4!sync!loop=3, rtsp://b.com!no-bgr;c, s3://bucket/video.mp4!region=us-west-2, webcam://0;e'
+                'file://a.mp4!sync!loop=3, rtsp://b.com!no-bgr;c, s3://bucket/video.mp4!region=us-west-2, webcam://0;e, file:///path/to/dir!pattern=*.mp4'
 
                     is the same as
 
-                ['file://a.mp4!sync!loop=3', 'rtsp://b.com!no-bgr;c', 's3://bucket/video.mp4!region=us-west-2', 'webcam://0;e']
+                ['file://a.mp4!sync!loop=3', 'rtsp://b.com!no-bgr;c', 's3://bucket/video.mp4!region=us-west-2', 'webcam://0;e', 'file:///path/to/dir!pattern=*.mp4']
 
                     is the same as
 
                 [{'source': 'file://a.mp4', 'topic': 'main', 'options': {'sync': True, 'loop': 3}},
                  {'source': 'rtsp://b.com', 'topic': 'c', 'options': {'bgr': False}},
                  {'source': 's3://bucket/video.mp4', 'topic': 'main', 'options': {'region': 'us-west-2'}},
-                 {'source': 'webcam://0', 'topic': 'e', 'options': {}}]
+                 {'source': 'webcam://0', 'topic': 'e', 'options': {}},
+                 {'source': 'file:///path/to/dir', 'topic': 'main', 'options': {'pattern': '*.mp4'}}]
 
                     For 'options' see below.
 
@@ -884,10 +889,13 @@ class VideoIn(Filter):
 
         pattern:
             Only has meaning for folder/directory file:// sources. A glob pattern (e.g. `*.mp4`) or regular expression
-            to match and filter video files in the directory. Set here to apply to all sources or can be set individually per source.
+            to match and filter video files in the directory. Set here to apply to all sources or can be set individually
+            per source. Global env var default FILTER_PATTERN / VIDEO_IN_PATTERN.
 
         recursive:
-            Only has meaning for folder/directory file:// sources. If True, scans the directory and its subdirectories recursively for matching files. Set here to apply to all sources or can be set individually per source.
+            Only has meaning for folder/directory file:// sources. If True, scans the directory and its subdirectories
+            recursively for matching files. Set here to apply to all sources or can be set individually per source.
+            Global env var default FILTER_RECURSIVE / VIDEO_IN_RECURSIVE.
 
         override_source_uri:
             Logical source URI to report as each frame's meta['src'] instead of the physical source opened by the
@@ -909,6 +917,9 @@ class VideoIn(Filter):
         With `loop`, the cap is reopened each pass, so src_frame and src_seconds restart at 0 every loop (they are the
         position WITHIN the file) while meta['id'] keeps counting across passes: a looped timeline is non-monotonic
         in src_frame/src_seconds but monotonic in id, so consumers indexing a looped source must key off id, not src_frame.
+        A directory source reproduces this same restart at every file transition even without `loop`: src_frame and
+        src_seconds reset to 0 (and meta['src'] changes) each time playback moves to the next file in the directory,
+        while meta['id'] keeps counting across the whole run - so consumers of a directory source must key off id too.
 
         Stream and webcam sources have no meaningful decoder position: both keys are absent, all other meta unchanged.
 
@@ -919,6 +930,8 @@ class VideoIn(Filter):
         FILTER_MAXFPS   / VIDEO_IN_MAXFPS
         FILTER_MAXSIZE  / VIDEO_IN_MAXSIZE
         FILTER_RESIZE   / VIDEO_IN_RESIZE
+        FILTER_PATTERN  / VIDEO_IN_PATTERN
+        FILTER_RECURSIVE / VIDEO_IN_RECURSIVE
 
     S3 Configuration:
         For s3:// sources, AWS credentials are required. Set these environment variables:

--- a/openfilter/filter_runtime/filters/video_in.py
+++ b/openfilter/filter_runtime/filters/video_in.py
@@ -1,3 +1,4 @@
+import glob
 import logging
 import os
 import re
@@ -43,6 +44,25 @@ is_video_file     = lambda name: name.startswith('file://')
 is_video_webcam   = lambda name: name.startswith('webcam://')
 is_video_stream   = lambda name: bool(re_video_stream.match(name))
 is_video_s3       = lambda name: name.startswith('s3://')
+
+VIDEO_EXTENSIONS = {'mp4', 'mkv', 'avi', 'mov', 'webm', 'flv', 'wmv', 'm4v', '3gp', 'mpg', 'mpeg'}
+
+def is_video_file_ext(path: str) -> bool:
+    """Check if the given file path has a valid video file extension."""
+    ext = path.split('.')[-1].lower() if '.' in path else ''
+    return ext in VIDEO_EXTENSIONS
+
+def matches_pattern(path: str, pattern: str) -> bool:
+    """Check if path matches the given pattern (glob or regex)."""
+    if not pattern:
+        return True
+    if '*' in pattern or '?' in pattern:
+        return glob.fnmatch.fnmatch(os.path.basename(path), pattern)
+    try:
+        return bool(re.search(pattern, path))
+    except re.error:
+        return pattern in path
+
 
 
 re_size = re.compile(r'^\s* (\d+) \s* ([x+]) \s* (\d+) \s* (n(?:ear)? | l(?:in)? | c(?:ub)?)? \s*$', re.VERBOSE | re.IGNORECASE)
@@ -134,6 +154,8 @@ class VideoReader:
         resize:  str | None = None,
         region:  str | None = None,
         expiration: int | None = None,
+        pattern:  str | None = None,
+        recursive: bool | None = None,
     ):
         """Read a single video file, network stream or webcam until the end.
 
@@ -175,6 +197,10 @@ class VideoReader:
         self.ns_per_maxfps = None if maxfps is None else 1_000_000_000 // maxfps
         self.is_file       = is_file = is_video_file(source) or is_video_s3(source)
         self.as_bgr        = bool(VIDEO_IN_BGR if bgr is None else bgr)  # only validated after first frame is read (set to False if frames are grayscale)
+        self.is_dir        = False
+        self.dir_files     = []
+        self.dir_index     = 0
+        self.source_dir_path = None
 
         if self.maxsize and self.resize:
             raise ValueError(f"can not specify both 'maxsize' and 'resize' together in {self.source!r}")
@@ -192,6 +218,31 @@ class VideoReader:
                 except Exception as e:
                     raise ValueError(f'Failed to generate presigned URL for S3 source {self.source!r}: {e}')
             self.is_file = True
+
+            if os.path.isdir(source):
+                self.is_dir = True
+                self.source_dir_path = self.source
+                
+                # Scan directory with pattern and recursive options
+                if recursive:
+                    glob_pat = os.path.join(source, '**', '*')
+                    candidates = glob.glob(glob_pat, recursive=True)
+                else:
+                    glob_pat = os.path.join(source, '*')
+                    candidates = glob.glob(glob_pat)
+
+                self.dir_files = []
+                for p in sorted(candidates):
+                    if os.path.isfile(p) and is_video_file_ext(p) and matches_pattern(p, pattern):
+                        self.dir_files.append(p)
+
+                if not self.dir_files:
+                    raise RuntimeError(f'no valid video files found in directory: {self.source!r}')
+                self.dir_index = 0
+                source = self.dir_files[0]
+                self.source = f'file://{source}'
+            else:
+                self.is_dir = False
 
             if sync := VIDEO_IN_SYNC if sync is None else sync:
                 self.sync_evt = Event()
@@ -313,6 +364,26 @@ class VideoReader:
 
         return ret, image
 
+    def _open_dir_file(self, index: int):
+        self.dir_index = index
+        active_source = self.dir_files[index]
+        self.cap.release()
+        self.cap = cv2.VideoCapture(active_source)
+        if not self.cap.isOpened():
+            raise RuntimeError(f'failed to open video in directory: {active_source}')
+
+        self.source = f'file://{active_source}'
+        self.ssource = active_source
+        fps = self.cap.get(cv2.CAP_PROP_FPS) or None
+        self.native_fps = fps
+        self.fps = fps
+        if self.maxfps is not None and fps is not None and fps > self.maxfps:
+            if not self.is_file or not self.sync_evt:
+                self.fps = self.maxfps
+
+        if not self.sync_evt:
+            self.ns_per_fps = 1_000_000_000 // (self.fps or 15)
+
     def read_one(self):
         def wait() -> bool:  # returns if should return frame or keep looping
             t = time_ns()
@@ -360,6 +431,31 @@ class VideoReader:
                 # frame may be lost on a realtime video if it takes too long to query it but it will never be lost on
                 # a `sync` video.
 
+                if self.is_dir and self.dir_index + 1 < len(self.dir_files):
+                    success = False
+                    while self.dir_index + 1 < len(self.dir_files):
+                        next_index = self.dir_index + 1
+                        active_source = self.dir_files[next_index]
+                        try:
+                            logger.info(f'video transition: opening next file in directory: {active_source}')
+                            self._open_dir_file(next_index)
+                            ret, image = self._cap_read()
+                            if ret and image is not None:
+                                success = True
+                                break
+                            self.dir_index = next_index
+                        except Exception as e:
+                            logger.error(f'Error during video transition to {active_source}: {e}')
+                            self.dir_index = next_index
+
+                    if success:
+                        if wait():
+                            break
+                        continue
+
+                    # If we ran out of directory files, fall through to loop/restart logic below
+
+                # Handle loop/restart
                 if loop := self.loop:
                     self.loop = loop - 1
 
@@ -369,21 +465,39 @@ class VideoReader:
                         return None
 
                 try:
-                    logger.info(f'video loop: {self.source}{f"  (last loop)" if loop == 2 else f"  ({self.loop} left)" if loop else ""}')
+                    if self.is_dir:
+                        logger.info(f'directory loop: {self.source_dir_path}{f"  (last loop)" if loop == 2 else f"  ({self.loop} left)" if loop else ""}')
+                        success = False
+                        self.dir_index = 0
+                        while self.dir_index < len(self.dir_files):
+                            active_source = self.dir_files[self.dir_index]
+                            try:
+                                self._open_dir_file(self.dir_index)
+                                ret, image = self._cap_read()
+                                if ret and image is not None:
+                                    success = True
+                                    break
+                                self.dir_index += 1
+                            except Exception as e:
+                                logger.error(f'Error during directory loop restart for {active_source}: {e}')
+                                self.dir_index += 1
 
-                    self.cap.release()
-                    self.cap = cv2.VideoCapture(self.ssource)
-                    if not self.cap.isOpened():
-                        raise RuntimeError(f'failed to reopen video source: {self.source!r}')
+                        if not success:
+                            return None
+                    else:
+                        logger.info(f'video loop: {self.source}{f"  (last loop)" if loop == 2 else f"  ({self.loop} left)" if loop else ""}')
+                        self.cap.release()
+                        self.cap = cv2.VideoCapture(self.ssource)
+                        if not self.cap.isOpened():
+                            raise RuntimeError(f'failed to reopen video source: {self.ssource}')
+                        ret, image = self._cap_read()
+                        if not ret or image is None:
+                            return None
 
-                except Exception:
+                except Exception as e:
+                    logger.error(f'Error during loop restart: {e}')
                     wait()
 
-                    return None
-
-                ret, image = self._cap_read()
-
-                if not ret or image is None:  # no wait() here because if first frame fails then nothing means anything anymore and we might as well just end it
                     return None
 
             if wait():
@@ -450,7 +564,10 @@ class VideoReader:
                 elif not self.as_bgr:
                     image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
 
-            self.deque.append((image, tframe, self.extras))
+            extras_copy = dict(self.extras) if self.extras else {}
+            extras_copy['source'] = self.source
+            extras_copy['fps'] = self.fps
+            self.deque.append((image, tframe, extras_copy))
 
             if cond is not None:
                 with cond:
@@ -496,7 +613,27 @@ class VideoReader:
 
     @staticmethod
     def get_info(source: str) -> tuple[int, int, str, float]:  # (height, width, format, fps)
-        cap = cv2.VideoCapture(int(source[9:]) if is_video_webcam(source) else source[7:] if is_video_file(source) else source)
+        path = source[7:] if is_video_file(source) else source
+        if os.path.isdir(path):
+            # Find the first valid video file in the directory
+            with os.scandir(path) as entries:
+                for entry in sorted(entries, key=lambda e: e.name):
+                    if entry.is_file() and is_video_file_ext(entry.path):
+                        test_cap = cv2.VideoCapture(entry.path)
+                        if test_cap.isOpened():
+                            ret, image = test_cap.read()
+                            if ret:
+                                width  = image.shape[1]
+                                height = image.shape[0]
+                                fps    = test_cap.get(cv2.CAP_PROP_FPS)
+                                is_bgr = test_cap.get(cv2.CAP_PROP_CONVERT_RGB)
+                                format = 'GRAY' if len(image.shape) == 2 else 'BGR' if is_bgr else 'RGB'
+                                test_cap.release()
+                                return height, width, format, fps
+                            test_cap.release()
+            raise RuntimeError(f'no valid video files found in directory: {source}')
+
+        cap = cv2.VideoCapture(int(source[9:]) if is_video_webcam(source) else path)
 
         try:
             ret, image = cap.read()
@@ -608,6 +745,8 @@ class VideoInConfig(FilterConfig):
             resize:     str | None
             region:     str | None
             expiration: int | None
+            pattern:    str | None
+            recursive:  bool | None
 
         source:  str
         topic:   str | None
@@ -622,6 +761,8 @@ class VideoInConfig(FilterConfig):
     maxfps:  float | None
     maxsize: str | None
     resize:  str | None
+    pattern:    str | None
+    recursive:  bool | None
 
     # Logical source URI to report as meta['src'] instead of the physical source
     # (set by an orchestrator; see resolve_override_source_uri). FILTER_OVERRIDE_SOURCE_URI
@@ -796,7 +937,7 @@ class VideoIn(Filter):
                 source.topic = 'main'
             if not isinstance(options := source.options, VideoInConfig.Source.Options):
                 source.options = options = VideoInConfig.Source.Options() if options is None else VideoInConfig.Source.Options(options)
-            if any((option := o) not in ('bgr', 'sync', 'loop', 'maxfps', 'maxsize', 'resize', 'region', 'expiration') for o in options):
+            if any((option := o) not in ('bgr', 'sync', 'loop', 'maxfps', 'maxsize', 'resize', 'region', 'expiration', 'pattern', 'recursive') for o in options):
                 raise ValueError(f'unknown option {option!r} in {source!r}')
 
         if len(set(source.topic for source in sources)) != len(sources):
@@ -820,7 +961,7 @@ class VideoIn(Filter):
             optionss.append(source.options or {})
 
         default_options      = {'bgr': config.bgr, 'sync': config.sync, 'loop': config.loop, 'maxfps': config.maxfps,
-            'maxsize': config.maxsize, 'resize': config.resize}
+            'maxsize': config.maxsize, 'resize': config.resize, 'pattern': config.get('pattern'), 'recursive': config.get('recursive')}
         self.mvreader        = MultiVideoReader(vsources, [{**default_options, **options} for options in optionss])
         self.tops_n_vids     = tuple(zip(topics, self.mvreader.videos))
         self.id              = -1  # frame id
@@ -832,10 +973,11 @@ class VideoIn(Filter):
         # override to every frame would mislabel each with the same meta['src'], so only honor
         # it for a single source; otherwise fall back to each video's real source and warn once.
         # Mirrors the ImageIn guard.
-        self._apply_override = bool(self.override_source_uri) and len(self.mvreader.videos) <= 1
+        self._apply_override = bool(self.override_source_uri) and len(self.mvreader.videos) <= 1 and not self.mvreader.videos[0].is_dir
         if self.override_source_uri and not self._apply_override:
+            reason = "a directory source" if len(self.mvreader.videos) == 1 and self.mvreader.videos[0].is_dir else f"{len(self.mvreader.videos)} sources"
             logger.warning(
-                f"FILTER_OVERRIDE_SOURCE_URI[_FILE] is set but this VideoIn has {len(self.mvreader.videos)} sources; "
+                f"FILTER_OVERRIDE_SOURCE_URI[_FILE] is set but this VideoIn has {reason}; "
                 "the override identifies a single source, so meta['src'] will report each video's real source instead")
 
         self.mvreader.start()
@@ -853,9 +995,11 @@ class VideoIn(Filter):
             self.id = id = self.id + 1
 
             def meta(vid, tfrm, extras):
-                meta = {'id': id, 'ts': tfrm / 1_000_000_000, 'src': self.override_source_uri if self._apply_override else vid.source, 'src_fps': vid.fps}
+                src = extras.get('source', vid.source) if extras else vid.source
+                src_fps = extras.get('fps', vid.fps) if extras else vid.fps
+                meta = {'id': id, 'ts': tfrm / 1_000_000_000, 'src': self.override_source_uri if self._apply_override else src, 'src_fps': src_fps}
 
-                if extras:  # file sources: decoder position of this frame = the video offset jump-to-frame needs
+                if extras and 'frame_n' in extras:  # file sources: decoder position of this frame = the video offset jump-to-frame needs
                     meta['src_frame'] = extras['frame_n']
 
                     if (pts_s := extras.get('pts_s')) is not None:

--- a/openfilter/filter_runtime/filters/video_in.py
+++ b/openfilter/filter_runtime/filters/video_in.py
@@ -1,4 +1,5 @@
 import glob
+import fnmatch
 import logging
 import os
 import re
@@ -57,12 +58,25 @@ def matches_pattern(path: str, pattern: str) -> bool:
     if not pattern:
         return True
     if '*' in pattern or '?' in pattern:
-        return glob.fnmatch.fnmatch(os.path.basename(path), pattern)
+        return fnmatch.fnmatch(os.path.basename(path), pattern)
     try:
         return bool(re.search(pattern, path))
     except re.error:
         return pattern in path
 
+
+def scan_dir_videos(path: str, pattern: str | None = None, recursive: bool | None = None) -> list[str]:
+    """List video files in a directory honoring `pattern` and `recursive`, sorted alphabetically.
+
+    Shared by VideoReader.__init__ and VideoReader.get_info so both agree on which file in a
+    directory is "first", instead of get_info silently reimplementing (and diverging from) the scan.
+    """
+    if recursive:
+        candidates = glob.glob(os.path.join(path, '**', '*'), recursive=True)
+    else:
+        candidates = glob.glob(os.path.join(path, '*'))
+
+    return [p for p in sorted(candidates) if os.path.isfile(p) and is_video_file_ext(p) and matches_pattern(p, pattern)]
 
 
 re_size = re.compile(r'^\s* (\d+) \s* ([x+]) \s* (\d+) \s* (n(?:ear)? | l(?:in)? | c(?:ub)?)? \s*$', re.VERBOSE | re.IGNORECASE)
@@ -157,22 +171,22 @@ class VideoReader:
         pattern:  str | None = None,
         recursive: bool | None = None,
     ):
-        """Read a single video file, network stream or webcam until the end.
+        """Read a single video file, network stream, webcam, or video directory until the end.
 
         Args:
-            source: Source video stream, can be file, web stream like 'rtsp://...' or a webcam index starting at 0 -
-                'webcam://0'.
+            source: Source video stream, can be file, web stream like 'rtsp://...', a webcam index starting at 0 -
+                'webcam://0', or a local directory path (e.g. 'file:///path/to/dir') for sequential playback of matching video files in alphabetical order.
 
             cond: A threading.Condition to .notify_all() whenever a new frame is read.
 
             bgr: True means images in BGR mode, False means RGB. Has env var default.
 
-            sync: Only has meaning for files. If True then frames will be delivered one by one without skipping or
+            sync: Only has meaning for files/directories. If True then frames will be delivered one by one without skipping or
                 waiting to maintain realtime, in this way all frames will be read. If None the the system default is
                 used which comes from an environment variable (and is False if not present).
 
-            loop: Only has meaning for files. True or 0 means infinite loop, False means loop once, otherwise int loops
-                through the video. Has env var default.
+            loop: Only has meaning for files/directories. True or 0 means infinite loop, False means loop once, otherwise int loops
+                through the video files. Has env var default.
 
             maxsize: Maximum image size to allow, above this will be resized down. Valid codes are '123x456' which will
                 proportionally resize maintaining aspect ratio so that neither dimension exceeds the max, '123+456' will
@@ -180,6 +194,14 @@ class VideoReader:
                 interpolation, default is 'near'est neighbor.
 
             resize: Straight resize always, can not be specified together with `maxsize`, it is one or the other.
+
+            region: S3 bucket AWS region (optional).
+
+            expiration: Presigned URL expiration in seconds (optional).
+
+            pattern: Filter string or glob pattern (e.g., `*.mp4`) to select specific video files from directories.
+
+            recursive: If True, subfolders in directories are recursively scanned for video files.
         """
 
         if not isinstance((loop := VIDEO_IN_LOOP if loop is None else loop), (bool, int)) or loop < 0:
@@ -222,19 +244,8 @@ class VideoReader:
             if os.path.isdir(source):
                 self.is_dir = True
                 self.source_dir_path = self.source
-                
-                # Scan directory with pattern and recursive options
-                if recursive:
-                    glob_pat = os.path.join(source, '**', '*')
-                    candidates = glob.glob(glob_pat, recursive=True)
-                else:
-                    glob_pat = os.path.join(source, '*')
-                    candidates = glob.glob(glob_pat)
 
-                self.dir_files = []
-                for p in sorted(candidates):
-                    if os.path.isfile(p) and is_video_file_ext(p) and matches_pattern(p, pattern):
-                        self.dir_files.append(p)
+                self.dir_files = scan_dir_videos(source, pattern, recursive)
 
                 if not self.dir_files:
                     raise RuntimeError(f'no valid video files found in directory: {self.source!r}')
@@ -382,7 +393,7 @@ class VideoReader:
                 self.fps = self.maxfps
 
         if not self.sync_evt:
-            self.ns_per_fps = 1_000_000_000 // (self.fps or 15)
+            self.ns_per_fps = 1_000_000_000 // (self.native_fps or 15)
 
     def read_one(self):
         def wait() -> bool:  # returns if should return frame or keep looping
@@ -489,7 +500,7 @@ class VideoReader:
                         self.cap.release()
                         self.cap = cv2.VideoCapture(self.ssource)
                         if not self.cap.isOpened():
-                            raise RuntimeError(f'failed to reopen video source: {self.ssource}')
+                            raise RuntimeError(f'failed to reopen video source: {self.source!r}')
                         ret, image = self._cap_read()
                         if not ret or image is None:
                             return None
@@ -592,8 +603,9 @@ class VideoReader:
 
     def read(self, with_tframe=False):  # -> np.ndarray | tuple[np.ndarray, int, dict] | None
         # BREAKING CHANGE (unreleased): with_tframe=True returns (image, tframe, extras) instead of (image, tframe);
-        # extras is {} for non-file sources and absorbs future additions without another arity break (same shape as
-        # the seekable-replay branch). with_tframe=False (the default) is unaffected.
+        # extras always carries 'source'/'fps' (added in thread_reader) and, for file sources only, 'frame_n'/'pts_s';
+        # this absorbs future additions without another arity break (same shape as the seekable-replay branch).
+        # with_tframe=False (the default) is unaffected.
         if self.state == 0:
             raise RuntimeError('can not read from video before it is started')
         elif self.state == 2:
@@ -612,25 +624,28 @@ class VideoReader:
         return image_n_tframe if with_tframe else image_n_tframe[0]
 
     @staticmethod
-    def get_info(source: str) -> tuple[int, int, str, float]:  # (height, width, format, fps)
+    def get_info(source: str, pattern: str | None = None, recursive: bool | None = None) -> tuple[int, int, str, float]:  # (height, width, format, fps)
         path = source[7:] if is_video_file(source) else source
         if os.path.isdir(path):
-            # Find the first valid video file in the directory
-            with os.scandir(path) as entries:
-                for entry in sorted(entries, key=lambda e: e.name):
-                    if entry.is_file() and is_video_file_ext(entry.path):
-                        test_cap = cv2.VideoCapture(entry.path)
-                        if test_cap.isOpened():
-                            ret, image = test_cap.read()
-                            if ret:
-                                width  = image.shape[1]
-                                height = image.shape[0]
-                                fps    = test_cap.get(cv2.CAP_PROP_FPS)
-                                is_bgr = test_cap.get(cv2.CAP_PROP_CONVERT_RGB)
-                                format = 'GRAY' if len(image.shape) == 2 else 'BGR' if is_bgr else 'RGB'
-                                test_cap.release()
-                                return height, width, format, fps
-                            test_cap.release()
+            # First file per scan_dir_videos, so this reports the file __init__ will actually play
+            dir_files = scan_dir_videos(path, pattern, recursive)
+
+            if not dir_files:
+                raise RuntimeError(f'no valid video files found in directory: {source}')
+
+            for entry_path in dir_files:
+                test_cap = cv2.VideoCapture(entry_path)
+                if test_cap.isOpened():
+                    ret, image = test_cap.read()
+                    if ret:
+                        width  = image.shape[1]
+                        height = image.shape[0]
+                        fps    = test_cap.get(cv2.CAP_PROP_FPS)
+                        is_bgr = test_cap.get(cv2.CAP_PROP_CONVERT_RGB)
+                        format = 'GRAY' if len(image.shape) == 2 else 'BGR' if is_bgr else 'RGB'
+                        test_cap.release()
+                        return height, width, format, fps
+                    test_cap.release()
             raise RuntimeError(f'no valid video files found in directory: {source}')
 
         cap = cv2.VideoCapture(int(source[9:]) if is_video_webcam(source) else path)
@@ -823,6 +838,12 @@ class VideoIn(Filter):
                     Set presigned URL expiration time in seconds for S3 sources. Default is 3600 (1 hour).
                     Only applies to s3:// sources.
 
+                '!pattern=*.mp4':
+                    Set pattern option for directory source.
+
+                '!recursive', '!no-recursive':
+                    Set recursive option for directory source.
+
         bgr:
             True means images in BGR format, False means RGB. Doesn't really affect anythong other than procesing speed
             since images should always be converted to the needed format. Don't touch this unless you have an explicit
@@ -860,6 +881,13 @@ class VideoIn(Filter):
             Same as `maxsize` but is always applied unconditionally regardless of input size.Can not be specified
             together with `maxsize`, it is one or the other. Set here to apply to all sources or can be set individually
             per source. Global env var default FILTER_RESIZE / VIDEO_IN_RESIZE.
+
+        pattern:
+            Only has meaning for folder/directory file:// sources. A glob pattern (e.g. `*.mp4`) or regular expression
+            to match and filter video files in the directory. Set here to apply to all sources or can be set individually per source.
+
+        recursive:
+            Only has meaning for folder/directory file:// sources. If True, scans the directory and its subdirectories recursively for matching files. Set here to apply to all sources or can be set individually per source.
 
         override_source_uri:
             Logical source URI to report as each frame's meta['src'] instead of the physical source opened by the

--- a/openfilter/filter_runtime/filters/video_in.py
+++ b/openfilter/filter_runtime/filters/video_in.py
@@ -72,7 +72,12 @@ def scan_dir_videos(path: str, pattern: str | None = None, recursive: bool | Non
 
     Shared by VideoReader.__init__ and VideoReader.get_info so both agree on which file in a
     directory is "first", instead of get_info silently reimplementing (and diverging from) the scan.
+    Also resolves the VIDEO_IN_PATTERN/VIDEO_IN_RECURSIVE env var defaults here (rather than in each
+    caller) so both callers apply them identically.
     """
+    pattern   = VIDEO_IN_PATTERN if pattern is None else pattern
+    recursive = VIDEO_IN_RECURSIVE if recursive is None else recursive
+
     if recursive:
         candidates = glob.glob(os.path.join(path, '**', '*'), recursive=True)
     else:
@@ -215,8 +220,6 @@ class VideoReader:
         self.maxfps        = maxfps = VIDEO_IN_MAXFPS if maxfps is None else maxfps
         self.maxsize       = None if (s := VIDEO_IN_MAXSIZE if maxsize is None else maxsize) is None else parse_size(s)
         self.resize        = None if (s := VIDEO_IN_RESIZE if resize is None else resize) is None else parse_size(s)
-        pattern            = VIDEO_IN_PATTERN if pattern is None else pattern
-        recursive          = VIDEO_IN_RECURSIVE if recursive is None else recursive
         self.state         = 0     # 0 = before start, 1 = playing, 2 = stopped / done
         self.sync_evt      = None  # this is set only for file fideo with 'sync' option True
         self.ns_per_fps    = None  # this is set only for file video with 'sync' option False

--- a/tests/test_filter_env_vars.py
+++ b/tests/test_filter_env_vars.py
@@ -20,8 +20,9 @@ ALL_FILTER_ENV_VARS = [
     'FILTER_BGR', 'FILTER_SYNC', 'FILTER_LOOP', 'FILTER_MAXFPS', 'FILTER_MAXSIZE',
     'FILTER_RESIZE', 'FILTER_FPS', 'FILTER_SEGTIME', 'FILTER_PARAMS',
     'FILTER_POLL_INTERVAL', 'FILTER_RECURSIVE', 'FILTER_QUALITY', 'FILTER_COMPRESSION',
+    'FILTER_PATTERN',
     'VIDEO_IN_BGR', 'VIDEO_IN_SYNC', 'VIDEO_IN_LOOP', 'VIDEO_IN_MAXFPS',
-    'VIDEO_IN_MAXSIZE', 'VIDEO_IN_RESIZE',
+    'VIDEO_IN_MAXSIZE', 'VIDEO_IN_RESIZE', 'VIDEO_IN_PATTERN', 'VIDEO_IN_RECURSIVE',
     'VIDEO_OUT_BGR', 'VIDEO_OUT_FPS', 'VIDEO_OUT_SEGTIME', 'VIDEO_OUT_PARAMS',
     'IMAGE_IN_POLL_INTERVAL', 'IMAGE_IN_LOOP', 'IMAGE_IN_RECURSIVE', 'IMAGE_IN_MAXFPS',
     'IMAGE_OUT_BGR', 'IMAGE_OUT_QUALITY', 'IMAGE_OUT_COMPRESSION',
@@ -107,6 +108,15 @@ class TestVideoInEnvVars(unittest.TestCase):
     def test_filter_resize_with_interpolation(self):
         self.assertEqual(self._get('VIDEO_IN_RESIZE', {'FILTER_RESIZE': '640x480lin'}), '640x480lin')
 
+    def test_filter_pattern(self):
+        self.assertEqual(self._get('VIDEO_IN_PATTERN', {'FILTER_PATTERN': '*.mp4'}), '*.mp4')
+
+    def test_filter_recursive_true(self):
+        self.assertTrue(self._get('VIDEO_IN_RECURSIVE', {'FILTER_RECURSIVE': 'true'}))
+
+    def test_filter_recursive_false(self):
+        self.assertFalse(self._get('VIDEO_IN_RECURSIVE', {'FILTER_RECURSIVE': 'false'}))
+
     # --- Legacy VIDEO_IN_* still works ---
 
     def test_legacy_bgr(self):
@@ -126,6 +136,12 @@ class TestVideoInEnvVars(unittest.TestCase):
 
     def test_legacy_resize(self):
         self.assertEqual(self._get('VIDEO_IN_RESIZE', {'VIDEO_IN_RESIZE': '320x240'}), '320x240')
+
+    def test_legacy_pattern(self):
+        self.assertEqual(self._get('VIDEO_IN_PATTERN', {'VIDEO_IN_PATTERN': '*.mkv'}), '*.mkv')
+
+    def test_legacy_recursive(self):
+        self.assertTrue(self._get('VIDEO_IN_RECURSIVE', {'VIDEO_IN_RECURSIVE': 'true'}))
 
     # --- Legacy takes precedence over FILTER_* ---
 
@@ -147,6 +163,12 @@ class TestVideoInEnvVars(unittest.TestCase):
     def test_precedence_resize(self):
         self.assertEqual(self._get('VIDEO_IN_RESIZE', {'FILTER_RESIZE': '320x240', 'VIDEO_IN_RESIZE': '640x480'}), '640x480')
 
+    def test_precedence_pattern(self):
+        self.assertEqual(self._get('VIDEO_IN_PATTERN', {'FILTER_PATTERN': '*.mp4', 'VIDEO_IN_PATTERN': '*.mkv'}), '*.mkv')
+
+    def test_precedence_recursive(self):
+        self.assertTrue(self._get('VIDEO_IN_RECURSIVE', {'FILTER_RECURSIVE': 'false', 'VIDEO_IN_RECURSIVE': 'true'}))
+
     # --- Defaults (no env vars set) ---
 
     def test_default_bgr(self):
@@ -166,6 +188,12 @@ class TestVideoInEnvVars(unittest.TestCase):
 
     def test_default_resize(self):
         self.assertIsNone(self._get('VIDEO_IN_RESIZE', {}))
+
+    def test_default_pattern(self):
+        self.assertIsNone(self._get('VIDEO_IN_PATTERN', {}))
+
+    def test_default_recursive(self):
+        self.assertFalse(self._get('VIDEO_IN_RECURSIVE', {}))
 
     # --- Case insensitivity ---
 

--- a/tests/test_filter_video_in.py
+++ b/tests/test_filter_video_in.py
@@ -2,6 +2,8 @@
 
 import logging
 import os
+import shutil
+import tempfile
 import unittest
 from time import sleep, time
 from unittest.mock import patch
@@ -835,6 +837,348 @@ class TestVideoIn(unittest.TestCase):
         finally:
             runner.stop()
             queue.close()
+
+    def test_directory_source(self):
+        import shutil
+        import tempfile
+
+        test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, test_dir)
+
+        # Write two separate video files into the temp directory
+        video_a_path = os.path.join(test_dir, 'video_a.mp4')
+        video_b_path = os.path.join(test_dir, 'video_b.mp4')
+
+        with open(video_a_path, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+        with open(video_b_path, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+
+        # Test VideoIn with directory as a source
+        runner = Filter.Runner([
+            (VideoIn, dict(
+                sources = f'file://{test_dir}!sync',
+                outputs = 'ipc://test-VideoIn-dir',
+            )),
+            (FiltersToQueue, dict(
+                sources = 'ipc://test-VideoIn-dir',
+                queue   = (queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=5)
+
+        try:
+            frames = []
+            while frame_dict := queue.get():
+                frames.append(frame_dict['main'])
+
+            # There should be exactly 6 frames (3 from video_a and 3 from video_b)
+            self.assertEqual(len(frames), 6)
+
+            # Check that src name is continuously updated
+            # First 3 frames should belong to video_a
+            self.assertEqual(frames[0].data['meta']['src'], f'file://{video_a_path}')
+            self.assertEqual(frames[1].data['meta']['src'], f'file://{video_a_path}')
+            self.assertEqual(frames[2].data['meta']['src'], f'file://{video_a_path}')
+
+            # Next 3 frames should belong to video_b
+            self.assertEqual(frames[3].data['meta']['src'], f'file://{video_b_path}')
+            self.assertEqual(frames[4].data['meta']['src'], f'file://{video_b_path}')
+            self.assertEqual(frames[5].data['meta']['src'], f'file://{video_b_path}')
+
+            # Check that src_frame resets upon opening each new video file
+            self.assertEqual([f.data['meta']['src_frame'] for f in frames], [0, 1, 2, 0, 1, 2])
+
+            # Check image colors to make sure they play correctly
+            self.assertTrue(is_image_very_red(frames[0].image))
+            self.assertTrue(is_image_very_green(frames[1].image))
+            self.assertTrue(is_image_very_blue(frames[2].image))
+            self.assertTrue(is_image_very_red(frames[3].image))
+            self.assertTrue(is_image_very_green(frames[4].image))
+            self.assertTrue(is_image_very_blue(frames[5].image))
+
+        finally:
+            runner.stop()
+            queue.close()
+
+    def test_directory_loop(self):
+        import shutil
+        import tempfile
+
+        test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, test_dir)
+
+        # Write two separate video files into the temp directory
+        video_a_path = os.path.join(test_dir, 'video_a.mp4')
+        video_b_path = os.path.join(test_dir, 'video_b.mp4')
+
+        with open(video_a_path, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+        with open(video_b_path, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+
+        # Test VideoIn with directory source and loop=2
+        runner = Filter.Runner([
+            (VideoIn, dict(
+                sources = f'file://{test_dir}!sync!loop=2',
+                outputs = 'ipc://test-VideoIn-dir-loop',
+            )),
+            (FiltersToQueue, dict(
+                sources = 'ipc://test-VideoIn-dir-loop',
+                queue   = (queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=5)
+
+        try:
+            frames = []
+            while frame_dict := queue.get():
+                frames.append(frame_dict['main'])
+
+            # 2 videos * 3 frames each * 2 loops = 12 frames
+            self.assertEqual(len(frames), 12)
+
+            # Check that src_frame resets and progresses properly
+            self.assertEqual([f.data['meta']['src_frame'] for f in frames], [0, 1, 2, 0, 1, 2] * 2)
+
+            # Check sources are correctly sequenced
+            expected_srcs = ([f'file://{video_a_path}'] * 3 + [f'file://{video_b_path}'] * 3) * 2
+            self.assertEqual([f.data['meta']['src'] for f in frames], expected_srcs)
+
+        finally:
+            runner.stop()
+            queue.close()
+
+    def test_directory_skips_non_videos(self):
+        import shutil
+        import tempfile
+
+        test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, test_dir)
+
+        # Write a non-video file and a video file
+        non_video_path = os.path.join(test_dir, 'video_a.txt')
+        video_b_path = os.path.join(test_dir, 'video_b.mp4')
+
+        with open(non_video_path, 'w') as f:
+            f.write("This is not a video file.")
+        with open(video_b_path, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+
+        # Test VideoIn with directory source
+        runner = Filter.Runner([
+            (VideoIn, dict(
+                sources = f'file://{test_dir}!sync',
+                outputs = 'ipc://test-VideoIn-dir-skip',
+            )),
+            (FiltersToQueue, dict(
+                sources = 'ipc://test-VideoIn-dir-skip',
+                queue   = (queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=3)
+
+        try:
+            frames = []
+            while frame_dict := queue.get():
+                frames.append(frame_dict['main'])
+
+            # Only video_b should play (3 frames)
+            self.assertEqual(len(frames), 3)
+            self.assertEqual(frames[0].data['meta']['src'], f'file://{video_b_path}')
+
+        finally:
+            runner.stop()
+            queue.close()
+
+
+    def test_sync_mode_fps_preservation_across_transition(self):
+        import shutil
+        import tempfile
+        test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, test_dir)
+
+        v_a = os.path.join(test_dir, '01.mp4')
+        v_b = os.path.join(test_dir, '02.mp4')
+        with open(v_a, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+        with open(v_b, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+
+        # In sync mode with maxfps, the original native frame rate (approx 30.0)
+        # must be preserved in meta['src_fps'] even after transitioning to 02.mp4
+        runner = Filter.Runner([
+            (VideoIn, dict(
+                sources = f'file://{test_dir}!sync!maxfps=10',
+                outputs = 'ipc://test-VideoIn-sync-fps',
+            )),
+            (FiltersToQueue, dict(
+                sources = 'ipc://test-VideoIn-sync-fps',
+                queue   = (queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=3)
+
+        try:
+            frames = []
+            while frame_dict := queue.get():
+                frames.append(frame_dict['main'])
+            
+            self.assertEqual(len(frames), 6)
+            for idx, f in enumerate(frames):
+                self.assertIsNotNone(f.data['meta']['src_fps'])
+                # Native test video is 30.0 fps. Maxfps is 10.
+                # In sync mode, native fps must be passed downstream.
+                self.assertAlmostEqual(f.data['meta']['src_fps'], 30.0, places=1)
+        finally:
+            runner.stop()
+            queue.close()
+
+    def test_override_source_uri_rejected_for_directory(self):
+        import shutil
+        import tempfile
+        test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, test_dir)
+
+        v_a = os.path.join(test_dir, '01.mp4')
+        with open(v_a, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+
+        override = 's3://some-logical-dir-uri'
+        runner = Filter.Runner([
+            (VideoIn, dict(
+                sources = f'file://{test_dir}!sync',
+                outputs = 'ipc://test-VideoIn-override-dir',
+                override_source_uri = override,
+            )),
+            (FiltersToQueue, dict(
+                sources = 'ipc://test-VideoIn-override-dir',
+                queue   = (queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=3)
+
+        try:
+            frames = []
+            while frame_dict := queue.get():
+                frames.append(frame_dict['main'])
+            self.assertTrue(len(frames) > 0)
+            # Override must be ignored because source is a directory.
+            self.assertEqual(frames[0].data['meta']['src'], f'file://{v_a}')
+        finally:
+            runner.stop()
+            queue.close()
+
+    def test_directory_transition_skip_bad_file(self):
+        import shutil
+        import tempfile
+        test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, test_dir)
+
+        # 01.mp4 is good, 02.mp4 is a file we will delete, 03.mp4 is good
+        v_a = os.path.join(test_dir, '01_good.mp4')
+        v_b = os.path.join(test_dir, '02_bad.mp4')
+        v_c = os.path.join(test_dir, '03_good.mp4')
+
+        with open(v_a, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+        with open(v_b, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+        with open(v_c, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+
+        runner = Filter.Runner([
+            (VideoIn, dict(
+                sources = f'file://{test_dir}!sync',
+                outputs = 'ipc://test-VideoIn-skip-bad',
+            )),
+            (FiltersToQueue, dict(
+                sources = 'ipc://test-VideoIn-skip-bad',
+                queue   = (queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=4)
+
+        try:
+            # Delete v_b right after VideoIn initializes its directory list.
+            # When VideoIn transitions to v_b, the file won't exist anymore,
+            # which fails instantly inside OpenCV without any FFmpeg demuxer stall!
+            if os.path.exists(v_b):
+                os.unlink(v_b)
+
+            frames = []
+            while frame_dict := queue.get():
+                frames.append(frame_dict['main'])
+            
+            # Since 02_bad.mp4 is skipped during transition, we expect 3 frames from 01_good
+            # and 3 frames from 03_good (total 6 frames).
+            self.assertEqual(len(frames), 6)
+            self.assertEqual(frames[0].data['meta']['src'], f'file://{v_a}')
+            self.assertEqual(frames[3].data['meta']['src'], f'file://{v_c}')
+        finally:
+            runner.stop()
+            queue.close()
+
+    def test_empty_directory_raises(self):
+        import shutil
+        import tempfile
+        test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, test_dir)
+
+        # Reading an empty directory must raise RuntimeError on initialization
+        with self.assertRaises(RuntimeError):
+            VideoReader(f'file://{test_dir}')
+
+    def test_directory_pattern_and_recursive_options(self):
+        import shutil
+        import tempfile
+        test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, test_dir)
+
+        # Create nested folders
+        nested_dir = os.path.join(test_dir, 'subdir')
+        os.makedirs(nested_dir)
+
+        v_root = os.path.join(test_dir, 'root_match.mp4')
+        v_ignored = os.path.join(test_dir, 'ignored.txt')
+        v_nested = os.path.join(nested_dir, 'nested_match.mp4')
+
+        with open(v_root, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+        with open(v_ignored, 'wb') as f:
+            f.write(b'not a video')
+        with open(v_nested, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+
+        # Test recursive glob scanning
+        reader_rec = VideoReader(f'file://{test_dir}', sync=True, recursive=True)
+        try:
+            self.assertEqual(len(reader_rec.dir_files), 2)
+            self.assertEqual(reader_rec.dir_files[0], v_root)
+            self.assertEqual(reader_rec.dir_files[1], v_nested)
+        finally:
+            reader_rec.cap.release()
+
+        # Test pattern filter
+        reader_pat = VideoReader(f'file://{test_dir}', sync=True, recursive=True, pattern='*nested*')
+        try:
+            self.assertEqual(len(reader_pat.dir_files), 1)
+            self.assertEqual(reader_pat.dir_files[0], v_nested)
+        finally:
+            reader_pat.cap.release()
+
+    def test_directory_get_info(self):
+        test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, test_dir)
+
+        # 1. Failure Case: Empty directory should raise RuntimeError
+        with self.assertRaises(RuntimeError):
+            VideoReader.get_info(f'file://{test_dir}')
+
+        # 2. Success Case: Directory with a valid video
+        v_path = os.path.join(test_dir, 'video.mp4')
+        with open(v_path, 'wb') as f:
+            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+
+        height, width, fmt, fps = VideoReader.get_info(f'file://{test_dir}')
+        self.assertGreater(height, 0)
+        self.assertGreater(width, 0)
+        self.assertEqual(fmt, 'BGR')
+        self.assertGreater(fps, 0.0)
 
 
 if __name__ == '__main__':

--- a/tests/test_filter_video_in.py
+++ b/tests/test_filter_video_in.py
@@ -1239,12 +1239,64 @@ class TestVideoIn(unittest.TestCase):
         finally:
             reader.stop()
 
-    def _write_clip(self, path, fps, size):
-        """Write a tiny 3-frame red/green/blue clip. size=(width, height)."""
+    def _write_clip(self, path, fps, size, num_frames=3):
+        """Write a tiny red/green/blue-cycling clip. size=(width, height)."""
         writer = cv2.VideoWriter(path, cv2.VideoWriter_fourcc(*'mp4v'), fps, size)
-        for color in ((0, 0, 255), (0, 255, 0), (255, 0, 0)):  # BGR: red, green, blue
-            writer.write(np.full((size[1], size[0], 3), color, dtype=np.uint8))
+        colors = ((0, 0, 255), (0, 255, 0), (255, 0, 0))  # BGR: red, green, blue
+        for i in range(num_frames):
+            writer.write(np.full((size[1], size[0], 3), colors[i % len(colors)], dtype=np.uint8))
         writer.release()
+
+    def test_nosync_mode_maxfps_paces_delivery_across_transition(self):
+        """Confirms actual frame DELIVERY (not just the reported meta['src_fps'] label checked by
+        test_nosync_mode_src_fps_capped_across_transition) still honors maxfps across a directory
+        transition: the pacing loop (ns_per_fps) reads each file at its own native rate, but it's the
+        separate maxfps skip-logic (ns_per_maxfps) that throttles what actually reaches the caller, and
+        that skip logic runs off a clock that is never reset in _open_dir_file. So delivered-frame
+        spacing - including the gap spanning the transition itself - should stay at ~1/maxfps
+        throughout, never collapsing to the (much faster) native-rate spacing."""
+        test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, test_dir)
+
+        v_a = os.path.join(test_dir, '01.mp4')
+        v_b = os.path.join(test_dir, '02.mp4')
+
+        native_fps, maxfps, frames_per_file = 100.0, 20.0, 40
+
+        self._write_clip(v_a, fps=native_fps, size=(64, 48), num_frames=frames_per_file)
+        self._write_clip(v_b, fps=native_fps, size=(64, 48), num_frames=frames_per_file)
+
+        reader = VideoReader(f'file://{test_dir}', sync=False, maxfps=maxfps)
+        try:
+            reader.start()
+
+            deliveries = []  # (wall_clock_time, source) per delivered frame
+
+            while (item := reader.read(with_tframe=True)) is not None:
+                _, _, extras = item
+                deliveries.append((time(), extras['source']))
+
+            self.assertGreaterEqual(len(deliveries), 6, 'expected several throttled deliveries per file')
+
+            # Locate the first delivery from the second file (its 'source' differs from the first).
+            transition_idx = next(i for i, (_, src) in enumerate(deliveries) if src != deliveries[0][1])
+
+            target = 1 / maxfps
+            deltas = [t2 - t1 for (t1, _), (t2, _) in zip(deliveries, deliveries[1:])]
+
+            # The last gap is exempt: the reader delivers end-of-stream's final frame immediately
+            # (see read_one()'s "maintain the last frame" comment) rather than waiting a full
+            # throttle interval, which is expected and unrelated to maxfps pacing correctness.
+            for i, d in enumerate(deltas[:-1]):
+                self.assertGreater(d, target / 2, f'gap {i} too short for maxfps throttling: {d}s')
+
+            # Specifically: the gap spanning the file transition must stay throttled to ~1/maxfps,
+            # not collapse to the much shorter native-rate (1/native_fps) spacing.
+            transition_delta = deliveries[transition_idx][0] - deliveries[transition_idx - 1][0]
+            self.assertGreater(transition_delta, target / 2,
+                'delivery spacing across the file transition collapsed to native rate instead of staying maxfps-throttled')
+        finally:
+            reader.stop()
 
     def test_directory_files_differing_fps_and_resolution(self):
         """A directory source is not guaranteed uniform: files may differ in native fps and/or

--- a/tests/test_filter_video_in.py
+++ b/tests/test_filter_video_in.py
@@ -1163,15 +1163,12 @@ class TestVideoIn(unittest.TestCase):
         self.assertEqual(fmt, 'BGR')
         self.assertGreater(fps, 0.0)
 
-    def test_nosync_mode_fps_preservation_across_transition(self):
+    def test_nosync_mode_src_fps_capped_across_transition(self):
         """Non-sync mode caps self.fps to maxfps when native fps exceeds it (see _open_dir_file),
-        and that capped value is what reaches meta['src_fps'] downstream. Asserting on
-        VideoReader.ns_per_fps (as a prior version of this test did) doesn't exercise that: ns_per_fps
-        is recomputed purely from native_fps regardless of maxfps (see _open_dir_file), so it would be
-        unaffected by maxfps handling and, with two byte-identical clips, would compare equal even if
-        the maxfps cap were dropped or stale after a transition. Checking meta['src_fps'] end-to-end
-        (like test_sync_mode_fps_preservation_across_transition does for sync mode) actually exercises
-        the cap being correctly reapplied to the newly opened file."""
+        and that capped value is what reaches meta['src_fps'] downstream. This is unaffected by
+        whether ns_per_fps (real-time pacing) is recomputed from native_fps or from the already-capped
+        self.fps - self.fps is capped identically either way - so this test does NOT cover that
+        distinction; see test_nosync_mode_ns_per_fps_native_after_transition for that."""
         test_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, test_dir)
 
@@ -1204,6 +1201,92 @@ class TestVideoIn(unittest.TestCase):
             self.assertTrue(frames, 'expected at least one frame')
             for f in frames:
                 self.assertAlmostEqual(f.data['meta']['src_fps'], 10.0, places=1)
+        finally:
+            runner.stop()
+            queue.close()
+
+    def test_nosync_mode_ns_per_fps_native_after_transition(self):
+        """Regression test: in non-sync mode, ns_per_fps (the real-time pacing interval used by
+        wait() to avoid reading a file faster than realtime) must be recomputed from the newly
+        opened file's native_fps after a directory transition (see _open_dir_file), not from
+        self.fps - which _open_dir_file may have already capped down to maxfps. A prior bug
+        recomputed ns_per_fps from self.fps, so with maxfps well below native fps, pacing after
+        the transition collapsed to 1e9 // maxfps instead of staying at 1e9 // native_fps.
+        meta['src_fps'] does not reveal this bug because self.fps is capped to maxfps identically
+        whether or not ns_per_fps is computed correctly (see test_nosync_mode_src_fps_capped_across_transition)."""
+        test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, test_dir)
+
+        v_a = os.path.join(test_dir, '01_good.mp4')
+        v_b = os.path.join(test_dir, '02_good.mp4')
+
+        for path in (v_a, v_b):
+            with open(path, 'wb') as f:
+                f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+
+        reader = VideoReader(f'file://{test_dir}', sync=False, maxfps=1)  # maxfps << native (~30 fps)
+        try:
+            initial_ns_per_fps = reader.ns_per_fps  # native-fps pacing, established before any transition
+
+            reader.start()
+
+            while reader.read() is not None:
+                pass  # drain both directory files to force the transition
+
+            # Pacing after the transition into 02_good.mp4 must still be native-fps derived, not
+            # collapsed to the maxfps-capped self.fps.
+            self.assertEqual(reader.ns_per_fps, initial_ns_per_fps)
+        finally:
+            reader.stop()
+
+    def _write_clip(self, path, fps, size):
+        """Write a tiny 3-frame red/green/blue clip. size=(width, height)."""
+        writer = cv2.VideoWriter(path, cv2.VideoWriter_fourcc(*'mp4v'), fps, size)
+        for color in ((0, 0, 255), (0, 255, 0), (255, 0, 0)):  # BGR: red, green, blue
+            writer.write(np.full((size[1], size[0], 3), color, dtype=np.uint8))
+        writer.release()
+
+    def test_directory_files_differing_fps_and_resolution(self):
+        """A directory source is not guaranteed uniform: files may differ in native fps and/or
+        resolution. Each file's own properties - not the previous file's, and not the first
+        file's - must be reflected per-frame: meta['src_fps'] from the newly opened file's fps
+        and the emitted image shape from the newly opened file's resolution."""
+        test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, test_dir)
+
+        v_a = os.path.join(test_dir, '01_small_30fps.mp4')
+        v_b = os.path.join(test_dir, '02_big_15fps.mp4')
+
+        self._write_clip(v_a, fps=30.0, size=(64, 48))
+        self._write_clip(v_b, fps=15.0, size=(128, 96))
+
+        runner = Filter.Runner([
+            (VideoIn, dict(
+                sources = f'file://{test_dir}!sync',
+                outputs = 'ipc://test-VideoIn-dir-mixed',
+            )),
+            (FiltersToQueue, dict(
+                sources = 'ipc://test-VideoIn-dir-mixed',
+                queue   = (queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=5)
+
+        try:
+            frames = []
+            while frame_dict := queue.get():
+                frames.append(frame_dict['main'])
+
+            self.assertEqual(len(frames), 6)  # 3 frames from each file
+
+            for f in frames[:3]:
+                self.assertEqual(f.shape[:2], (48, 64))
+                self.assertAlmostEqual(f.data['meta']['src_fps'], 30.0, delta=1.0)
+                self.assertEqual(f.data['meta']['src'], f'file://{v_a}')
+
+            for f in frames[3:]:
+                self.assertEqual(f.shape[:2], (96, 128))
+                self.assertAlmostEqual(f.data['meta']['src_fps'], 15.0, delta=1.0)
+                self.assertEqual(f.data['meta']['src'], f'file://{v_b}')
         finally:
             runner.stop()
             queue.close()

--- a/tests/test_filter_video_in.py
+++ b/tests/test_filter_video_in.py
@@ -839,8 +839,6 @@ class TestVideoIn(unittest.TestCase):
             queue.close()
 
     def test_directory_source(self):
-        import shutil
-        import tempfile
 
         test_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, test_dir)
@@ -901,8 +899,6 @@ class TestVideoIn(unittest.TestCase):
             queue.close()
 
     def test_directory_loop(self):
-        import shutil
-        import tempfile
 
         test_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, test_dir)
@@ -948,8 +944,6 @@ class TestVideoIn(unittest.TestCase):
             queue.close()
 
     def test_directory_skips_non_videos(self):
-        import shutil
-        import tempfile
 
         test_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, test_dir)
@@ -990,8 +984,7 @@ class TestVideoIn(unittest.TestCase):
 
 
     def test_sync_mode_fps_preservation_across_transition(self):
-        import shutil
-        import tempfile
+
         test_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, test_dir)
 
@@ -1031,8 +1024,7 @@ class TestVideoIn(unittest.TestCase):
             queue.close()
 
     def test_override_source_uri_rejected_for_directory(self):
-        import shutil
-        import tempfile
+
         test_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, test_dir)
 
@@ -1065,12 +1057,13 @@ class TestVideoIn(unittest.TestCase):
             queue.close()
 
     def test_directory_transition_skip_bad_file(self):
-        import shutil
-        import tempfile
         test_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, test_dir)
 
-        # 01.mp4 is good, 02.mp4 is a file we will delete, 03.mp4 is good
+        # 01.mp4 is good, 02.mp4 has a valid extension but garbage bytes (fails to open), 03.mp4 is good.
+        # A deleted file would race VideoReader.__init__'s directory scan (which runs in the Filter.Runner
+        # subprocess): if the delete won, 02_bad.mp4 would never make it into dir_files and the
+        # transition-skip code path would never be entered. A present-but-corrupt file is deterministic.
         v_a = os.path.join(test_dir, '01_good.mp4')
         v_b = os.path.join(test_dir, '02_bad.mp4')
         v_c = os.path.join(test_dir, '03_good.mp4')
@@ -1078,7 +1071,7 @@ class TestVideoIn(unittest.TestCase):
         with open(v_a, 'wb') as f:
             f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
         with open(v_b, 'wb') as f:
-            f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+            f.write(b'not actually a video, but has a .mp4 extension')
         with open(v_c, 'wb') as f:
             f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
 
@@ -1094,12 +1087,6 @@ class TestVideoIn(unittest.TestCase):
         ], exit_time=4)
 
         try:
-            # Delete v_b right after VideoIn initializes its directory list.
-            # When VideoIn transitions to v_b, the file won't exist anymore,
-            # which fails instantly inside OpenCV without any FFmpeg demuxer stall!
-            if os.path.exists(v_b):
-                os.unlink(v_b)
-
             frames = []
             while frame_dict := queue.get():
                 frames.append(frame_dict['main'])
@@ -1114,8 +1101,6 @@ class TestVideoIn(unittest.TestCase):
             queue.close()
 
     def test_empty_directory_raises(self):
-        import shutil
-        import tempfile
         test_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, test_dir)
 
@@ -1124,8 +1109,6 @@ class TestVideoIn(unittest.TestCase):
             VideoReader(f'file://{test_dir}')
 
     def test_directory_pattern_and_recursive_options(self):
-        import shutil
-        import tempfile
         test_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, test_dir)
 
@@ -1179,6 +1162,51 @@ class TestVideoIn(unittest.TestCase):
         self.assertGreater(width, 0)
         self.assertEqual(fmt, 'BGR')
         self.assertGreater(fps, 0.0)
+
+    def test_nosync_mode_fps_preservation_across_transition(self):
+        """Non-sync mode caps self.fps to maxfps when native fps exceeds it (see _open_dir_file),
+        and that capped value is what reaches meta['src_fps'] downstream. Asserting on
+        VideoReader.ns_per_fps (as a prior version of this test did) doesn't exercise that: ns_per_fps
+        is recomputed purely from native_fps regardless of maxfps (see _open_dir_file), so it would be
+        unaffected by maxfps handling and, with two byte-identical clips, would compare equal even if
+        the maxfps cap were dropped or stale after a transition. Checking meta['src_fps'] end-to-end
+        (like test_sync_mode_fps_preservation_across_transition does for sync mode) actually exercises
+        the cap being correctly reapplied to the newly opened file."""
+        test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, test_dir)
+
+        v_a = os.path.join(test_dir, '01_good.mp4')
+        v_b = os.path.join(test_dir, '02_good.mp4')
+
+        for path in (v_a, v_b):
+            with open(path, 'wb') as f:
+                f.write(RED_THEN_GREEN_THEN_BLUE_FRAME_MP4)
+
+        # Native test video is ~30 fps; maxfps=10 forces the cap on both files. loop keeps the
+        # reader emitting past the two files (6 frames) so the slow-joining ipc subscriber below
+        # doesn't miss frames that were already sent before it connected.
+        runner = Filter.Runner([
+            (VideoIn, dict(
+                sources = f'file://{test_dir}!maxfps=10!loop=3',
+                outputs = 'ipc://test-VideoIn-nosync-fps',
+            )),
+            (FiltersToQueue, dict(
+                sources = 'ipc://test-VideoIn-nosync-fps',
+                queue   = (queue := FiltersToQueue.Queue()).child_queue,
+            )),
+        ], exit_time=4)
+
+        try:
+            frames = []
+            while frame_dict := queue.get():
+                frames.append(frame_dict['main'])
+
+            self.assertTrue(frames, 'expected at least one frame')
+            for f in frames:
+                self.assertAlmostEqual(f.data['meta']['src_fps'], 10.0, places=1)
+        finally:
+            runner.stop()
+            queue.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem / Feature Goal

Currently, the `VideoIn` filter only supports playing a single `.mp4` file or remote streams. There was no way to supply a folder of multiple video clips directly and have them play sequentially as a single continuous stream.

## Solution

This PR adds native support for local directory-based video sources in `VideoIn`. 

### Key Accomplishments:
1. **Directory Scanning & Verification**:
   - Checks if a local file source points to a directory.
   - Alphabetically sorts and scans immediate files (depth 1).
   - Verifies validity with `cv2.VideoCapture.isOpened()`, gracefully ignoring non-video files.
2. **Seamless Playback Transitions**:
   - Once a video clip finishes, `VideoReader` seamlessly opens the next sorted file.
   - Pacing timers (`ns_per_fps`) are dynamically adjusted to fit the new segment's native or capped FPS.
3. **Dynamic Metadata & Offsets**:
   - `meta['src']` is dynamically updated on the fly to reflect the exact file being read.
   - `meta['src_frame']` and `meta['src_seconds']` are cleanly reset to `0` upon opening each new video file.
4. **End-to-End runnable demo**:
   - Created a complete runnable demo in `examples/directory-pipeline-demo/main.py`.

## Verification & Testing

### 1. Automated Tests
Added three comprehensive unit test cases in `tests/test_filter_video_in.py`:
- `test_directory_source`: Verifies alphabetical sorting, dynamic metadata update, and frame counter resets.
- `test_directory_loop`: Verifies looping of the directory source works seamlessly.
- `test_directory_skips_non_videos`: Verifies non-video formats (e.g. text files) are skipped.

All 25 test cases inside `tests/test_filter_video_in.py` pass successfully:
```bash
pytest tests/test_filter_video_in.py
```

### 2. Manual Demo Verification
Successfully executed the custom demo pipeline (`VideoIn` -> `InfoPrinter` -> `ImageOut`):
```bash
python examples/directory-pipeline-demo/main.py
```
Logs perfectly demonstrate alphabetical directory traversing, frame-index resets (`0` to `2` for each segment), and active source path updating.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790969655&installation_model_id=20112&pr_number=161&repository=PlainsightAI%2Fopenfilter&return_to=https%3A%2F%2Fgithub.com%2FPlainsightAI%2Fopenfilter%2Fpull%2F161&signature=20c6a581550af463187ea6f5744a43d28ec6338f92a9cc1f887c6e1a86bbfad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->