### PR TITLE
fix(analytics): report usage off-thread and honour the opt-out in the log

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,24 @@ OpenFilter Library release notes
 
 ## [Unreleased]
 
+### Changed
+
+- **Usage analytics no longer block filter startup.** The Scarf event reported once
+  per `Filter` init went out through a synchronous POST with a 3s timeout, run
+  inline in `Filter.__init__`. Anywhere the endpoint is unreachable but not
+  actively refused — a firewall that DROPs, a captive network, an air-gapped
+  host — every filter paid up to 3s of startup, multiplied by the number of
+  filters in the pipeline. The report now runs on a daemon thread, so a slow or
+  blackholed endpoint can neither delay startup nor hold up process exit. What is
+  sent, and the `DO_NOT_TRACK` / `SCARF_NO_ANALYTICS` opt-out, are unchanged.
+
+### Fixed
+
+- **The startup log no longer claims analytics are enabled when they are opted
+  out.** `Filter` printed `Usage analytics enabled via Scarf` unconditionally,
+  including for users who had set `DO_NOT_TRACK`. It now reports the actual state
+  and skips the reporting thread entirely when opted out.
+
 ## v1.3.0 - 2026-08-17
 
 ### Added

--- a/openfilter/filter_runtime/filter.py
+++ b/openfilter/filter_runtime/filter.py
@@ -123,6 +123,27 @@ scarf_elogger = ScarfEventLogger(
     endpoint_url=f"https://python.openfilter.io/openfilter"
 )
 
+
+def _usage_analytics_disabled() -> bool:
+    """Whether the user opted out of usage analytics.
+
+    Mirrors the two environment variables the Scarf SDK itself honors. Checking
+    them here as well keeps the startup log honest — it previously announced
+    analytics as enabled even when they were opted out — and avoids starting a
+    thread that would do nothing.
+    """
+    return (os.getenv("DO_NOT_TRACK") or "").lower() in ("1", "true") or (
+        os.getenv("SCARF_NO_ANALYTICS") or ""
+    ).lower() in ("1", "true")
+
+
+def _report_filter_initialized(filter_name: str) -> None:
+    """Send one usage event. Runs on a daemon thread; never raises."""
+    try:
+        scarf_elogger.log_event(properties={"filter_initialized": filter_name})
+    except Exception as e:
+        logger.warning(f"Failed to log Scarf event: {e}")
+
 LOG_LEVEL = (os.getenv("LOG_LEVEL") or "INFO").upper()
 LOG_FORMAT = os.getenv("LOG_FORMAT") or None
 LOG_PID = bool(
@@ -902,16 +923,27 @@ class Filter:
                 "[Filter] Raw subject data export is DISABLED (set OPENLINEAGE_EXPORT_RAW_DATA=true to enable)"
             )
 
-        try:
-            scarf_metric_name = type(self).__name__.lower()
+        # Usage analytics. The SDK's log_event is a synchronous POST with a 3s
+        # timeout and used to run inline here, so anywhere the endpoint is
+        # unreachable but not actively refused — a firewall that DROPs, a
+        # captive network, an air-gapped host — every Filter paid up to 3s of
+        # startup, multiplied by the number of filters in the pipeline. Hand it
+        # to a daemon thread instead: a slow or blackholed endpoint can no
+        # longer delay startup, and being a daemon it never holds up exit.
+        if _usage_analytics_disabled():
+            logger.info(
+                "[Filter] Usage analytics disabled (DO_NOT_TRACK / SCARF_NO_ANALYTICS)"
+            )
+        else:
             logger.info(
                 "[Filter] Usage analytics enabled via Scarf (set DO_NOT_TRACK=true to disable)"
             )
-            scarf_elogger.log_event(
-                properties={"filter_initialized": f"{scarf_metric_name}"}
-            )
-        except Exception as e:
-            logger.warning(f"Failed to log Scarf event: {e}")
+            threading.Thread(
+                target=_report_filter_initialized,
+                args=(type(self).__name__.lower(),),
+                name="scarf-usage-event",
+                daemon=True,
+            ).start()
 
         try:
             try:

