### PR TITLE
fix(base): upgrade the bundled pip/setuptools/wheel

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -28,6 +28,13 @@ RUN apt-get update \
     && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
+# Same idea one layer up: the python:X-slim tags ship pip/setuptools/wheel frozen at
+# whatever was current when that tag was cut, and they drift. On py3.10/py3.11 that
+# leaves wheel and setuptools' vendored jaraco.context flagged High, plus a handful of
+# Medium pip findings, inherited by every downstream image. py3.13/py3.14 already ship
+# current versions, so this is a no-op there and cheap everywhere.
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
## Why

`apt upgrade` in the base clears the OS packages, but the `python:X-slim` tags also ship `pip`/`setuptools`/`wheel` frozen at whatever was current when that tag was cut. Those drift, and every downstream image inherits them.

## Measured, not assumed

Built this Dockerfile before and after, scanned each with grype 0.118 using `--only-fixed` to match the CI scan:

| tag | before | after | cleared |
|---|---|---|---|
| py3.10 | High=6 Medium=14 Low=3 | **High=4 Medium=7 Low=2** | jaraco-context, pip, setuptools, wheel |
| py3.11 | High=5 Medium=12 Low=3 | **High=3 Medium=6 Low=2** | jaraco-context, pip, setuptools, wheel |
| py3.14 | Medium=1 | Medium=1 | — (no-op, no regression) |

Specifically cleared on the older lines: `wheel` 0.45.1 (High), setuptools' vendored `jaraco.context` 5.3.0 (High), `setuptools` 79.0.1 (Medium), and six `pip` findings.

What remains on those tags is the `python` binary itself, whose fix versions are 3.13.13/3.14.4 — not clearable while 3.10–3.12 are supported.

## Blast radius

py3.13/py3.14 already ship current tooling, so they are unchanged; the change is there so the tags do not diverge as images age.

Five managed filters build on py3.11 and pick this up directly: `protege-model`, `rt-detr`, `qrcode-parse`, `geolocator`, `license-plate-detection`. The eight built-in images are all py3.14 and are unaffected by this specific change.

## Sequencing note

Separately from this PR: the eight published built-in images are stale, not vulnerable-by-construction. They were built 2026-08-17 against the then-current base; the base was rebuilt 2026-08-31 and picked up `openssl` 3.5.7. Scanning them today:

```
openfilter-video-in:latest (and the other seven, identical)
  Critical=6 High=24 Medium=25
```

Of that, **6 Critical + 21 High + 3 Medium are openssl / libssl3t64 / openssl-provider-legacy 3.5.6 → 3.5.7**, plus ~14 findings from the `util-linux` family — all already fixed in the current base. A plain rebuild clears them with no code change.

What a rebuild does *not* clear is `ffmpeg` 8.1.1 (3 High, 3 Medium), which is bundled inside `opencv-python-headless`'s shipped libs, not PyAV. `opencv-python-headless` is pinned `~=5.0.0.93` and 5.0.0.93 is the newest release on PyPI, so there is nothing to bump to — it waits on an upstream OpenCV release. It is High, not Critical, so it does not trip `fail_on: critical`.

Merging this before cutting the rebuild means the py3.11 filters get the improved base in the same cycle rather than needing a second one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PlainsightAI/codesmith/openfilter/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791124451&installation_model_id=20112&pr_number=164&repository=PlainsightAI%2Fopenfilter&return_to=https%3A%2F%2Fgithub.com%2FPlainsightAI%2Fopenfilter%2Fpull%2F164&signature=cbb866d87807ceeb1af92295a104bb639b4c84b08f1e89d482855ebec8362744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->