### PR TITLE
fix(tests): repair the tracing integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
+import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -29,7 +31,8 @@ CONTAINER_STARTUP_TIMEOUT_SECS = 30
 class JaegerContainer:
     """Handle to a running jaeger-all-in-one container.
 
-    otlp_grpc_endpoint is a host:port string suitable for OTLPSpanExporter.
+    otlp_grpc_endpoint is a URL suitable for OTLPSpanExporter, including the
+    scheme — see the note where it is built.
     query_base_url is the jaeger query API root (append /api/traces/<id>).
     """
 
@@ -110,7 +113,11 @@ def _docker_run_jaeger() -> JaegerContainer:
 
     jc = JaegerContainer(
         container_id=container_id,
-        otlp_grpc_endpoint=f"localhost:{otlp_port}",
+        # The scheme is load-bearing, not decoration: infer_otlp_insecure treats a
+        # bare host:port as TLS (the OTel SDK's secure default), so dropping it
+        # makes the exporter TLS-handshake this plaintext receiver and fail with
+        # WRONG_VERSION_NUMBER instead of exporting anything.
+        otlp_grpc_endpoint=f"http://localhost:{otlp_port}",
         query_base_url=f"http://localhost:{query_port}",
     )
 
@@ -165,3 +172,28 @@ def jaeger() -> Iterator[JaegerContainer]:
             capture_output=True,
             timeout=15,
         )
+
+
+@pytest.fixture
+def short_ipc_dir() -> Iterator[str]:
+    """A unique directory short enough to hold a ZMQ ipc:// socket.
+
+    pytest's ``tmp_path`` cannot be used for this. A unix domain socket path
+    must fit in ``sockaddr_un.sun_path`` — 104 bytes on macOS, 108 on Linux —
+    and on macOS ``tmp_path`` resolves under
+    ``/private/var/folders/<...>/T/pytest-of-<user>/pytest-<n>/<testname>/``,
+    which puts a socket beneath it at ~138 characters. The bind fails, and the
+    only symptom is the receiver never coming up, which reads like a hang rather
+    than a path problem.
+
+    ``/tmp`` is hardcoded because it is short on both macOS and Linux, unlike
+    ``tempfile.gettempdir()`` which returns the long ``/var/folders`` path on
+    macOS. That is safe here: ``ipc://`` is POSIX-only to begin with, so these
+    tests never run where ``/tmp`` is absent. ``mkdtemp`` keeps the per-run
+    uniqueness that using ``tmp_path`` was there to provide.
+    """
+    path = tempfile.mkdtemp(prefix="of-ipc-", dir="/tmp")
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)

--- a/tests/integration/test_tracing_export.py
+++ b/tests/integration/test_tracing_export.py
@@ -74,7 +74,7 @@ def test_otlp_grpc_export_reaches_jaeger(jaeger):
 
 
 @pytest.mark.slow
-def test_per_frame_trace_context_crosses_mq_hop(jaeger, tmp_path):
+def test_per_frame_trace_context_crosses_mq_hop(jaeger, short_ipc_dir):
     """Two MQ endpoints across an IPC hop must produce spans for the same frame.id
     that share a single trace ID and nest under the producer's mq.send span.
 
@@ -114,8 +114,11 @@ def test_per_frame_trace_context_crosses_mq_hop(jaeger, tmp_path):
     tracer = provider.get_tracer("openfilter-mq-hop-test")
     register_hop_tracer(tracer)
 
-    # IPC socket lives in the test's tmp dir so parallel runs don't collide.
-    ipc_addr = f"ipc://{tmp_path}/mq-hop-test.sock"
+    # IPC socket lives in a per-test dir so parallel runs don't collide. It has
+    # to be short_ipc_dir rather than tmp_path — a unix socket path must fit in
+    # sun_path (104 bytes on macOS), and tmp_path blows past that. See the
+    # fixture for the details.
+    ipc_addr = f"ipc://{short_ipc_dir}/mq-hop-test.sock"
 
     recv_ready = threading.Event()
     recv_done = threading.Event()


### PR DESCRIPTION
All three tests in `tests/integration/test_tracing_export.py` have been failing. Two unrelated causes, neither of them a library bug — both are in the fixtures.

## 1. The exporter TLS-handshook a plaintext receiver

The jaeger fixture handed out `localhost:<port>`. `infer_otlp_insecure` only treats an explicit `http://` scheme as plaintext — a **bare `host:port` infers TLS**, deliberately, matching the OTel SDK's secure default. So the exporter opened TLS against jaeger's plaintext OTLP port and died:

```
SSL_ERROR_SSL: error:100000f7:SSL routines:OPENSSL_internal:WRONG_VERSION_NUMBER
```

No span ever arrived, so `assert services, "jaeger never saw trace ..."` failed.

The fixture predates that inference (#90, `28b4d70`) and was never updated — #99 later touched this directory without catching it. The comment at `observability/tracing.py:132` already warns that a bare host:port against a plaintext collector needs `insecure=True`; the fixture just never got the memo.

**Fix:** give the endpoint its `http://` scheme. Two of the three tests go green on this alone.

## 2. The IPC socket path was too long on macOS

`test_per_frame_trace_context_crosses_mq_hop` put its ZMQ socket under pytest's `tmp_path`. A unix domain socket path must fit in `sockaddr_un.sun_path` — **104 bytes on macOS** — and there `tmp_path` resolves under `/private/var/folders/<...>/T/pytest-of-<user>/pytest-<n>/<testname>/`, landing the socket at **138 characters**:

```
/private/var/folders/m7/6f_4w35d3xz7rgc29x39n0hm0000gn/T/pytest-of-<user>/pytest-999/test_per_frame_trace_context_0/mq-hop-test.sock
```

The bind fails and the only symptom is `AssertionError: receiver thread never started` — which reads like a hang, not a path problem. Linux has short `/tmp` paths and a 108-byte limit, which is why CI never saw this and it only bites locally on macOS.

**Fix:** a `short_ipc_dir` fixture that `mkdtemp`s under `/tmp`, keeping the per-run uniqueness `tmp_path` was there to provide. `/tmp` is hardcoded rather than `tempfile.gettempdir()` (which returns the long `/var/folders` path on macOS); safe because `ipc://` is POSIX-only to begin with.

## Verification

- `pytest tests/integration/` — **3 passed**, three runs in a row, with the plain invocation and no `--basetemp` workaround.
- Temp dirs cleaned up, nothing left in `/tmp`.
- Tests only — no library code touched. Unit gate unchanged: **827 passed, 1 skipped, 2 deselected, 0 failed**.

## Not included

`tests/test_benchmarks.py::TestZmqIpcBenchmarks::test_zmq_roundtrip_report` also fails, and is **not** fixed here — it is a separate problem. Reproduced standalone: the stall point is non-deterministic (frames 15/25/30/35/45/50, and some runs complete all 60) and it happens on both `ipc://` and `tcp://`, so it is neither the socket-path limit nor the transport. It looks like a lost-wakeup race in the strict send-one/recv-one lockstep the benchmark drives, which is not how a real filter runs. `TestPipelineSimulation::test_pipeline_simulation_report` is the flaky sibling, roughly 1 failure in 9. Both are `slow`-marked and excluded from `make test`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791042375&installation_model_id=20112&pr_number=163&repository=PlainsightAI%2Fopenfilter&return_to=https%3A%2F%2Fgithub.com%2FPlainsightAI%2Fopenfilter%2Fpull%2F163&signature=f0b3363eebce50c5b0f0062118bfd38e5b9abe57484f6d25d50f69649b5c55a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->