--- a/tests/test_usage_analytics.py
+++ b/tests/test_usage_analytics.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+"""Tests for the Scarf usage-analytics opt-out and its off-thread dispatch.
+
+The event is reported once per Filter init. Two properties matter and are easy to
+regress:
+
+1. The opt-out is honored, and the startup log agrees with it. The SDK has the
+   final say, but openfilter checks the same variables so it does not announce
+   analytics as enabled to someone who opted out.
+2. Reporting never blocks Filter construction. The SDK call is a synchronous POST
+   with a 3s timeout; run inline it made every Filter wait out that timeout on any
+   network where the endpoint is unreachable but not actively refused.
+"""
+
+import os
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+from openfilter.filter_runtime.filter import (
+    _report_filter_initialized,
+    _usage_analytics_disabled,
+)
+
+OPT_OUT_VARS = ["DO_NOT_TRACK", "SCARF_NO_ANALYTICS"]
+
+
+class TestUsageAnalyticsOptOut(unittest.TestCase):
+    """_usage_analytics_disabled mirrors the variables the Scarf SDK honors."""
+
+    def _assert(self, env, expected):
+        clean = {k: v for k, v in os.environ.items() if k not in OPT_OUT_VARS}
+        clean.update(env)
+        with patch.dict(os.environ, clean, clear=True):
+            self.assertEqual(_usage_analytics_disabled(), expected, env)
+
+    def test_enabled_when_unset(self):
+        self._assert({}, False)
+
+    def test_do_not_track_truthy_values(self):
+        for value in ("1", "true", "TRUE", "True"):
+            self._assert({"DO_NOT_TRACK": value}, True)
+
+    def test_scarf_no_analytics_truthy_values(self):
+        for value in ("1", "true", "TRUE"):
+            self._assert({"SCARF_NO_ANALYTICS": value}, True)
+
+    def test_falsy_values_do_not_opt_out(self):
+        # An explicit "0"/"" means "do not opt out" and must not be read as a
+        # generic "the variable is present" signal.
+        for value in ("0", "", "false", "no"):
+            self._assert({"DO_NOT_TRACK": value}, False)
+
+    def test_either_variable_is_enough(self):
+        self._assert({"DO_NOT_TRACK": "0", "SCARF_NO_ANALYTICS": "1"}, True)
+
+
+class TestReportFilterInitialized(unittest.TestCase):
+    """_report_filter_initialized runs on a daemon thread and never raises."""
+
+    def test_sends_the_filter_name(self):
+        with patch("openfilter.filter_runtime.filter.scarf_elogger") as elogger:
+            _report_filter_initialized("myfilter")
+        elogger.log_event.assert_called_once_with(
+            properties={"filter_initialized": "myfilter"}
+        )
+
+    def test_swallows_sdk_errors(self):
+        # It runs on a thread, so an escaping exception would print a bare
+        # traceback to stderr with nothing to catch it.
+        with patch("openfilter.filter_runtime.filter.scarf_elogger") as elogger:
+            elogger.log_event.side_effect = RuntimeError("connection refused")
+            _report_filter_initialized("myfilter")  # must not raise
+
+    def test_does_not_block_the_caller(self):
+        # The regression this guards: the SDK call used to run inline in
+        # Filter.__init__, so an endpoint that accepts the connection and then
+        # stalls delayed startup by the full timeout, once per filter.
+        started = threading.Event()
+
+        def stall(*_args, **_kwargs):
+            started.set()
+            time.sleep(3.0)
+
+        with patch("openfilter.filter_runtime.filter.scarf_elogger") as elogger:
+            elogger.log_event.side_effect = stall
+
+            begin = time.monotonic()
+            thread = threading.Thread(
+                target=_report_filter_initialized,
+                args=("myfilter",),
+                name="scarf-usage-event",
+                daemon=True,
+            )
+            thread.start()
+            elapsed = time.monotonic() - begin
+
+            self.assertTrue(started.wait(timeout=2.0), "reporter never ran")
+            self.assertLess(elapsed, 0.5, f"dispatch blocked for {elapsed:.2f}s")
+            self.assertTrue(thread.daemon, "reporter must not hold up process exit")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The Scarf event reported once per `Filter` init goes out through a **synchronous POST with a 3s timeout**, run inline in `Filter.__init__`.

Anywhere the endpoint is reachable-but-silent — a firewall that DROPs rather than REJECTs, a captive network, an air-gapped host — every filter pays up to 3s of startup, multiplied by the number of filters in the pipeline. A ten-filter pipeline can lose half a minute before doing any work. This is not hypothetical: it is what a filter does on a cluster whose egress allowlist does not include `python.openfilter.io`.

## Changes

**Report on a daemon thread.** A slow or blackholed endpoint can no longer delay construction, and being a daemon it never holds up process exit. What is sent is unchanged, and the SDK still has the final say on the opt-out.

**Fix the startup log.** `Filter` printed `Usage analytics enabled via Scarf` unconditionally, including for users who had set `DO_NOT_TRACK`. Telling someone their opt-out did nothing is worse than saying nothing. `_usage_analytics_disabled()` mirrors the two variables the SDK honours, so the log matches reality and no thread is started when opted out.

This does **not** change what is collected, and does not touch the opt-out contract — analytics stay on by default.

## Tests

`tests/test_usage_analytics.py`, 8 cases:

- opt-out matrix: both variables, truthy (`1`/`true`/`TRUE`/`True`) and falsy (`0`/`""`/`false`/`no`) values, and either variable being sufficient. The falsy cases matter — an explicit `DO_NOT_TRACK=0` must not be read as a generic "variable is present" signal.
- dispatch: forwards the filter name; swallows SDK errors (an exception escaping a thread would print a bare traceback with nothing to catch it); and returns immediately when the reporter stalls, which is the regression itself.

## Verification

Measured against a blackholed address, dispatch returns in **0.0002s** where the inline call took the full ~3s.

Full unit suite green: **835 passed, 1 skipped, 2 deselected, 0 failed** (`pytest tests/ --ignore=tests/integration --benchmark-disable -m "not slow"`). The 8 new tests pass both with and without `DO_NOT_TRACK` set in the environment.